### PR TITLE
Fix tile drag animation when border hidden

### DIFF
--- a/src/components/admin/TileRenderer.tsx
+++ b/src/components/admin/TileRenderer.tsx
@@ -423,12 +423,12 @@ export const TileRenderer: React.FC<TileRendererProps> = ({
 
   return (
     <div
-      className={`absolute select-none ${
+      className={`absolute select-none transition-all duration-200 ${
         isEditing || isImageEditing || isEditingText ? 'z-20' : 'z-10'
       } ${
         isSelected ? 'ring-2 ring-blue-500 ring-opacity-75' : ''
       } ${
-        !isFramelessTextTile ? `transition-all duration-200 rounded-lg ${
+        !isFramelessTextTile ? `rounded-lg ${
           isSelected ? 'shadow-lg' : 'shadow-sm'
         }` : ''
       }`}


### PR DESCRIPTION
## Summary
- keep tile drag animation even when text tile border is hidden

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 26 problems)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c7f7b0d1b08321bf1b840a5bb380ae