### PR TITLE
feat: enable basic text formatting with tiptap

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@tiptap/extension-list-item": "^3.4.2",
         "@tiptap/extension-ordered-list": "^3.4.2",
         "@tiptap/extension-text-style": "^3.4.2",
+        "@tiptap/extension-underline": "^3.4.2",
         "@tiptap/react": "^3.4.2",
         "@tiptap/starter-kit": "^3.4.2",
         "lucide-react": "^0.344.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@tiptap/extension-list-item": "^3.4.2",
     "@tiptap/extension-ordered-list": "^3.4.2",
     "@tiptap/extension-text-style": "^3.4.2",
+    "@tiptap/extension-underline": "^3.4.2",
     "@tiptap/react": "^3.4.2",
     "@tiptap/starter-kit": "^3.4.2",
     "lucide-react": "^0.344.0",

--- a/src/Pages/LessonEditor.tsx
+++ b/src/Pages/LessonEditor.tsx
@@ -8,6 +8,7 @@ import { TilePalette } from '../components/admin/TilePalette.tsx';
 import { LessonCanvas } from '../components/admin/LessonCanvas.tsx';
 import { TileSideEditor } from '../components/admin/TileSideEditor.tsx';
 import { TopToolbar } from '../components/admin/TopToolbar.tsx';
+import { Editor } from '@tiptap/react';
 import { ToastContainer } from '../components/common/Toast.tsx';
 import { useToast } from '../hooks/useToast.ts';
 import { ConfirmDialog } from '../components/common/ConfirmDialog.tsx';
@@ -31,6 +32,7 @@ export const LessonEditor: React.FC<LessonEditorProps> = ({ lesson, course, onBa
   const [isSaving, setIsSaving] = useState(false);
   
   const { editorState, dispatch } = useLessonEditor();
+  const [activeEditor, setActiveEditor] = useState<Editor | null>(null);
 
   // Confirmation dialog state
   const [confirmDialog, setConfirmDialog] = useState<{
@@ -236,6 +238,7 @@ export const LessonEditor: React.FC<LessonEditorProps> = ({ lesson, course, onBa
 
   const handleFinishTextEditing = () => {
     dispatch({ type: 'stopEditing' });
+    setActiveEditor(null);
   };
 
   const handleToggleGrid = () => {
@@ -434,6 +437,7 @@ export const LessonEditor: React.FC<LessonEditorProps> = ({ lesson, course, onBa
             currentMode={editorState.selectedTileId ? 'Tryb edycji' : 'Tryb dodawania'}
             isTextEditing={editorState.mode === 'textEditing'}
             onFinishTextEditing={handleFinishTextEditing}
+            editor={activeEditor}
           />
 
           {/* Canvas */}
@@ -449,6 +453,7 @@ export const LessonEditor: React.FC<LessonEditorProps> = ({ lesson, course, onBa
               onAddTile={handleAddTile}
               dispatch={dispatch}
               showGrid={editorState.showGrid}
+              onEditorReady={setActiveEditor}
             />
           </div>
         </div>

--- a/src/components/admin/LessonCanvas.tsx
+++ b/src/components/admin/LessonCanvas.tsx
@@ -5,6 +5,7 @@ import { EditorAction } from '../../state/editorReducer.ts';
 import { TileRenderer } from './TileRenderer.tsx';
 import { GridUtils } from '../../utils/gridUtils.ts';
 import { useTileInteractions } from '../../hooks/useTileInteractions.ts';
+import { Editor } from '@tiptap/react';
 
 interface LessonCanvasProps {
   content: LessonContent;
@@ -16,6 +17,7 @@ interface LessonCanvasProps {
   onAddTile: (tileType: string, position: { x: number; y: number }) => void;
   onFinishTextEditing: () => void;
   showGrid?: boolean;
+  onEditorReady: (editor: Editor | null) => void;
 }
 
 export const LessonCanvas = forwardRef<HTMLDivElement, LessonCanvasProps>(({ 
@@ -27,7 +29,8 @@ export const LessonCanvas = forwardRef<HTMLDivElement, LessonCanvasProps>(({
   onDeleteTile,
   onAddTile,
   onFinishTextEditing,
-  showGrid = true
+  showGrid = true,
+  onEditorReady
 }, ref) => {
   const {
     dragPreview,
@@ -132,6 +135,7 @@ export const LessonCanvas = forwardRef<HTMLDivElement, LessonCanvasProps>(({
             onDelete={onDeleteTile}
             onFinishTextEditing={onFinishTextEditing}
             showGrid={showGrid}
+            onEditorReady={onEditorReady}
           />
         ))}
 

--- a/src/components/admin/TopToolbar.tsx
+++ b/src/components/admin/TopToolbar.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Bold, Italic, Underline, List, ListOrdered, Undo, Redo, Type, Palette, Code, FileCode, X } from 'lucide-react';
+import { Editor } from '@tiptap/react';
 
 
 interface TopToolbarProps {
@@ -9,6 +10,7 @@ interface TopToolbarProps {
   currentMode: string;
   isTextEditing: boolean;
   onFinishTextEditing?: () => void;
+  editor?: Editor | null;
   className?: string;
 }
 
@@ -19,15 +21,34 @@ export const TopToolbar: React.FC<TopToolbarProps> = ({
   currentMode,
   isTextEditing,
   onFinishTextEditing,
+  editor,
   className = ''
 }) => {
   if (isTextEditing) {
     return (
       <div className={`top-toolbar flex items-center justify-between bg-white border-b border-gray-200 px-4 lg:px-6 py-3 ${className}`}>
-        <div className="flex items-center space-x-1 text-gray-400">
-          <button className="p-2" disabled><Bold className="w-4 h-4" /></button>
-          <button className="p-2" disabled><Italic className="w-4 h-4" /></button>
-          <button className="p-2" disabled><Underline className="w-4 h-4" /></button>
+        <div className="flex items-center space-x-1 text-gray-600">
+          <button
+            className={`p-2 ${editor?.isActive('bold') ? 'text-gray-900' : ''}`}
+            onMouseDown={e => e.preventDefault()}
+            onClick={() => editor?.chain().focus().toggleBold().run()}
+          >
+            <Bold className="w-4 h-4" />
+          </button>
+          <button
+            className={`p-2 ${editor?.isActive('italic') ? 'text-gray-900' : ''}`}
+            onMouseDown={e => e.preventDefault()}
+            onClick={() => editor?.chain().focus().toggleItalic().run()}
+          >
+            <Italic className="w-4 h-4" />
+          </button>
+          <button
+            className={`p-2 ${editor?.isActive('underline') ? 'text-gray-900' : ''}`}
+            onMouseDown={e => e.preventDefault()}
+            onClick={() => editor?.chain().focus().toggleUnderline().run()}
+          >
+            <Underline className="w-4 h-4" />
+          </button>
           <button className="p-2" disabled><List className="w-4 h-4" /></button>
           <button className="p-2" disabled><ListOrdered className="w-4 h-4" /></button>
           <button className="p-2" disabled><Type className="w-4 h-4" /></button>


### PR DESCRIPTION
## Summary
- integrate Tiptap editor for text tiles
- expose editor instance to toolbar
- enable bold, italic and underline buttons

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_e_68c72dd9fdf8832187e1ae080fbbd598