### PR TITLE
Fix sequencing tile configuration loss during toolbar updates

### DIFF
--- a/src/Pages/LessonEditor.tsx
+++ b/src/Pages/LessonEditor.tsx
@@ -186,8 +186,8 @@ export const LessonEditor: React.FC<LessonEditorProps> = ({ lesson, course, onBa
           updated_at: updates.updated_at || new Date().toISOString()
         };
         
-        // Special handling for text tiles to ensure rich text is preserved
-        if (tile.type === 'text' && updates.content) {
+        // Special handling for text-based tiles to ensure content properties are merged
+        if ((tile.type === 'text' || tile.type === 'programming' || tile.type === 'sequencing') && updates.content) {
           updatedTile.content = {
             ...tile.content,
             ...updates.content

--- a/src/services/lessonContentService.ts
+++ b/src/services/lessonContentService.ts
@@ -364,6 +364,7 @@ export class LessonContentService {
         richQuestion: '<p style="margin: 0;">Ułóż elementy w prawidłowej kolejności</p>',
         fontFamily: 'Inter, system-ui, sans-serif',
         fontSize: 16,
+        verticalAlign: 'top',
         backgroundColor: '#ffffff',
         showBorder: true,
         items: [

--- a/src/types/lessonEditor.ts
+++ b/src/types/lessonEditor.ts
@@ -109,6 +109,7 @@ export interface SequencingTile extends LessonTile {
     richQuestion?: string; // HTML content with formatting for question
     fontFamily: string;
     fontSize: number;
+    verticalAlign: 'top' | 'center' | 'bottom';
     backgroundColor: string;
     showBorder: boolean;
     items: Array<{


### PR DESCRIPTION
## Summary
- keep sequencing tile content intact when partial updates arrive by merging content fields like other text-based tiles
- add default vertical alignment metadata to sequencing tiles to align with toolbar controls

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc11beff4c8321985c8b4f1c9362f1