### PR TITLE
Redesign sequencing exercise tile UI

### DIFF
--- a/src/components/admin/SequencingInteractive.tsx
+++ b/src/components/admin/SequencingInteractive.tsx
@@ -1,5 +1,12 @@
-import React, { useState, useEffect } from 'react';
-import { CheckCircle, XCircle, RotateCcw, GripVertical } from 'lucide-react';
+import React, { useEffect, useState } from 'react';
+import {
+  CheckCircle,
+  XCircle,
+  RotateCcw,
+  GripVertical,
+  ListOrdered,
+  ArrowRightCircle
+} from 'lucide-react';
 import { SequencingTile } from '../../types/lessonEditor';
 
 interface SequencingInteractiveProps {
@@ -7,89 +14,182 @@ interface SequencingInteractiveProps {
   isPreview?: boolean;
 }
 
-interface DraggedItem {
+interface SequencingItem {
   id: string;
   text: string;
   originalIndex: number;
 }
 
+type DragSource =
+  | { source: 'available'; index: number }
+  | { source: 'slot'; index: number };
+
 export const SequencingInteractive: React.FC<SequencingInteractiveProps> = ({
   tile,
   isPreview = false
 }) => {
-  const [currentOrder, setCurrentOrder] = useState<DraggedItem[]>([]);
+  const [availableItems, setAvailableItems] = useState<SequencingItem[]>([]);
+  const [slots, setSlots] = useState<(SequencingItem | null)[]>([]);
   const [isChecked, setIsChecked] = useState(false);
   const [isCorrect, setIsCorrect] = useState<boolean | null>(null);
   const [attempts, setAttempts] = useState(0);
-  const [draggedItem, setDraggedItem] = useState<string | null>(null);
-  const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
+  const [draggedItem, setDraggedItem] = useState<DragSource | null>(null);
+  const [dragOverSlot, setDragOverSlot] = useState<number | null>(null);
+  const [isPoolHighlighted, setIsPoolHighlighted] = useState(false);
 
-  // Initialize with randomized order
-  useEffect(() => {
-    const shuffledItems = [...tile.content.items]
+  const canInteract = !isPreview && (!isChecked || !isCorrect || tile.content.allowMultipleAttempts);
+
+  const initializeSequence = () => {
+    const shuffledItems = tile.content.items
       .map((item, index) => ({
         id: item.id,
         text: item.text,
         originalIndex: index
       }))
       .sort(() => Math.random() - 0.5);
-    
-    setCurrentOrder(shuffledItems);
+
+    setAvailableItems(shuffledItems);
+    setSlots(Array(tile.content.items.length).fill(null));
     setIsChecked(false);
     setIsCorrect(null);
     setAttempts(0);
+  };
+
+  useEffect(() => {
+    initializeSequence();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tile.content.items]);
 
-  const handleDragStart = (e: React.DragEvent, itemId: string) => {
-    setDraggedItem(itemId);
-    e.dataTransfer.effectAllowed = 'move';
-  };
-
-  const handleDragOver = (e: React.DragEvent, index: number) => {
-    e.preventDefault();
-    e.dataTransfer.dropEffect = 'move';
-    setDragOverIndex(index);
-  };
-
-  const handleDragLeave = () => {
-    setDragOverIndex(null);
-  };
-
-  const handleDrop = (e: React.DragEvent, targetIndex: number) => {
-    e.preventDefault();
-    setDragOverIndex(null);
-
-    if (!draggedItem) return;
-
-    const draggedIndex = currentOrder.findIndex(item => item.id === draggedItem);
-    if (draggedIndex === -1 || draggedIndex === targetIndex) {
-      setDraggedItem(null);
-      return;
-    }
-
-    const newOrder = [...currentOrder];
-    const [draggedItemData] = newOrder.splice(draggedIndex, 1);
-    newOrder.splice(targetIndex, 0, draggedItemData);
-
-    setCurrentOrder(newOrder);
-    setDraggedItem(null);
-    
-    // Reset check state when items are moved
+  const resetCheckState = () => {
     if (isChecked) {
       setIsChecked(false);
       setIsCorrect(null);
     }
   };
 
+  const handleAvailableDragStart = (e: React.DragEvent, index: number) => {
+    if (!canInteract) return;
+    setDraggedItem({ source: 'available', index });
+    e.dataTransfer.effectAllowed = 'move';
+  };
+
+  const handleSlotDragStart = (e: React.DragEvent, index: number) => {
+    if (!canInteract || !slots[index]) return;
+    setDraggedItem({ source: 'slot', index });
+    e.dataTransfer.effectAllowed = 'move';
+  };
+
+  const handleSlotDragOver = (e: React.DragEvent, index: number) => {
+    if (!canInteract) return;
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'move';
+    setDragOverSlot(index);
+  };
+
+  const handleSlotDragLeave = () => {
+    setDragOverSlot(null);
+  };
+
   const handleDragEnd = () => {
     setDraggedItem(null);
-    setDragOverIndex(null);
+    setDragOverSlot(null);
+    setIsPoolHighlighted(false);
+  };
+
+  const handleSlotDrop = (e: React.DragEvent, targetIndex: number) => {
+    if (!canInteract) return;
+    e.preventDefault();
+    setDragOverSlot(null);
+
+    if (!draggedItem) return;
+
+    const newSlots = [...slots];
+    const newAvailable = [...availableItems];
+
+    if (draggedItem.source === 'available') {
+      const [item] = newAvailable.splice(draggedItem.index, 1);
+      if (!item) {
+        setDraggedItem(null);
+        return;
+      }
+
+      const displaced = newSlots[targetIndex];
+      newSlots[targetIndex] = item;
+
+      if (displaced) {
+        newAvailable.push(displaced);
+      }
+
+      setAvailableItems(newAvailable);
+      setSlots(newSlots);
+      resetCheckState();
+      setDraggedItem(null);
+      return;
+    }
+
+    if (draggedItem.source === 'slot') {
+      const sourceIndex = draggedItem.index;
+      if (sourceIndex === targetIndex) {
+        setDraggedItem(null);
+        return;
+      }
+
+      const movingItem = newSlots[sourceIndex];
+      if (!movingItem) {
+        setDraggedItem(null);
+        return;
+      }
+
+      const targetItem = newSlots[targetIndex];
+      newSlots[targetIndex] = movingItem;
+      newSlots[sourceIndex] = targetItem ?? null;
+
+      setSlots(newSlots);
+      resetCheckState();
+      setDraggedItem(null);
+    }
+  };
+
+  const handlePoolDragOver = (e: React.DragEvent) => {
+    if (!canInteract) return;
+    e.preventDefault();
+    setIsPoolHighlighted(true);
+  };
+
+  const handlePoolDragLeave = () => {
+    setIsPoolHighlighted(false);
+  };
+
+  const handlePoolDrop = (e: React.DragEvent) => {
+    if (!canInteract) return;
+    e.preventDefault();
+    setIsPoolHighlighted(false);
+
+    if (!draggedItem || draggedItem.source !== 'slot') {
+      setDraggedItem(null);
+      return;
+    }
+
+    const newSlots = [...slots];
+    const item = newSlots[draggedItem.index];
+
+    if (!item) {
+      setDraggedItem(null);
+      return;
+    }
+
+    newSlots[draggedItem.index] = null;
+    setSlots(newSlots);
+    setAvailableItems(prev => [...prev, item]);
+    resetCheckState();
+    setDraggedItem(null);
   };
 
   const checkSequence = () => {
-    const isSequenceCorrect = currentOrder.every((item, index) => {
-      const originalItem = tile.content.items.find(original => original.id === item.id);
-      return originalItem && originalItem.correctPosition === index;
+    const isSequenceCorrect = slots.every((slotItem, index) => {
+      if (!slotItem) return false;
+      const originalItem = tile.content.items.find(original => original.id === slotItem.id);
+      return originalItem ? originalItem.correctPosition === index : false;
     });
 
     setIsCorrect(isSequenceCorrect);
@@ -98,48 +198,59 @@ export const SequencingInteractive: React.FC<SequencingInteractiveProps> = ({
   };
 
   const resetSequence = () => {
-    const shuffledItems = [...tile.content.items]
-      .map((item, index) => ({
-        id: item.id,
-        text: item.text,
-        originalIndex: index
-      }))
-      .sort(() => Math.random() - 0.5);
-    
-    setCurrentOrder(shuffledItems);
-    setIsChecked(false);
-    setIsCorrect(null);
+    initializeSequence();
   };
 
-  const getItemStyle = (index: number, itemId: string) => {
-    let baseClasses = "flex items-center space-x-3 p-4 bg-white border-2 rounded-lg transition-all duration-200 cursor-grab active:cursor-grabbing select-none";
-    
-    if (draggedItem === itemId) {
-      baseClasses += " opacity-50 scale-95 rotate-2";
-    } else if (dragOverIndex === index && draggedItem && draggedItem !== itemId) {
-      baseClasses += " border-blue-400 bg-blue-50 transform scale-105";
-    } else if (isChecked && isCorrect !== null) {
-      const originalItem = tile.content.items.find(item => item.id === itemId);
-      const isInCorrectPosition = originalItem && originalItem.correctPosition === index;
-      
-      if (isInCorrectPosition) {
-        baseClasses += " border-green-400 bg-green-50";
-      } else {
-        baseClasses += " border-red-400 bg-red-50";
-      }
-    } else {
-      baseClasses += " border-gray-200 hover:border-gray-300 hover:shadow-sm";
+  const isReadyToCheck = slots.every(slotItem => slotItem !== null);
+
+  const renderFeedback = () => {
+    if (!isChecked || isCorrect === null) {
+      return null;
     }
 
-    return baseClasses;
+    return (
+      <div
+        className={`rounded-2xl border px-5 py-4 text-sm font-medium transition-all ${
+          isCorrect
+            ? 'border-emerald-500/40 bg-emerald-500/10 text-emerald-200'
+            : 'border-rose-500/40 bg-rose-500/10 text-rose-200'
+        }`}
+      >
+        <div className="flex items-center justify-center gap-3">
+          {isCorrect ? (
+            <CheckCircle className="w-5 h-5" />
+          ) : (
+            <XCircle className="w-5 h-5" />
+          )}
+          <span>{isCorrect ? tile.content.correctFeedback : tile.content.incorrectFeedback}</span>
+        </div>
+      </div>
+    );
   };
 
   return (
-    <div className="w-full h-full p-4 space-y-4 overflow-auto">
-      {/* Question */}
-      <div className="text-center">
+    <div className="w-full h-full bg-slate-950/95 text-slate-100 rounded-3xl shadow-[0_0_35px_rgba(15,23,42,0.45)] overflow-hidden flex flex-col">
+      <div className="border-b border-slate-900/70">
+        <div className="px-6 pt-6 pb-5 flex items-center justify-between gap-4">
+          <div className="flex items-center gap-4">
+            <div className="w-12 h-12 rounded-2xl bg-emerald-500/15 text-emerald-300 flex items-center justify-center">
+              <ListOrdered className="w-5 h-5" />
+            </div>
+            <div>
+              <p className="text-[11px] uppercase tracking-[0.32em] text-slate-500">Ćwiczenie sekwencyjne</p>
+              <h2 className="text-lg font-semibold text-slate-100">Ułóż poprawną kolejność</h2>
+            </div>
+          </div>
+
+          {attempts > 0 && (
+            <div className="text-xs font-semibold uppercase tracking-[0.28em] text-slate-500">
+              Próba <span className="ml-2 text-slate-200">{attempts}</span>
+            </div>
+          )}
+        </div>
+
         <div
-          className="text-lg font-medium text-gray-800 mb-2"
+          className="px-6 pb-6 text-sm leading-relaxed text-slate-200"
           style={{
             fontFamily: tile.content.fontFamily,
             fontSize: `${tile.content.fontSize}px`
@@ -148,109 +259,174 @@ export const SequencingInteractive: React.FC<SequencingInteractiveProps> = ({
             __html: tile.content.richQuestion || tile.content.question
           }}
         />
-        {attempts > 0 && (
-          <div className="text-sm text-gray-600">
-            Próba: {attempts}
-          </div>
-        )}
       </div>
 
-      {/* Draggable Items */}
-      <div className="space-y-3 flex-1">
-        {currentOrder.map((item, index) => (
-          <div
-            key={item.id}
-            draggable={!isPreview && (!isChecked || !isCorrect || tile.content.allowMultipleAttempts)}
-            onDragStart={(e) => handleDragStart(e, item.id)}
-            onDragOver={(e) => handleDragOver(e, index)}
-            onDragLeave={handleDragLeave}
-            onDrop={(e) => handleDrop(e, index)}
-            onDragEnd={handleDragEnd}
-            className={getItemStyle(index, item.id)}
-          >
-            {!isPreview && (
-              <GripVertical className="w-5 h-5 text-gray-400 flex-shrink-0" />
-            )}
-            
-            {tile.content.showPositionNumbers && (
-              <div className="w-8 h-8 bg-blue-100 text-blue-600 rounded-full flex items-center justify-center text-sm font-medium flex-shrink-0">
-                {index + 1}
+      <div className="flex-1 px-6 py-6 overflow-hidden">
+        <div className="flex h-full flex-col gap-6 lg:flex-row">
+          <div className="lg:w-1/2">
+            <div
+              className={`h-full rounded-2xl border bg-slate-900/50 p-5 transition-colors ${
+                isPoolHighlighted ? 'border-emerald-400/60 bg-emerald-500/10' : 'border-slate-900/60'
+              }`}
+              onDragOver={handlePoolDragOver}
+              onDragLeave={handlePoolDragLeave}
+              onDrop={handlePoolDrop}
+            >
+              <div className="flex items-center justify-between gap-3 pb-4">
+                <div>
+                  <p className="text-[11px] uppercase tracking-[0.28em] text-slate-500">Dostępne elementy</p>
+                  <h3 className="text-sm font-semibold text-slate-100">Przeciągnij, aby umieścić po prawej stronie</h3>
+                </div>
+                <ArrowRightCircle className="hidden h-5 w-5 text-emerald-300 lg:block" />
               </div>
-            )}
-            
-            <div className="flex-1 text-gray-800 font-medium">
-              {item.text}
+
+              <div className="space-y-3 overflow-y-auto pr-1">
+                {availableItems.length === 0 ? (
+                  <div className="rounded-xl border border-dashed border-slate-800/80 bg-slate-900/40 px-4 py-6 text-center text-xs text-slate-500">
+                    Wszystkie elementy zostały przypisane do sekwencji.
+                  </div>
+                ) : (
+                  availableItems.map((item, index) => (
+                    <div
+                      key={item.id}
+                      draggable={canInteract}
+                      onDragStart={(e) => handleAvailableDragStart(e, index)}
+                      onDragEnd={handleDragEnd}
+                      className={`group flex items-center gap-4 rounded-xl border bg-slate-900/80 px-4 py-3 text-sm font-medium shadow-sm transition-all ${
+                        canInteract
+                          ? 'cursor-grab border-slate-800/80 hover:border-emerald-400/50 hover:bg-slate-900'
+                          : 'border-slate-900/60 cursor-default'
+                      }`}
+                    >
+                      <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-slate-950/60 text-slate-500 group-hover:text-emerald-300">
+                        <GripVertical className="h-4 w-4" />
+                      </div>
+                      <span className="flex-1 text-slate-200 leading-relaxed">{item.text}</span>
+                    </div>
+                  ))
+                )}
+              </div>
             </div>
-
-            {isChecked && isCorrect !== null && (
-              <div className="flex-shrink-0">
-                {(() => {
-                  const originalItem = tile.content.items.find(original => original.id === item.id);
-                  const isInCorrectPosition = originalItem && originalItem.correctPosition === index;
-                  
-                  return isInCorrectPosition ? (
-                    <CheckCircle className="w-5 h-5 text-green-500" />
-                  ) : (
-                    <XCircle className="w-5 h-5 text-red-500" />
-                  );
-                })()}
-              </div>
-            )}
           </div>
-        ))}
+
+          <div className="flex-1">
+            <div className="flex h-full flex-col rounded-2xl border border-slate-900/60 bg-slate-900/50 p-5">
+              <div className="flex items-center justify-between gap-3 pb-4">
+                <div>
+                  <p className="text-[11px] uppercase tracking-[0.28em] text-slate-500">Docelowa kolejność</p>
+                  <h3 className="text-sm font-semibold text-slate-100">Upuść elementy w odpowiednich miejscach</h3>
+                </div>
+                {tile.content.showPositionNumbers && (
+                  <span className="text-[11px] uppercase tracking-[0.28em] text-slate-500">Numery pozycji włączone</span>
+                )}
+              </div>
+
+              <div className="flex-1 space-y-3 overflow-y-auto pr-1">
+                {slots.map((slotItem, index) => {
+                  const originalItem = slotItem
+                    ? tile.content.items.find(item => item.id === slotItem.id)
+                    : null;
+                  const isInCorrectPosition =
+                    isChecked && isCorrect !== null && slotItem && originalItem
+                      ? originalItem.correctPosition === index
+                      : null;
+
+                  return (
+                    <div
+                      key={index}
+                      onDragOver={(e) => handleSlotDragOver(e, index)}
+                      onDragLeave={handleSlotDragLeave}
+                      onDrop={(e) => handleSlotDrop(e, index)}
+                      className={`rounded-2xl border-2 border-dashed transition-all ${
+                        dragOverSlot === index
+                          ? 'border-emerald-400/70 bg-emerald-500/10'
+                          : slotItem
+                            ? 'border-transparent bg-slate-900/80'
+                            : 'border-slate-800/70 bg-slate-900/30'
+                      }`}
+                    >
+                      <div
+                        className={`flex min-h-[72px] items-center gap-4 px-4 py-3 ${
+                          slotItem && canInteract ? 'cursor-grab active:cursor-grabbing' : 'cursor-default'
+                        }`}
+                        draggable={canInteract && !!slotItem}
+                        onDragStart={(e) => handleSlotDragStart(e, index)}
+                        onDragEnd={handleDragEnd}
+                      >
+                        {tile.content.showPositionNumbers && (
+                          <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-slate-950/60 text-xs font-semibold text-slate-400">
+                            {index + 1}
+                          </div>
+                        )}
+
+                        {slotItem ? (
+                          <div className="flex flex-1 items-center gap-4">
+                            <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-slate-950/60 text-slate-500">
+                              <GripVertical className="h-4 w-4" />
+                            </div>
+                            <p className="flex-1 text-sm font-medium leading-relaxed text-slate-100">{slotItem.text}</p>
+
+                            {isChecked && isCorrect !== null && (
+                              <div className="flex items-center text-sm">
+                                {isInCorrectPosition ? (
+                                  <CheckCircle className="h-5 w-5 text-emerald-300" />
+                                ) : (
+                                  <XCircle className="h-5 w-5 text-rose-300" />
+                                )}
+                              </div>
+                            )}
+                          </div>
+                        ) : (
+                          <div className="flex flex-1 items-center justify-between gap-3 text-sm text-slate-500">
+                            <span>Upuść element tutaj</span>
+                            <ArrowRightCircle className="h-5 w-5 text-slate-700" />
+                          </div>
+                        )}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
 
-      {/* Feedback */}
-      {isChecked && isCorrect !== null && (
-        <div className={`p-4 rounded-lg text-center ${
-          isCorrect 
-            ? 'bg-green-100 border border-green-300 text-green-800' 
-            : 'bg-red-100 border border-red-300 text-red-800'
-        }`}>
-          <div className="flex items-center justify-center space-x-2 mb-2">
-            {isCorrect ? (
-              <CheckCircle className="w-5 h-5 text-green-600" />
-            ) : (
-              <XCircle className="w-5 h-5 text-red-600" />
+      <div className="border-t border-slate-900/70 px-6 py-5">
+        <div className="flex flex-col gap-4">
+          {renderFeedback()}
+
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+            {!isPreview && !isChecked && (
+              <div className="rounded-2xl border border-slate-900/60 bg-slate-900/40 px-4 py-3 text-sm text-slate-300">
+                💡 Przeciągnij element z lewej strony i upuść go w odpowiednim miejscu po prawej, aby zbudować sekwencję.
+              </div>
             )}
-            <span className="font-medium">
-              {isCorrect ? tile.content.correctFeedback : tile.content.incorrectFeedback}
-            </span>
+
+            <div className="flex flex-wrap items-center justify-end gap-3">
+              {(!isChecked || (isChecked && !isCorrect && tile.content.allowMultipleAttempts)) && (
+                <button
+                  onClick={checkSequence}
+                  disabled={!isReadyToCheck || !canInteract}
+                  className="rounded-xl bg-emerald-500 px-6 py-2 text-sm font-semibold text-emerald-950 transition hover:bg-emerald-400 disabled:cursor-not-allowed disabled:opacity-40"
+                >
+                  Sprawdź kolejność
+                </button>
+              )}
+
+              {isChecked && !isCorrect && tile.content.allowMultipleAttempts && (
+                <button
+                  onClick={resetSequence}
+                  className="flex items-center gap-2 rounded-xl border border-slate-800 bg-slate-900 px-4 py-2 text-sm font-semibold text-slate-200 transition hover:border-emerald-400/50 hover:text-emerald-200"
+                >
+                  <RotateCcw className="h-4 w-4" />
+                  Wymieszaj ponownie
+                </button>
+              )}
+            </div>
           </div>
         </div>
-      )}
-
-      {/* Action Buttons */}
-      {!isPreview && (
-        <div className="flex justify-center space-x-3 pt-2">
-          {(!isChecked || (isChecked && !isCorrect && tile.content.allowMultipleAttempts)) && (
-            <button
-              onClick={checkSequence}
-              disabled={currentOrder.length === 0}
-              className="px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors font-medium"
-            >
-              Sprawdź kolejność
-            </button>
-          )}
-          
-          {(isChecked && !isCorrect && tile.content.allowMultipleAttempts) && (
-            <button
-              onClick={resetSequence}
-              className="px-4 py-2 bg-gray-500 text-white rounded-lg hover:bg-gray-600 transition-colors font-medium flex items-center space-x-2"
-            >
-              <RotateCcw className="w-4 h-4" />
-              <span>Wymieszaj ponownie</span>
-            </button>
-          )}
-        </div>
-      )}
-
-      {/* Instructions */}
-      {!isPreview && !isChecked && (
-        <div className="text-center text-sm text-gray-600 bg-blue-50 p-3 rounded-lg">
-          💡 Przeciągnij elementy, aby ułożyć je w prawidłowej kolejności, a następnie kliknij "Sprawdź kolejność"
-        </div>
-      )}
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- redesign the sequencing exercise tile with a split layout that mirrors the programming task styling
- introduce separate pools for available items and ordered slots, including drag-and-drop interactions between them
- preserve feedback, attempt tracking, and validation while updating styling and instructional messaging

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cc286d26008321b20ea148438e2535