### PR TITLE
Fix tile selection and editing interactions

### DIFF
--- a/src/LessonCanvas.tsx
+++ b/src/LessonCanvas.tsx
@@ -123,6 +123,7 @@ export const LessonCanvas = forwardRef<HTMLDivElement, LessonCanvasProps>(({
             isSelected={editorState.selectedTileId === tile.id}
             isEditing={editorState.mode === 'editing' && editorState.selectedTileId === tile.id}
             isEditingText={editorState.mode === 'textEditing' && editorState.selectedTileId === tile.id}
+            isImageEditing={editorState.mode === 'imageEditing' && editorState.selectedTileId === tile.id}
             onMouseDown={(e) => handleTileMouseDown(e, tile)}
             onImageMouseDown={(e) => handleImageMouseDown(e, tile)}
             isDraggingImage={editorState.interaction.type === 'imageDrag'}

--- a/src/components/admin/TileRenderer.tsx
+++ b/src/components/admin/TileRenderer.tsx
@@ -9,6 +9,7 @@ interface TileRendererProps {
   isSelected: boolean;
   isEditing: boolean;
   isEditingText: boolean;
+  isImageEditing: boolean;
   onMouseDown: (e: React.MouseEvent) => void;
   onImageMouseDown: (e: React.MouseEvent) => void;
   isDraggingImage: boolean;
@@ -23,6 +24,7 @@ export const TileRenderer: React.FC<TileRendererProps> = ({
   tile,
   isSelected,
   isEditing,
+  isImageEditing,
   onMouseDown,
   onImageMouseDown,
   isDraggingImage,
@@ -55,8 +57,8 @@ export const TileRenderer: React.FC<TileRendererProps> = ({
   };
 
   const handleImageWheel = (e: React.WheelEvent, imageTile: ImageTile) => {
-    // Only handle wheel events when tile is selected and in editing mode
-    if (!isSelected || !isEditing) return;
+    // Only handle wheel events when tile is selected and in image editing mode
+    if (!isSelected || !isImageEditing) return;
     
     e.preventDefault();
     e.stopPropagation();
@@ -154,15 +156,15 @@ export const TileRenderer: React.FC<TileRendererProps> = ({
         
         return (
           <div className="w-full h-full bg-gray-100 rounded-lg overflow-hidden relative">
-            <div 
+            <div
               className="w-full h-full relative overflow-hidden"
-              style={{ cursor: isSelected && isEditing ? 'grab' : 'default' }}
+              style={{ cursor: isSelected && isImageEditing ? 'grab' : 'default' }}
             >
               <img
                 src={imageTile.content.url}
                 alt={imageTile.content.alt}
                 className={`absolute select-none ${
-                  isSelected && isEditing ? 'cursor-grab active:cursor-grabbing' : ''
+                  isSelected && isImageEditing ? 'cursor-grab active:cursor-grabbing' : ''
                 }`}
                 style={{
                   left: imagePosition.x,
@@ -171,13 +173,13 @@ export const TileRenderer: React.FC<TileRendererProps> = ({
                   transformOrigin: '0 0',
                   maxWidth: 'none',
                   maxHeight: 'none',
-                  cursor: isSelected && isEditing ? (isDraggingImage ? 'grabbing' : 'grab') : 'default'
+                  cursor: isSelected && isImageEditing ? (isDraggingImage ? 'grabbing' : 'grab') : 'default'
                 }}
-                onMouseDown={isSelected && isEditing ? (e) => {
+                onMouseDown={isSelected && isImageEditing ? (e) => {
                   console.log('🖱️ Image onMouseDown triggered in TileRenderer');
                   handleImageDragStart(e, imageTile);
                 } : undefined}
-                onWheel={isSelected && isEditing ? (e) => {
+                onWheel={isSelected && isImageEditing ? (e) => {
                   handleImageWheel(e, imageTile);
                 } : undefined}
                 draggable={false}
@@ -275,7 +277,7 @@ export const TileRenderer: React.FC<TileRendererProps> = ({
     }
   };
   const renderResizeHandles = () => {
-    if (!isSelected || isEditing) return null;
+    if (!isSelected || isEditingText || isImageEditing) return null;
 
     const handles = GridUtils.getResizeHandles(tile.gridPosition);
     
@@ -305,7 +307,9 @@ export const TileRenderer: React.FC<TileRendererProps> = ({
 
   return (
     <div
-      className={`absolute select-none ${isEditing ? 'z-20' : 'z-10'} ${
+      className={`absolute select-none ${
+        isEditing || isImageEditing || isEditingText ? 'z-20' : 'z-10'
+      } ${
         isSelected ? 'ring-2 ring-blue-500 ring-opacity-75' : ''
       } ${
         !isFramelessTextTile ? `transition-all duration-200 rounded-lg ${
@@ -342,7 +346,7 @@ export const TileRenderer: React.FC<TileRendererProps> = ({
       </div>
 
       {/* Tile Controls */}
-      {(isSelected || isHovered) && !isEditing && !isEditingText && (
+      {(isSelected || isHovered) && !isEditing && !isEditingText && !isImageEditing && (
         <div className="absolute -top-8 left-0 flex items-center space-x-1 bg-white rounded-md shadow-md border border-gray-200 px-2 py-1">
           <Move className="w-3 h-3 text-gray-500" />
           <span className="text-xs text-gray-600 capitalize">{tile.type}</span>
@@ -368,7 +372,7 @@ export const TileRenderer: React.FC<TileRendererProps> = ({
       )}
 
       {/* Image Editing Indicator */}
-      {isSelected && isEditing && tile.type === 'image' && (
+      {isSelected && isImageEditing && tile.type === 'image' && (
         <div className="absolute -top-8 left-0 flex items-center space-x-1 bg-blue-100 rounded-md shadow-md border border-blue-300 px-2 py-1">
           <Move className="w-3 h-3 text-blue-600" />
           <span className="text-xs text-blue-700 font-medium">Przeciągnij obraz aby zmienić pozycję</span>
@@ -384,7 +388,7 @@ export const TileRenderer: React.FC<TileRendererProps> = ({
       )}
 
       {/* Resize Handles - Always Available When Selected */}
-      {!isEditingText && renderResizeHandles()}
+      {!isEditingText && !isImageEditing && renderResizeHandles()}
     </div>
   );
 };

--- a/src/hooks/useTileInteractions.ts
+++ b/src/hooks/useTileInteractions.ts
@@ -31,6 +31,8 @@ export const useTileInteractions = ({
   const handleTileDoubleClick = (tile: LessonTile) => {
     if (tile.type === 'text') {
       dispatch({ type: 'startTextEditing', tileId: tile.id });
+    } else if (tile.type === 'image') {
+      dispatch({ type: 'startImageEditing', tileId: tile.id });
     } else {
       dispatch({ type: 'startEditing', tileId: tile.id });
     }
@@ -88,7 +90,7 @@ export const useTileInteractions = ({
   };
 
   const handleTileMouseDown = (e: React.MouseEvent, tile: LessonTile) => {
-    if (editorState.mode === 'textEditing') {
+    if (editorState.mode === 'textEditing' || editorState.mode === 'imageEditing') {
       return;
     }
     e.preventDefault();
@@ -109,7 +111,7 @@ export const useTileInteractions = ({
   const handleImageMouseDown = (e: React.MouseEvent, tile: LessonTile) => {
     e.preventDefault();
     e.stopPropagation();
-    if (tile.type !== 'image') return;
+    if (tile.type !== 'image' || editorState.mode !== 'imageEditing') return;
     onSelectTile(tile.id);
     const imageTile = tile as ImageTile;
     const imagePosition = imageTile.content.position || { x: 0, y: 0 };

--- a/src/state/editorReducer.ts
+++ b/src/state/editorReducer.ts
@@ -4,6 +4,7 @@ export type EditorAction =
   | { type: 'selectTile'; tileId: string | null }
   | { type: 'startEditing'; tileId: string }
   | { type: 'startTextEditing'; tileId: string }
+  | { type: 'startImageEditing'; tileId: string }
   | { type: 'stopEditing' }
   | { type: 'startDrag'; tile: LessonTile; offset: Position }
   | { type: 'startImageDrag'; start: { x: number; y: number; imageX: number; imageY: number } }
@@ -31,6 +32,8 @@ export function editorReducer(state: EditorState, action: EditorAction): EditorS
       return { ...state, selectedTileId: action.tileId, mode: 'editing' };
     case 'startTextEditing':
       return { ...state, selectedTileId: action.tileId, mode: 'textEditing' };
+    case 'startImageEditing':
+      return { ...state, selectedTileId: action.tileId, mode: 'imageEditing' };
     case 'stopEditing':
       return { ...state, mode: state.selectedTileId ? 'editing' : 'idle' };
     case 'startDrag':

--- a/src/types/lessonEditor.ts
+++ b/src/types/lessonEditor.ts
@@ -104,7 +104,16 @@ export interface LessonContent {
 
 export type ResizeHandle = 'nw' | 'ne' | 'sw' | 'se' | 'n' | 's' | 'e' | 'w';
 
-export type EditorMode = 'idle' | 'editing' | 'textEditing' | 'dragging' | 'resizing';
+// EditorMode represents the high-level state of the editor.
+// - 'editing' is used when a tile is selected but not in a specific content editor
+// - 'textEditing' and 'imageEditing' lock the tile for content editing
+export type EditorMode =
+  | 'idle'
+  | 'editing'
+  | 'textEditing'
+  | 'imageEditing'
+  | 'dragging'
+  | 'resizing';
 
 export type InteractionState =
   | { type: 'idle' }


### PR DESCRIPTION
## Summary
- add explicit `imageEditing` mode to separate tile selection from editing
- prevent drag/resize while editing and start image editing on double click
- gate TileRenderer image actions behind new `isImageEditing` flag and show resize handles only when appropriate

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 72 errors, 9 warnings)


------
https://chatgpt.com/codex/tasks/task_e_68c69a8391a88321bd76ed98972020c2