### PR TITLE
Fix multi-line code blocks splitting

### DIFF
--- a/src/components/admin/TileRenderer.tsx
+++ b/src/components/admin/TileRenderer.tsx
@@ -13,6 +13,7 @@ import BulletList from '@tiptap/extension-bullet-list';
 import OrderedList from '@tiptap/extension-ordered-list';
 import ListItem from '@tiptap/extension-list-item';
 import TextAlign from '../../extensions/TextAlign';
+import UnifiedCodeBlock from '../../extensions/UnifiedCodeBlock';
 
 interface TileRendererProps {
   tile: LessonTile;
@@ -46,7 +47,9 @@ const TextTileEditor: React.FC<TextEditorProps> = ({ textTile, tileId, onUpdateT
         bulletList: false,
         orderedList: false,
         listItem: false,
+        codeBlock: false,
       }),
+      UnifiedCodeBlock,
       BulletList.configure({
         HTMLAttributes: { class: 'bullet-list' },
         keepMarks: true,

--- a/src/extensions/UnifiedCodeBlock.ts
+++ b/src/extensions/UnifiedCodeBlock.ts
@@ -1,0 +1,54 @@
+import CodeBlock from '@tiptap/extension-code-block';
+import { TextSelection } from '@tiptap/pm/state';
+
+const UnifiedCodeBlock = CodeBlock.extend({
+  addCommands() {
+    return {
+      ...this.parent?.(),
+      toggleCodeBlock:
+        (attributes) =>
+        ({ editor, state, commands }) => {
+          if (editor.isActive(this.name)) {
+            return commands.toggleNode(this.name, 'paragraph', attributes);
+          }
+
+          const { from, to } = state.selection;
+
+          if (from === to) {
+            return commands.toggleNode(this.name, 'paragraph', attributes);
+          }
+
+          const { schema } = state;
+          const codeBlockType = schema.nodes[this.name];
+
+          if (!codeBlockType) {
+            return false;
+          }
+
+          const selectedText = state.doc.textBetween(from, to, '\n', '\n');
+
+          return commands.command(({ tr, dispatch }) => {
+            const textNode = selectedText.length ? schema.text(selectedText) : undefined;
+            const codeBlockNode = codeBlockType.create(attributes, textNode);
+            tr.replaceRangeWith(from, to, codeBlockNode);
+
+            const mappedFrom = tr.mapping.map(from);
+            const textLength = codeBlockNode.textContent.length;
+            const cursorPosition = mappedFrom + textLength + 1;
+            const safeCursorPosition = Math.min(cursorPosition, tr.doc.content.size);
+
+            tr.setSelection(TextSelection.create(tr.doc, safeCursorPosition));
+
+            if (dispatch) {
+              dispatch(tr);
+            }
+
+            return true;
+          });
+        },
+    };
+  },
+});
+
+export default UnifiedCodeBlock;
+


### PR DESCRIPTION
## Summary
- add a custom Tiptap code block extension that merges multi-paragraph selections into a single block while keeping caret placement inside
- register the new extension in the text tile editor and disable StarterKit's built-in code block

## Testing
- npm run build
- npm run lint (fails: existing lint errors unrelated to this change)


------
https://chatgpt.com/codex/tasks/task_e_68c93cbf4cec83218a7ca8b4e3da91a9