### PR TITLE
Improve editor focus handling

### DIFF
--- a/src/components/admin/TileRenderer.tsx
+++ b/src/components/admin/TileRenderer.tsx
@@ -97,6 +97,21 @@ const TextTileEditor: React.FC<TextEditorProps> = ({ textTile, tileId, onUpdateT
     onFinishTextEditing();
   };
 
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Tab') {
+      e.preventDefault();
+      if (editor.isActive('listItem')) {
+        if (e.shiftKey) {
+          editor.chain().focus().liftListItem('listItem').run();
+        } else {
+          editor.chain().focus().sinkListItem('listItem').run();
+        }
+      } else {
+        editor.chain().focus().insertContent('\t').run();
+      }
+    }
+  };
+
   return (
     <div
       className="w-full h-full p-3 overflow-hidden relative tile-text-content tiptap-editor"
@@ -117,6 +132,7 @@ const TextTileEditor: React.FC<TextEditorProps> = ({ textTile, tileId, onUpdateT
         editor={editor}
         className="w-full h-full focus:outline-none break-words flex-1 rich-text-content tile-formatted-text"
         onBlur={handleBlur}
+        onKeyDown={handleKeyDown}
       />
     </div>
   );

--- a/src/components/admin/TopToolbar.tsx
+++ b/src/components/admin/TopToolbar.tsx
@@ -59,7 +59,7 @@ export const TopToolbar: React.FC<TopToolbarProps> = ({
   // Enhanced button styling for formatting buttons
   const getFormattingButtonClass = (isActive: boolean, isDisabled = false) => {
     if (isDisabled) {
-      return 'p-2 text-gray-300 cursor-not-allowed rounded-lg transition-all duration-200 min-w-[36px] h-9 flex items-center justify-center';
+      return 'p-2 text-gray-300 cursor-not-allowed rounded-lg transition-all duration-200 min-w-[36px] h-9 flex items-center justify-center pointer-events-none';
     }
     
     if (isActive) {


### PR DESCRIPTION
## Summary
- prevent focus loss when clicking disabled undo/redo controls
- insert indentation on Tab key instead of leaving editor

## Testing
- `npm run lint` *(fails: Unexpected any and unused vars in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c7eebe9398832198adcab1782e314d