### PR TITLE
fix: preserve selection and prevent safari crash

### DIFF
--- a/src/components/admin/RichTextEditor.tsx
+++ b/src/components/admin/RichTextEditor.tsx
@@ -67,13 +67,10 @@ export const RichTextEditor: React.FC<RichTextEditorProps> = ({
   };
   const handleInput = () => {
     if (editorRef.current) {
-      console.log('Rich text content updated:', editorRef.current.innerHTML);
       const content = editorRef.current.innerHTML;
       const cleanedHTML = cleanHTML(content);
-      console.log('Cleaned HTML:', cleanedHTML);
       onChange(cleanedHTML);
-      
-      // Preserve cursor position after content update
+
       const selection = window.getSelection();
       if (selection && selection.rangeCount > 0) {
         const range = selection.getRangeAt(0);
@@ -172,111 +169,63 @@ export const RichTextEditor: React.FC<RichTextEditorProps> = ({
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, []);
   const applyFormat = (command: string, value?: string) => {
-    console.log('Applying format:', command, value);
-    
-    // Prevent menu from hiding during formatting
+    if (!editorRef.current) return;
+
     setIsFormattingActive(true);
+    editorRef.current.focus({ preventScroll: true });
 
-    // Critical: Ensure editor has focus FIRST
-    if (editorRef.current) {
-      editorRef.current.focus();
-      
-      // Verify focus was actually set
-      if (document.activeElement !== editorRef.current) {
-        console.warn('Failed to focus editor');
-        setIsFormattingActive(false);
-        return;
-      }
-    }
-
-    // Restore selection with validation
-    if (savedSelection && savedSelection.startContainer && savedSelection.endContainer) {
-      const selection = window.getSelection();
-      if (selection) {
-        try {
-          selection.removeAllRanges();
-          const clonedRange = savedSelection.cloneRange();
-          selection.addRange(clonedRange);
-          console.log('Selection restored for formatting');
-          
-          // Verify selection was restored
-          if (selection.isCollapsed) {
-            console.warn('Selection collapsed after restoration');
-          }
-        } catch (error) {
-          console.error('Failed to restore selection:', error);
-          setIsFormattingActive(false);
-          return;
-        }
-      }
-    } else {
-      console.warn('No valid saved selection to restore');
+    const selection = window.getSelection();
+    if (!selection || selection.rangeCount === 0) {
       setIsFormattingActive(false);
       return;
     }
 
-    // Execute formatting with proper error handling
-    const executeFormatting = () => {
-      try {
-        // Ensure we still have focus
-        if (document.activeElement !== editorRef.current) {
-          editorRef.current?.focus();
-        }
-        
-        // Apply the formatting command
-        const success = document.execCommand(command, false, value);
-        console.log('Format command executed:', command, 'success:', success);
-        
-        if (!success) {
-          console.error('execCommand failed for:', command);
-        }
-        
-        if (editorRef.current) {
-          // Force content update
-          const content = editorRef.current.innerHTML;
-          console.log('Content after formatting:', content);
-          
-          // Trigger change event
-          const event = new Event('input', { bubbles: true });
-          editorRef.current.dispatchEvent(event);
-          onChange(content);
-          
-          // Save the new selection after formatting
-          const newSelection = window.getSelection();
-          if (newSelection && newSelection.rangeCount > 0 && !newSelection.isCollapsed) {
-            const newRange = newSelection.getRangeAt(0);
-            setSavedSelection(newRange.cloneRange());
-            
-            // Update toolbar position if selection has dimensions
-            const rect = newRange.getBoundingClientRect();
-            if (rect.width > 0 && rect.height > 0) {
-              setToolbarPosition({
-                top: rect.top - 50,
-                left: rect.left + (rect.width / 2) - 100
-              });
-            }
-          } else {
-            // If no selection after formatting, keep the saved one
-            console.log('No selection after formatting, keeping saved selection');
-          }
-        }
-        
-      } catch (error) {
-        console.error('Error applying format:', error);
-      } finally {
-        // Always reset formatting state after a delay
-        setTimeout(() => {
-          setIsFormattingActive(false);
-        }, 100);
-      }
-    };
+    const range = selection.getRangeAt(0);
+    setSavedSelection(range.cloneRange());
 
-    // Execute immediately if we have focus, otherwise with small delay
-    if (document.activeElement === editorRef.current) {
-      executeFormatting();
-    } else {
-      setTimeout(executeFormatting, 10);
+    try {
+      const executed = document.execCommand(command, false, value);
+
+      // Safari may return false without throwing; apply fallback styling
+      if (!executed && /Safari/.test(navigator.userAgent) && !/Chrome/.test(navigator.userAgent)) {
+        const wrapper = document.createElement('span');
+        switch (command) {
+          case 'bold':
+            wrapper.style.fontWeight = 'bold';
+            break;
+          case 'italic':
+            wrapper.style.fontStyle = 'italic';
+            break;
+          case 'underline':
+            wrapper.style.textDecoration = 'underline';
+            break;
+          case 'foreColor':
+            if (value) wrapper.style.color = value;
+            break;
+        }
+        range.surroundContents(wrapper);
+      }
+    } catch {
+      // ignore errors to prevent Safari from crashing
     }
+
+    // Restore selection and keep toolbar/focus
+    requestAnimationFrame(() => {
+      restoreSelection();
+      editorRef.current?.focus({ preventScroll: true });
+      const sel = window.getSelection();
+      if (sel && sel.rangeCount > 0) {
+        const rect = sel.getRangeAt(0).getBoundingClientRect();
+        if (rect.width > 0 && rect.height > 0) {
+          setToolbarPosition({
+            top: rect.top - 50,
+            left: rect.left + rect.width / 2 - 100,
+          });
+        }
+      }
+      setShowToolbar(true);
+      setIsFormattingActive(false);
+    });
   };
 
   // Handle focus events to maintain selection
@@ -289,7 +238,7 @@ export const RichTextEditor: React.FC<RichTextEditorProps> = ({
   };
 
   // Handle click to position cursor correctly
-  const handleClick = (e: React.MouseEvent) => {
+  const handleClick = () => {
     // Allow normal cursor positioning on click
     setTimeout(() => {
       const selection = window.getSelection();

--- a/src/components/admin/TextFormattingToolbar.tsx
+++ b/src/components/admin/TextFormattingToolbar.tsx
@@ -18,28 +18,7 @@ export const TextFormattingToolbar = forwardRef<HTMLDivElement, TextFormattingTo
   const [selectedColor, setSelectedColor] = useState('#000000');
   const colorPickerRef = useRef<HTMLDivElement>(null);
 
-  // Debug effect to monitor state changes
-  useEffect(() => {
-    console.log('🔄 showColorPicker state changed to:', showColorPicker);
-  }, [showColorPicker]);
-
-  // Fallback click handler setup
-  useEffect(() => {
-    const handleDocumentClick = (e: MouseEvent) => {
-      const target = e.target as HTMLElement;
-      if (target.closest('[title="Kolor tekstu"]')) {
-        console.log('🎯 Fallback click handler triggered');
-        if (!showColorPicker) {
-          setShowColorPicker(true);
-          onToolbarInteraction?.();
-        }
-      }
-    };
-
-    // Add fallback listener
-    document.addEventListener('click', handleDocumentClick);
-    return () => document.removeEventListener('click', handleDocumentClick);
-  }, [showColorPicker, onToolbarInteraction]);
+  // Remove debug logging and fallback click handler for stability
   const predefinedColors = [
     '#000000', '#494949', '#9c9c9c', '#ffffff',
     '#a10000', '#ff0000', '#ffa500', '#FFFF00',
@@ -64,35 +43,19 @@ export const TextFormattingToolbar = forwardRef<HTMLDivElement, TextFormattingTo
   }, [showColorPicker]);
 
   const handleColorSelect = (color: string) => {
-    console.log('Color selected:', color);
     setSelectedColor(color);
     onToolbarInteraction?.();
-    
-    // Apply color immediately
     onFormat('foreColor', color);
   };
 
   const handleColorPickerToggle = (e: React.MouseEvent) => {
-      
-      // Prevent event bubbling that might interfere
-      
-    setShowColorPicker(!showColorPicker);
-        // return newState;
-      // });
-      
-    // } catch (error) {
-      // console.error('Error in color picker toggle:', error);
-    // }
     e.stopPropagation();
-    setShowColorPicker(!showColorPicker);
-    
-    console.log('New showColorPicker state will be:', !showColorPicker);
+    setShowColorPicker((prev) => !prev);
     onToolbarInteraction?.();
   };
 
   const handleCustomColorChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const color = e.target.value;
-    console.log('Custom color selected:', color);
     setSelectedColor(color);
     onToolbarInteraction?.();
     onFormat('foreColor', color);
@@ -100,18 +63,7 @@ export const TextFormattingToolbar = forwardRef<HTMLDivElement, TextFormattingTo
 
   // Handle formatting button clicks
   const handleFormatClick = (command: string) => {
-    console.log('Format button clicked:', command);
-    
-    // Prevent event bubbling that might hide toolbar
-    // if (event) {
-      // event.preventDefault();
-      // event.stopPropagation();
-    // }
-    
-    // Signal toolbar interaction
     onToolbarInteraction?.();
-    
-    // Execute formatting immediately
     onFormat(command);
   };
 
@@ -131,10 +83,6 @@ export const TextFormattingToolbar = forwardRef<HTMLDivElement, TextFormattingTo
         e.preventDefault();
       }}
     >
-      {/* Debug info - remove in production */}
-      <div className="absolute -top-6 left-0 text-xs bg-yellow-100 px-2 py-1 rounded">
-        ColorPicker: {showColorPicker ? 'OPEN' : 'CLOSED'}
-      </div>
       <button
         onClick={() => handleFormatClick('bold')}
         onMouseDown={(e) => {
@@ -177,15 +125,10 @@ export const TextFormattingToolbar = forwardRef<HTMLDivElement, TextFormattingTo
         <button 
           className="p-2 hover:bg-gray-100 rounded transition-colors flex items-center space-x-1 group"
           onClick={(e) => {
-            console.log('🎨 Direct onClick handler');
             handleColorPickerToggle(e);
           }}
           onMouseDown={(e) => {
-            console.log('🖱️ Color picker button mousedown');
             e.preventDefault();
-          }}
-          onMouseUp={(e) => {
-            console.log('🖱️ Color picker button mouseup');
           }}
           title="Kolor tekstu"
           type="button"
@@ -199,8 +142,7 @@ export const TextFormattingToolbar = forwardRef<HTMLDivElement, TextFormattingTo
         
         {showColorPicker && (
           <>
-            {console.log('🎨 Rendering color picker, showColorPicker:', showColorPicker)}
-          <div 
+          <div
             ref={colorPickerRef}
             className="absolute top-full left-0 mt-2 bg-white border border-gray-200 rounded-xl shadow-xl p-4 min-w-[280px]"
             style={{


### PR DESCRIPTION
## Summary
- keep editor focused and selection intact after formatting, updating toolbar position
- simplify formatting toolbar to avoid focus loss and remove problematic global handlers

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Unexpected any. Specify a different type)


------
https://chatgpt.com/codex/tasks/task_e_68c6c48b4180832180e94f0767a0cf11