### PR TITLE
Fix list formatting in TipTap editor

### DIFF
--- a/src/components/admin/TileRenderer.tsx
+++ b/src/components/admin/TileRenderer.tsx
@@ -9,6 +9,9 @@ import { TextStyle } from '@tiptap/extension-text-style';
 import Color from '@tiptap/extension-color';
 import FontFamily from '@tiptap/extension-font-family';
 import FontSize from '../../extensions/FontSize';
+import BulletList from '@tiptap/extension-bullet-list';
+import OrderedList from '@tiptap/extension-ordered-list';
+import ListItem from '@tiptap/extension-list-item';
 
 interface TileRendererProps {
   tile: LessonTile;
@@ -38,7 +41,22 @@ interface TextEditorProps {
 const TextTileEditor: React.FC<TextEditorProps> = ({ textTile, tileId, onUpdateTile, onFinishTextEditing, onEditorReady }) => {
   const editor = useEditor({
     extensions: [
-      StarterKit,
+      StarterKit.configure({
+        bulletList: false,
+        orderedList: false,
+        listItem: false,
+      }),
+      BulletList.configure({
+        HTMLAttributes: { class: 'bullet-list' },
+        keepMarks: true,
+        keepAttributes: true,
+      }),
+      OrderedList.configure({
+        HTMLAttributes: { class: 'ordered-list' },
+        keepMarks: true,
+        keepAttributes: true,
+      }),
+      ListItem,
       Underline,
       TextStyle,
       Color.configure({ types: ['textStyle'] }),
@@ -80,10 +98,24 @@ const TextTileEditor: React.FC<TextEditorProps> = ({ textTile, tileId, onUpdateT
   };
 
   return (
-    <div className="w-full h-full p-3 overflow-hidden relative">
+    <div
+      className="w-full h-full p-3 overflow-hidden relative tile-text-content tiptap-editor"
+      style={{
+        backgroundColor: textTile.content.backgroundColor,
+        fontSize: `${textTile.content.fontSize}px`,
+        fontFamily: textTile.content.fontFamily,
+        display: 'flex',
+        alignItems:
+          textTile.content.verticalAlign === 'center'
+            ? 'center'
+            : textTile.content.verticalAlign === 'bottom'
+            ? 'flex-end'
+            : 'flex-start',
+      }}
+    >
       <EditorContent
         editor={editor}
-        className="w-full h-full focus:outline-none"
+        className="w-full h-full focus:outline-none break-words flex-1 rich-text-content tile-formatted-text"
         onBlur={handleBlur}
       />
     </div>
@@ -194,7 +226,6 @@ export const TileRenderer: React.FC<TileRendererProps> = ({
                 backgroundColor: textTile.content.backgroundColor,
                 fontSize: `${textTile.content.fontSize}px`,
                 fontFamily: textTile.content.fontFamily,
-                textAlign: textTile.content.textAlign,
                 display: 'flex',
                 alignItems: textTile.content.verticalAlign === 'center' ? 'center' :
                            textTile.content.verticalAlign === 'bottom' ? 'flex-end' : 'flex-start'

--- a/src/index.css
+++ b/src/index.css
@@ -14,6 +14,12 @@
   line-height: 1.4;
 }
 
+/* Preserve empty paragraphs as visible blank lines */
+.rich-text-content p:empty,
+.tile-formatted-text p:empty {
+  min-height: 1.4em;
+}
+
 .rich-text-content strong,
 .rich-text-content b,
 .tile-formatted-text strong,

--- a/src/services/lessonContentService.ts
+++ b/src/services/lessonContentService.ts
@@ -94,7 +94,6 @@ export class LessonContentService {
         richText: '<p style="margin: 0;">Nowy tekst</p>',
         fontFamily: 'Inter, system-ui, sans-serif',
         fontSize: 16,
-        textAlign: 'left',
         verticalAlign: 'top',
         backgroundColor: '#ffffff',
         showBorder: true,

--- a/src/types/lessonEditor.ts
+++ b/src/types/lessonEditor.ts
@@ -34,7 +34,6 @@ export interface TextTile extends LessonTile {
     richText?: string; // HTML content with formatting
     fontFamily: string;
     fontSize: number;
-    textAlign: 'left' | 'center' | 'right';
     verticalAlign: 'top' | 'center' | 'bottom';
     backgroundColor: string;
     showBorder: boolean;


### PR DESCRIPTION
## Summary
- add bullet and ordered list extensions to TipTap editor and configure
- align text tile editor styling with its rendered view
- remove legacy `textAlign` field from text tiles and related code

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any in existing files)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c7d20a3c4883219ba3c5e7fc4e89b0