### PR TITLE
Connect text editing toolbar to TipTap

### DIFF
--- a/src/LessonCanvas.tsx
+++ b/src/LessonCanvas.tsx
@@ -1,4 +1,5 @@
 import React, { forwardRef } from 'react';
+import type { Editor } from '@tiptap/react';
 import { Type } from 'lucide-react';
 import { LessonContent, LessonTile, EditorState } from './types/lessonEditor';
 import { EditorAction } from './state/editorReducer';
@@ -16,6 +17,7 @@ interface LessonCanvasProps {
   onAddTile: (tileType: string, position: { x: number; y: number }) => void;
   onFinishTextEditing: () => void;
   showGrid?: boolean;
+  onEditorMount?: (editor: Editor | null) => void;
 }
 
 export const LessonCanvas = forwardRef<HTMLDivElement, LessonCanvasProps>(({ 
@@ -27,7 +29,8 @@ export const LessonCanvas = forwardRef<HTMLDivElement, LessonCanvasProps>(({
   onDeleteTile,
   onAddTile,
   onFinishTextEditing,
-  showGrid = true
+  showGrid = true,
+  onEditorMount,
 }, ref) => {
   const {
     dragPreview,
@@ -131,6 +134,7 @@ export const LessonCanvas = forwardRef<HTMLDivElement, LessonCanvasProps>(({
             onUpdateTile={onUpdateTile}
             onDelete={onDeleteTile}
             onFinishTextEditing={onFinishTextEditing}
+            onEditorMount={onEditorMount}
             showGrid={showGrid}
           />
         ))}

--- a/src/LessonEditor.tsx
+++ b/src/LessonEditor.tsx
@@ -15,6 +15,7 @@ import { ConfirmDialog } from './components/common/ConfirmDialog';
 import { LoadingSpinner } from './components/common/LoadingSpinner';
 import { GridUtils } from './utils/gridUtils';
 import { logger } from './utils/logger';
+import type { Editor } from '@tiptap/react';
 
 interface LessonEditorProps {
   lesson: Lesson;
@@ -25,11 +26,12 @@ interface LessonEditorProps {
 export const LessonEditor: React.FC<LessonEditorProps> = ({ lesson, course, onBack }) => {
   const { toasts, removeToast, success, error, warning } = useToast();
   const canvasRef = useRef<HTMLDivElement>(null);
-  
+
   // Core state
   const [lessonContent, setLessonContent] = useState<LessonContent | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isSaving, setIsSaving] = useState(false);
+  const [activeEditor, setActiveEditor] = useState<Editor | null>(null);
   
   const { editorState, dispatch } = useLessonEditor();
 
@@ -435,8 +437,9 @@ export const LessonEditor: React.FC<LessonEditorProps> = ({ lesson, course, onBa
         <div className="flex-1 flex flex-col min-w-0">
           {/* Dynamic Toolbar - Text Editing or Canvas Info */}
           {editorState.mode === 'textEditing' ? (
-            <TextEditingToolbar 
+            <TextEditingToolbar
               onFinishEditing={handleFinishTextEditing}
+              editor={activeEditor}
             />
           ) : (
             <div className="bg-white border-b border-gray-200 px-4 lg:px-6 py-3">
@@ -482,6 +485,7 @@ export const LessonEditor: React.FC<LessonEditorProps> = ({ lesson, course, onBa
               onFinishTextEditing={handleFinishTextEditing}
               onDeleteTile={handleDeleteTile}
               onAddTile={handleAddTile}
+              onEditorMount={setActiveEditor}
               dispatch={dispatch}
               showGrid={editorState.showGrid}
             />

--- a/src/components/admin/TextEditingToolbar.tsx
+++ b/src/components/admin/TextEditingToolbar.tsx
@@ -1,51 +1,66 @@
 import React from 'react';
-import { Bold, Italic, Underline, List, ListOrdered, Undo, Redo, Type, Palette } from 'lucide-react';
+import { Bold, Italic, Underline as UnderlineIcon, List, ListOrdered, Undo, Redo, Type, Palette } from 'lucide-react';
+import type { Editor } from '@tiptap/react';
 
 interface TextEditingToolbarProps {
   onFinishEditing: () => void;
+  editor: Editor | null;
   className?: string;
 }
 
 export const TextEditingToolbar: React.FC<TextEditingToolbarProps> = ({
   onFinishEditing,
-  className = ''
+  editor,
+  className = '',
 }) => {
+  const baseBtn = 'p-2 rounded-lg transition-colors';
+  const fmtClass = (active: boolean) =>
+    `${baseBtn} ${active ? 'text-blue-600 bg-blue-50' : 'text-gray-600 hover:text-blue-600 hover:bg-blue-50'}`;
+
+  const canUndo = editor?.can().undo() ?? false;
+  const canRedo = editor?.can().redo() ?? false;
+
   return (
     <div className={`flex items-center justify-between bg-white border-b border-gray-200 px-4 lg:px-6 py-3 ${className}`}>
       <div className="flex items-center space-x-1">
         {/* Text formatting buttons */}
         <div className="flex items-center space-x-1 border-r border-gray-200 pr-3 mr-3">
           <button
-            className="p-2 text-gray-600 hover:text-blue-600 hover:bg-blue-50 rounded-lg transition-colors"
+            className={fmtClass(editor?.isActive('bold') ?? false)}
             title="Pogrub tekst"
+            onClick={() => editor?.chain().focus().toggleBold().run()}
           >
             <Bold className="w-4 h-4" />
           </button>
           <button
-            className="p-2 text-gray-600 hover:text-blue-600 hover:bg-blue-50 rounded-lg transition-colors"
+            className={fmtClass(editor?.isActive('italic') ?? false)}
             title="Kursywa"
+            onClick={() => editor?.chain().focus().toggleItalic().run()}
           >
             <Italic className="w-4 h-4" />
           </button>
           <button
-            className="p-2 text-gray-600 hover:text-blue-600 hover:bg-blue-50 rounded-lg transition-colors"
+            className={fmtClass(editor?.isActive('underline') ?? false)}
             title="Podkreślenie"
+            onClick={() => editor?.chain().focus().toggleUnderline().run()}
           >
-            <Underline className="w-4 h-4" />
+            <UnderlineIcon className="w-4 h-4" />
           </button>
         </div>
 
         {/* List buttons */}
         <div className="flex items-center space-x-1 border-r border-gray-200 pr-3 mr-3">
           <button
-            className="p-2 text-gray-600 hover:text-blue-600 hover:bg-blue-50 rounded-lg transition-colors"
+            className={fmtClass(editor?.isActive('bulletList') ?? false)}
             title="Lista punktowana"
+            onClick={() => editor?.chain().focus().toggleBulletList().run()}
           >
             <List className="w-4 h-4" />
           </button>
           <button
-            className="p-2 text-gray-600 hover:text-blue-600 hover:bg-blue-50 rounded-lg transition-colors"
+            className={fmtClass(editor?.isActive('orderedList') ?? false)}
             title="Lista numerowana"
+            onClick={() => editor?.chain().focus().toggleOrderedList().run()}
           >
             <ListOrdered className="w-4 h-4" />
           </button>
@@ -54,13 +69,13 @@ export const TextEditingToolbar: React.FC<TextEditingToolbarProps> = ({
         {/* Color and style buttons */}
         <div className="flex items-center space-x-1 border-r border-gray-200 pr-3 mr-3">
           <button
-            className="p-2 text-gray-600 hover:text-blue-600 hover:bg-blue-50 rounded-lg transition-colors"
+            className={`${baseBtn} text-gray-600 hover:text-blue-600 hover:bg-blue-50`}
             title="Kolor tekstu"
           >
             <Palette className="w-4 h-4" />
           </button>
           <button
-            className="p-2 text-gray-600 hover:text-blue-600 hover:bg-blue-50 rounded-lg transition-colors"
+            className={`${baseBtn} text-gray-600 hover:text-blue-600 hover:bg-blue-50`}
             title="Rozmiar tekstu"
           >
             <Type className="w-4 h-4" />
@@ -70,14 +85,18 @@ export const TextEditingToolbar: React.FC<TextEditingToolbarProps> = ({
         {/* Undo/Redo buttons */}
         <div className="flex items-center space-x-1">
           <button
-            className="p-2 text-gray-600 hover:text-blue-600 hover:bg-blue-50 rounded-lg transition-colors"
+            className={`${baseBtn} text-gray-600 hover:text-blue-600 hover:bg-blue-50 ${!canUndo ? 'opacity-50 cursor-not-allowed' : ''}`}
             title="Cofnij"
+            onClick={() => editor?.chain().focus().undo().run()}
+            disabled={!canUndo}
           >
             <Undo className="w-4 h-4" />
           </button>
           <button
-            className="p-2 text-gray-600 hover:text-blue-600 hover:bg-blue-50 rounded-lg transition-colors"
+            className={`${baseBtn} text-gray-600 hover:text-blue-600 hover:bg-blue-50 ${!canRedo ? 'opacity-50 cursor-not-allowed' : ''}`}
             title="Ponów"
+            onClick={() => editor?.chain().focus().redo().run()}
+            disabled={!canRedo}
           >
             <Redo className="w-4 h-4" />
           </button>
@@ -90,7 +109,7 @@ export const TextEditingToolbar: React.FC<TextEditingToolbarProps> = ({
           <div className="w-2 h-2 bg-blue-500 rounded-full animate-pulse"></div>
           <span className="font-medium">Edytujesz tekst</span>
         </div>
-        
+
         <button
           onClick={onFinishEditing}
           className="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 transition-colors text-sm font-medium"

--- a/src/components/admin/TileRenderer.tsx
+++ b/src/components/admin/TileRenderer.tsx
@@ -3,6 +3,7 @@ import { Type, Image, Puzzle, BarChart3, HelpCircle, Move, Trash2 } from 'lucide
 import { LessonTile, TextTile, ImageTile, InteractiveTile, VisualizationTile, QuizTile } from '../../types/lessonEditor';
 import { GridUtils } from '../../utils/gridUtils';
 import { TipTapEditor } from './TipTapEditor';
+import type { Editor } from '@tiptap/react';
 
 interface TileRendererProps {
   tile: LessonTile;
@@ -17,6 +18,7 @@ interface TileRendererProps {
   onUpdateTile: (tileId: string, updates: Partial<LessonTile>) => void;
   onDelete: (tileId: string) => void;
   onFinishTextEditing: () => void;
+  onEditorMount?: (editor: Editor | null) => void;
   showGrid: boolean;
 }
 
@@ -33,6 +35,7 @@ export const TileRenderer: React.FC<TileRendererProps> = ({
   onUpdateTile,
   onDelete,
   onFinishTextEditing,
+  onEditorMount,
   showGrid
 }) => {
   const [isHovered, setIsHovered] = useState(false);
@@ -109,6 +112,7 @@ export const TileRenderer: React.FC<TileRendererProps> = ({
                   });
                 }}
                 onBlur={onFinishTextEditing}
+                onEditorChange={onEditorMount}
                 autoFocus={true}
                 placeholder="Wpisz tekst..."
                 className="w-full h-full"

--- a/src/components/admin/TipTapEditor.tsx
+++ b/src/components/admin/TipTapEditor.tsx
@@ -1,8 +1,9 @@
 import React, { useEffect } from 'react';
-import { useEditor, EditorContent } from '@tiptap/react';
+import { useEditor, EditorContent, type Editor } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
 import { TextStyle } from '@tiptap/extension-text-style';
 import Color from '@tiptap/extension-color';
+import Underline from '../../extensions/Underline';
 
 interface TipTapEditorProps {
   content: string;
@@ -11,6 +12,7 @@ interface TipTapEditorProps {
   className?: string;
   placeholder?: string;
   autoFocus?: boolean;
+  onEditorChange?: (editor: Editor | null) => void;
 }
 
 export const TipTapEditor: React.FC<TipTapEditorProps> = ({
@@ -19,7 +21,8 @@ export const TipTapEditor: React.FC<TipTapEditorProps> = ({
   onBlur,
   className = '',
   placeholder = 'Wpisz tekst...',
-  autoFocus = false
+  autoFocus = false,
+  onEditorChange,
 }) => {
   const editor = useEditor({
     extensions: [
@@ -32,6 +35,7 @@ export const TipTapEditor: React.FC<TipTapEditorProps> = ({
       }),
       TextStyle,
       Color,
+      Underline,
     ],
     content: content,
     onUpdate: ({ editor }) => {
@@ -48,6 +52,11 @@ export const TipTapEditor: React.FC<TipTapEditorProps> = ({
       },
     },
   });
+
+  useEffect(() => {
+    onEditorChange?.(editor);
+    return () => onEditorChange?.(null);
+  }, [editor, onEditorChange]);
 
   useEffect(() => {
     if (editor && autoFocus) {

--- a/src/extensions/Underline.ts
+++ b/src/extensions/Underline.ts
@@ -1,0 +1,33 @@
+import { Mark, mergeAttributes } from '@tiptap/core';
+
+export const Underline = Mark.create({
+  name: 'underline',
+
+  parseHTML() {
+    return [
+      { tag: 'u' },
+      {
+        style: 'text-decoration',
+        getAttrs: (value) => value === 'underline' && null,
+      },
+    ];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ['u', mergeAttributes(HTMLAttributes), 0];
+  },
+
+  addCommands() {
+    return {
+      toggleUnderline: () => ({ commands }) => commands.toggleMark('underline'),
+    };
+  },
+
+  addKeyboardShortcuts() {
+    return {
+      'Mod-u': () => this.editor.commands.toggleUnderline(),
+    };
+  },
+});
+
+export default Underline;


### PR DESCRIPTION
## Summary
- expose TipTap editor instance and add custom underline extension
- hook toolbar buttons up to TipTap commands for bold, italic, underline, lists and history
- propagate editor instance from tiles through canvas so toolbar controls active editor

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: many existing lint errors)


------
https://chatgpt.com/codex/tasks/task_e_68c6ad04afb083219444020649b74967