### PR TITLE
Integrate text formatting options with TipTap editor

### DIFF
--- a/src/components/admin/FontFamilySelector.tsx
+++ b/src/components/admin/FontFamilySelector.tsx
@@ -131,13 +131,14 @@ export const FontFamilySelector: React.FC<FontFamilySelectorProps> = ({
       {isOpen && (
         <>
           {/* Backdrop */}
-          <div 
-            className="fixed inset-0 z-10" 
+          <div
+            className="fixed inset-0 z-40"
+            onMouseDown={(e) => e.preventDefault()}
             onClick={() => setIsOpen(false)}
           />
           
           {/* Dropdown Content */}
-          <div className="absolute top-full left-0 mt-2 w-96 bg-white border border-gray-200 rounded-xl shadow-xl z-20 overflow-hidden">
+          <div className="absolute top-full left-0 mt-2 w-96 bg-white border border-gray-200 rounded-xl shadow-xl z-50 overflow-hidden">
             {/* Header */}
             <div className="px-4 py-3 bg-gray-50 border-b border-gray-100">
               <h3 className="text-sm font-semibold text-gray-800">Rodzina czcionek</h3>

--- a/src/components/admin/FontSizeSelector.tsx
+++ b/src/components/admin/FontSizeSelector.tsx
@@ -58,13 +58,14 @@ export const FontSizeSelector: React.FC<FontSizeSelectorProps> = ({
       {isOpen && (
         <>
           {/* Backdrop */}
-          <div 
-            className="fixed inset-0 z-10" 
+          <div
+            className="fixed inset-0 z-40"
+            onMouseDown={(e) => e.preventDefault()}
             onClick={() => setIsOpen(false)}
           />
           
           {/* Dropdown Content */}
-          <div className="absolute top-full left-0 mt-2 w-64 bg-white border border-gray-200 rounded-xl shadow-xl z-20 overflow-hidden">
+          <div className="absolute top-full left-0 mt-2 w-64 bg-white border border-gray-200 rounded-xl shadow-xl z-50 overflow-hidden">
             {/* Header */}
             <div className="px-4 py-3 bg-gray-50 border-b border-gray-100">
               <h3 className="text-sm font-semibold text-gray-800">Rozmiar czcionki</h3>

--- a/src/components/admin/TextColorPicker.tsx
+++ b/src/components/admin/TextColorPicker.tsx
@@ -94,13 +94,14 @@ export const TextColorPicker: React.FC<TextColorPickerProps> = ({
       {isOpen && (
         <>
           {/* Backdrop */}
-          <div 
-            className="fixed inset-0 z-10" 
+          <div
+            className="fixed inset-0 z-40"
+            onMouseDown={(e) => e.preventDefault()}
             onClick={() => setIsOpen(false)}
           />
           
           {/* Dropdown Content */}
-          <div className="absolute top-full left-0 mt-2 w-80 bg-white border border-gray-200 rounded-xl shadow-xl z-20 overflow-hidden">
+          <div className="absolute top-full left-0 mt-2 w-80 bg-white border border-gray-200 rounded-xl shadow-xl z-50 overflow-hidden">
             {/* Header */}
             <div className="px-4 py-3 bg-gray-50 border-b border-gray-100">
               <div className="flex items-center justify-between">

--- a/src/components/admin/TileRenderer.tsx
+++ b/src/components/admin/TileRenderer.tsx
@@ -5,6 +5,10 @@ import { GridUtils } from '../../utils/gridUtils';
 import { Editor, EditorContent, useEditor } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
 import Underline from '@tiptap/extension-underline';
+import { TextStyle } from '@tiptap/extension-text-style';
+import Color from '@tiptap/extension-color';
+import FontFamily from '@tiptap/extension-font-family';
+import FontSize from '../../extensions/FontSize';
 
 interface TileRendererProps {
   tile: LessonTile;
@@ -33,8 +37,17 @@ interface TextEditorProps {
 
 const TextTileEditor: React.FC<TextEditorProps> = ({ textTile, tileId, onUpdateTile, onFinishTextEditing, onEditorReady }) => {
   const editor = useEditor({
-    extensions: [StarterKit, Underline],
-    content: textTile.content.richText || `<p style="margin: 0;">${textTile.content.text || ''}</p>`,
+    extensions: [
+      StarterKit,
+      Underline,
+      TextStyle,
+      Color.configure({ types: ['textStyle'] }),
+      FontFamily.configure({ types: ['textStyle'] }),
+      FontSize,
+    ],
+    content:
+      textTile.content.richText ||
+      `<p style="margin: 0;">${textTile.content.text || ''}</p>`,
     onUpdate: ({ editor }) => {
       const html = editor.getHTML();
       const plain = editor.getText();

--- a/src/components/admin/TileRenderer.tsx
+++ b/src/components/admin/TileRenderer.tsx
@@ -69,12 +69,22 @@ const TextTileEditor: React.FC<TextEditorProps> = ({ textTile, tileId, onUpdateT
 
   if (!editor) return null;
 
+  const handleBlur = (e: React.FocusEvent) => {
+    const toolbar = document.querySelector('.top-toolbar');
+    if (toolbar && e.relatedTarget && toolbar.contains(e.relatedTarget as Node)) {
+      e.preventDefault();
+      editor.commands.focus();
+      return;
+    }
+    onFinishTextEditing();
+  };
+
   return (
     <div className="w-full h-full p-3 overflow-hidden relative">
       <EditorContent
         editor={editor}
         className="w-full h-full focus:outline-none"
-        onBlur={onFinishTextEditing}
+        onBlur={handleBlur}
       />
     </div>
   );

--- a/src/components/admin/TopToolbar.tsx
+++ b/src/components/admin/TopToolbar.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Bold, Italic, Underline, List, ListOrdered, Undo, Redo, Code, FileCode, X } from 'lucide-react';
 import { Editor } from '@tiptap/react';
 import { FontSizeSelector } from './FontSizeSelector';
@@ -27,16 +27,41 @@ export const TopToolbar: React.FC<TopToolbarProps> = ({
   editor,
   className = ''
 }) => {
+  const [currentFont, setCurrentFont] = useState('Inter, system-ui, sans-serif');
+  const [currentSize, setCurrentSize] = useState(16);
+  const [currentColor, setCurrentColor] = useState('#000000');
+
+  useEffect(() => {
+    if (!editor) return;
+
+    const updateAttributes = () => {
+      const attrs = editor.getAttributes('textStyle');
+      setCurrentFont(attrs.fontFamily || 'Inter, system-ui, sans-serif');
+      const sizeAttr = attrs.fontSize ? parseInt(attrs.fontSize) : 16;
+      setCurrentSize(sizeAttr || 16);
+      setCurrentColor(attrs.color || '#000000');
+    };
+
+    updateAttributes();
+
+    editor.on('selectionUpdate', updateAttributes);
+    editor.on('transaction', updateAttributes);
+
+    return () => {
+      editor.off('selectionUpdate', updateAttributes);
+      editor.off('transaction', updateAttributes);
+    };
+  }, [editor]);
+
   if (isTextEditing) {
     return (
       <div className={`top-toolbar flex items-center justify-between bg-white border-b border-gray-200 px-4 lg:px-6 py-3 ${className}`}>
         <div className="flex items-center space-x-2 text-gray-600">
           {/* Font Family Selector */}
           <FontFamilySelector
-            selectedFont="Inter, system-ui, sans-serif"
+            selectedFont={currentFont}
             onChange={(font) => {
-              console.log('Font changed:', font);
-              // Tutaj będzie logika zmiany czcionki w edytorze
+              editor?.chain().focus().setFontFamily(font).run();
             }}
           />
           
@@ -44,10 +69,9 @@ export const TopToolbar: React.FC<TopToolbarProps> = ({
           
           {/* Font Size Selector */}
           <FontSizeSelector
-            selectedSize={16}
+            selectedSize={currentSize}
             onChange={(size) => {
-              console.log('Size changed:', size);
-              // Tutaj będzie logika zmiany rozmiaru w edytorze
+              editor?.chain().focus().setFontSize(size).run();
             }}
           />
           
@@ -55,10 +79,9 @@ export const TopToolbar: React.FC<TopToolbarProps> = ({
           
           {/* Text Color Picker */}
           <TextColorPicker
-            selectedColor="#000000"
+            selectedColor={currentColor}
             onChange={(color) => {
-              console.log('Color changed:', color);
-              // Tutaj będzie logika zmiany koloru w edytorze
+              editor?.chain().focus().setColor(color).run();
             }}
           />
           
@@ -90,16 +113,54 @@ export const TopToolbar: React.FC<TopToolbarProps> = ({
           <div className="w-px h-6 bg-gray-300"></div>
           
           {/* Lists and Advanced */}
-          <button className="p-2" disabled onMouseDown={e => e.preventDefault()}><List className="w-4 h-4" /></button>
-          <button className="p-2" disabled onMouseDown={e => e.preventDefault()}><ListOrdered className="w-4 h-4" /></button>
-          <button className="p-2" disabled onMouseDown={e => e.preventDefault()}><Code className="w-4 h-4" /></button>
-          <button className="p-2" disabled onMouseDown={e => e.preventDefault()}><FileCode className="w-4 h-4" /></button>
+          <button
+            className={`p-2 ${editor?.isActive('bulletList') ? 'text-gray-900' : ''}`}
+            onMouseDown={e => e.preventDefault()}
+            onClick={() => editor?.chain().focus().toggleBulletList().run()}
+          >
+            <List className="w-4 h-4" />
+          </button>
+          <button
+            className={`p-2 ${editor?.isActive('orderedList') ? 'text-gray-900' : ''}`}
+            onMouseDown={e => e.preventDefault()}
+            onClick={() => editor?.chain().focus().toggleOrderedList().run()}
+          >
+            <ListOrdered className="w-4 h-4" />
+          </button>
+          <button
+            className={`p-2 ${editor?.isActive('code') ? 'text-gray-900' : ''}`}
+            onMouseDown={e => e.preventDefault()}
+            onClick={() => editor?.chain().focus().toggleCode().run()}
+          >
+            <Code className="w-4 h-4" />
+          </button>
+          <button
+            className={`p-2 ${editor?.isActive('codeBlock') ? 'text-gray-900' : ''}`}
+            onMouseDown={e => e.preventDefault()}
+            onClick={() => editor?.chain().focus().toggleCodeBlock().run()}
+          >
+            <FileCode className="w-4 h-4" />
+          </button>
           
           <div className="w-px h-6 bg-gray-300"></div>
           
           {/* History */}
-          <button className="p-2" disabled onMouseDown={e => e.preventDefault()}><Undo className="w-4 h-4" /></button>
-          <button className="p-2" disabled onMouseDown={e => e.preventDefault()}><Redo className="w-4 h-4" /></button>
+          <button
+            className="p-2"
+            onMouseDown={e => e.preventDefault()}
+            disabled={!editor?.can().undo()}
+            onClick={() => editor?.chain().focus().undo().run()}
+          >
+            <Undo className="w-4 h-4" />
+          </button>
+          <button
+            className="p-2"
+            onMouseDown={e => e.preventDefault()}
+            disabled={!editor?.can().redo()}
+            onClick={() => editor?.chain().focus().redo().run()}
+          >
+            <Redo className="w-4 h-4" />
+          </button>
         </div>
         
         <button

--- a/src/components/admin/TopToolbar.tsx
+++ b/src/components/admin/TopToolbar.tsx
@@ -55,8 +55,11 @@ export const TopToolbar: React.FC<TopToolbarProps> = ({
 
   if (isTextEditing) {
     return (
-      <div className={`top-toolbar flex items-center justify-between bg-white border-b border-gray-200 px-4 lg:px-6 py-3 ${className}`}>
-        <div className="flex items-center space-x-2 text-gray-600">
+      <div
+        className={`top-toolbar relative z-30 flex items-center justify-between bg-white border-b border-gray-200 px-4 lg:px-6 py-3 ${className}`}
+        onMouseDown={(e) => e.preventDefault()}
+      >
+        <div className="flex items-center space-x-2 text-gray-600" onMouseDown={(e) => e.preventDefault()}>
           {/* Font Family Selector */}
           <FontFamilySelector
             selectedFont={currentFont}

--- a/src/extensions/FontSize.ts
+++ b/src/extensions/FontSize.ts
@@ -1,0 +1,53 @@
+import { Extension } from '@tiptap/core';
+
+export const FontSize = Extension.create({
+  name: 'fontSize',
+
+  addOptions() {
+    return {
+      types: ['textStyle'],
+    };
+  },
+
+  addGlobalAttributes() {
+    return [
+      {
+        types: this.options.types,
+        attributes: {
+          fontSize: {
+            default: null,
+            parseHTML: (element) => element.style.fontSize || null,
+            renderHTML: (attributes) => {
+              if (!attributes.fontSize) {
+                return {};
+              }
+              return { style: `font-size: ${attributes.fontSize}` };
+            },
+          },
+        },
+      },
+    ];
+  },
+
+  addCommands() {
+    return {
+      setFontSize:
+        (fontSize: string | number) => ({ chain }) => {
+          return chain()
+            .setMark('textStyle', {
+              fontSize: typeof fontSize === 'number' ? `${fontSize}px` : fontSize,
+            })
+            .run();
+        },
+      unsetFontSize:
+        () => ({ chain }) => {
+          return chain()
+            .setMark('textStyle', { fontSize: null })
+            .removeEmptyTextStyle()
+            .run();
+        },
+    };
+  },
+});
+
+export default FontSize;

--- a/src/index.css
+++ b/src/index.css
@@ -210,6 +210,14 @@
   margin: 0.5rem 0;
 }
 
+.tiptap-editor .ProseMirror .bullet-list {
+  list-style-type: disc;
+}
+
+.tiptap-editor .ProseMirror .ordered-list {
+  list-style-type: decimal;
+}
+
 .tiptap-editor .ProseMirror .bullet-list li,
 .tiptap-editor .ProseMirror .ordered-list li {
   margin: 0.25rem 0;
@@ -238,10 +246,19 @@
   margin: 0.5rem 0 !important;
 }
 
+
 .tile-formatted-text .bullet-list,
 .tile-formatted-text .ordered-list {
   padding-left: 1.5rem !important;
   margin: 0.5rem 0 !important;
+}
+
+.tile-formatted-text .bullet-list {
+  list-style-type: disc !important;
+}
+
+.tile-formatted-text .ordered-list {
+  list-style-type: decimal !important;
 }
 
 .tile-formatted-text .bullet-list li,


### PR DESCRIPTION
## Summary
- wire font family, size, and color pickers to TipTap commands
- enable list, code, and history actions in top toolbar
- add custom FontSize extension and register TipTap color/font family extensions

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Unexpected any in existing files)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c7c68828848321862ac20ff131b758