### PR TITLE
Render sequencing tiles on canvas

### DIFF
--- a/src/components/admin/TileRenderer.tsx
+++ b/src/components/admin/TileRenderer.tsx
@@ -685,7 +685,7 @@ export const TileRenderer: React.FC<TileRendererProps> = ({
         }
         break;
       }
-        
+
       case 'quiz': {
           const quizTile = tile as QuizTile;
           contentToRender = (
@@ -704,6 +704,14 @@ export const TileRenderer: React.FC<TileRendererProps> = ({
           );
           break;
         }
+
+      case 'sequencing': {
+        const sequencingTile = tile as SequencingTile;
+        contentToRender = (
+          <SequencingInteractive tile={sequencingTile} />
+        );
+        break;
+      }
 
       default:
         contentToRender = (


### PR DESCRIPTION
## Summary
- render sequencing lesson tiles on the canvas by delegating to the SequencingInteractive component

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cc223dc02483218f84d826d0b2b92e