### PR TITLE
Enhance sequencing task tile randomization and editing UX

### DIFF
--- a/src/components/admin/SequencingInteractive.tsx
+++ b/src/components/admin/SequencingInteractive.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import {
   CheckCircle,
   XCircle,
@@ -6,13 +6,32 @@ import {
   Sparkles,
   Shuffle,
   ArrowLeftRight,
-  GripVertical
+  GripVertical,
+  PenSquare,
+  PlayCircle
 } from 'lucide-react';
-import { SequencingTile } from '../../types/lessonEditor';
+import { Editor, EditorContent, useEditor } from '@tiptap/react';
+import StarterKit from '@tiptap/starter-kit';
+import Underline from '@tiptap/extension-underline';
+import TextStyle from '@tiptap/extension-text-style';
+import Color from '@tiptap/extension-color';
+import ListItem from '@tiptap/extension-list-item';
+import BulletList from '@tiptap/extension-bullet-list';
+import OrderedList from '@tiptap/extension-ordered-list';
+import FontFamily from '@tiptap/extension-font-family';
+import TextAlign from '@tiptap/extension-text-align';
+import { LessonTile, SequencingTile } from '../../types/lessonEditor';
+import { FontSize } from '../../extensions/FontSize';
 
 interface SequencingInteractiveProps {
   tile: SequencingTile;
   isPreview?: boolean;
+  isSelected?: boolean;
+  isEditingText?: boolean;
+  onUpdateTile?: (tileId: string, updates: Partial<LessonTile>) => void;
+  onFinishTextEditing?: () => void;
+  onEditorReady?: (editor: Editor | null) => void;
+  onRequestEditMode?: () => void;
 }
 
 interface DraggedItem {
@@ -29,9 +48,187 @@ interface DragState {
   index?: number;
 }
 
+interface SequencingQuestionEditorProps {
+  tile: SequencingTile;
+  onUpdateTile?: (tileId: string, updates: Partial<LessonTile>) => void;
+  onFinishTextEditing?: () => void;
+  onEditorReady?: (editor: Editor | null) => void;
+  textColor: string;
+}
+
+const createGradientLayers = (color: string) => {
+  const hexMatch = color?.match(/^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/);
+  if (!hexMatch) {
+    return {
+      base: color || 'rgba(2, 6, 23, 0.86)',
+      from: undefined,
+      to: undefined,
+      textColor: 'rgba(248, 250, 252, 0.95)'
+    };
+  }
+
+  const hex = hexMatch[0].replace('#', '');
+  const normalized = hex.length === 3
+    ? hex.split('').map(char => char + char).join('')
+    : hex;
+
+  const r = parseInt(normalized.slice(0, 2), 16);
+  const g = parseInt(normalized.slice(2, 4), 16);
+  const b = parseInt(normalized.slice(4, 6), 16);
+
+  const toRgba = (red: number, green: number, blue: number, alpha: number) =>
+    `rgba(${Math.min(255, Math.max(0, Math.round(red)))}, ${Math.min(255, Math.max(0, Math.round(green)))}, ${Math.min(255, Math.max(0, Math.round(blue)))}, ${alpha})`;
+
+  const lighten = (channel: number, amount: number) => channel + (255 - channel) * amount;
+  const darken = (channel: number, amount: number) => channel * (1 - amount);
+
+  const from = toRgba(lighten(r, 0.08), lighten(g, 0.08), lighten(b, 0.08), 0.98);
+  const to = toRgba(darken(r, 0.12), darken(g, 0.12), darken(b, 0.12), 0.92);
+  const base = toRgba(r, g, b, 0.96);
+  const luminance = 0.2126 * r + 0.7152 * g + 0.0722 * b;
+  const textColor = luminance > 180 ? 'rgba(15, 23, 42, 0.92)' : 'rgba(248, 250, 252, 0.95)';
+
+  return { base, from, to, textColor };
+};
+
+const SequencingQuestionEditor: React.FC<SequencingQuestionEditorProps> = ({
+  tile,
+  onUpdateTile,
+  onFinishTextEditing,
+  onEditorReady,
+  textColor
+}) => {
+  const editor = useEditor({
+    extensions: [
+      StarterKit.configure({
+        bulletList: false,
+        orderedList: false,
+        listItem: false
+      }),
+      BulletList.configure({ keepAttributes: true, keepMarks: true }),
+      OrderedList.configure({ keepAttributes: true, keepMarks: true }),
+      ListItem,
+      Underline,
+      TextStyle,
+      Color.configure({ types: ['textStyle'] }),
+      FontFamily.configure({ types: ['textStyle'] }),
+      FontSize,
+      TextAlign.configure({ types: ['paragraph'] })
+    ],
+    content:
+      tile.content.richQuestion ||
+      `<p style="margin: 0;">${tile.content.question || ''}</p>`,
+    onUpdate: ({ editor }) => {
+      const html = editor.getHTML();
+      const plain = editor.getText();
+      onUpdateTile?.(tile.id, {
+        content: {
+          ...tile.content,
+          question: plain,
+          richQuestion: html
+        }
+      });
+    },
+    autofocus: true
+  });
+
+  useEffect(() => {
+    onEditorReady?.(editor);
+    return () => onEditorReady?.(null);
+  }, [editor, onEditorReady]);
+
+  if (!editor) return null;
+
+  const handleBlur = (e: React.FocusEvent) => {
+    const toolbar = document.querySelector('.top-toolbar');
+    if (toolbar && e.relatedTarget && toolbar.contains(e.relatedTarget as Node)) {
+      e.preventDefault();
+      editor.commands.focus();
+      return;
+    }
+    onFinishTextEditing?.();
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Tab') {
+      e.preventDefault();
+      if (editor.isActive('listItem')) {
+        if (e.shiftKey) {
+          editor.chain().focus().liftListItem('listItem').run();
+        } else {
+          editor.chain().focus().sinkListItem('listItem').run();
+        }
+      } else {
+        editor.chain().focus().insertContent('\t').run();
+      }
+    }
+  };
+
+  return (
+    <div
+      className="tiptap-editor w-full"
+      style={{
+        fontFamily: tile.content.fontFamily,
+        fontSize: `${tile.content.fontSize}px`,
+        color: textColor
+      }}
+    >
+      <EditorContent
+        editor={editor}
+        className="w-full focus:outline-none break-words rich-text-content tile-formatted-text"
+        onBlur={handleBlur}
+        onKeyDown={handleKeyDown}
+      />
+    </div>
+  );
+};
+
+const createRandomizedPool = (tile: SequencingTile): DraggedItem[] => {
+  const orderedItems = [...tile.content.items]
+    .sort((a, b) => a.correctPosition - b.correctPosition)
+    .map((item, index) => ({
+      id: item.id,
+      text: item.text,
+      originalIndex: index
+    }));
+
+  if (orderedItems.length <= 1) {
+    return orderedItems;
+  }
+
+  const isCorrectOrder = (items: DraggedItem[]) =>
+    items.every((item, index) => item.id === orderedItems[index].id);
+
+  const shuffleOnce = () => {
+    const shuffled = [...orderedItems];
+    for (let i = shuffled.length - 1; i > 0; i -= 1) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+    }
+    return shuffled;
+  };
+
+  for (let attempt = 0; attempt < 24; attempt += 1) {
+    const shuffled = shuffleOnce();
+    if (!isCorrectOrder(shuffled)) {
+      return shuffled;
+    }
+  }
+
+  const fallback = [...orderedItems];
+  [fallback[0], fallback[1]] = [fallback[1], fallback[0]];
+  return fallback;
+};
+
 export const SequencingInteractive: React.FC<SequencingInteractiveProps> = ({
   tile,
-  isPreview = false
+  isPreview = false,
+  isSelected = false,
+  isEditingText = false,
+  onUpdateTile,
+  onFinishTextEditing,
+  onEditorReady,
+  onRequestEditMode
 }) => {
   const [availableItems, setAvailableItems] = useState<DraggedItem[]>([]);
   const [placedItems, setPlacedItems] = useState<(DraggedItem | null)[]>([]);
@@ -41,29 +238,67 @@ export const SequencingInteractive: React.FC<SequencingInteractiveProps> = ({
   const [dragState, setDragState] = useState<DragState | null>(null);
   const [dragOverSlot, setDragOverSlot] = useState<number | null>(null);
   const [isPoolHighlighted, setIsPoolHighlighted] = useState(false);
+  const [experienceMode, setExperienceMode] = useState<'preview' | 'edit'>('preview');
+  const [showModePrompt, setShowModePrompt] = useState(false);
+  const hasPromptBeenShown = useRef(false);
 
-  const canInteract = !isPreview;
+  const gradientLayers = useMemo(
+    () => createGradientLayers(tile.content.backgroundColor || '#0f172a'),
+    [tile.content.backgroundColor]
+  );
+
+  const containerStyle: React.CSSProperties = {
+    backgroundColor: gradientLayers.base,
+    ...(gradientLayers.from && gradientLayers.to
+      ? { backgroundImage: `linear-gradient(160deg, ${gradientLayers.from}, ${gradientLayers.to})` }
+      : {})
+  };
+
+  const isLightBackground = gradientLayers.textColor.startsWith('rgba(15');
+  const baseTextClass = isLightBackground ? 'text-slate-900' : 'text-slate-100';
+  const mutedTextClass = isLightBackground ? 'text-slate-600' : 'text-slate-200/80';
+  const subtleTextClass = isLightBackground ? 'text-slate-500' : 'text-slate-400';
+  const borderClass = showBorder
+    ? isLightBackground
+      ? 'border border-slate-200'
+      : 'border border-white/10'
+    : '';
+  const poolBaseClasses = isLightBackground
+    ? 'border-slate-200 bg-white/80 shadow-sm shadow-slate-300/30'
+    : 'border-white/10 bg-slate-950/30';
+  const poolHandleClasses = isLightBackground
+    ? 'border-slate-300 bg-white text-slate-500'
+    : 'border-white/5 bg-slate-900/70 text-slate-400';
+  const poolItemTextClass = isLightBackground ? 'text-slate-800' : 'text-slate-100';
+
+  const canInteract = !isPreview && experienceMode === 'preview' && !showModePrompt;
   const sequenceComplete = placedItems.length > 0 && placedItems.every(item => item !== null);
 
-  const cardBackground = tile.content.backgroundColor || 'rgba(2, 6, 23, 0.86)';
   const showBorder = tile.content.showBorder !== false;
 
-  // Initialize with randomized order
+  // Initialize with randomized order whenever the items change
   useEffect(() => {
-    const shuffledItems = [...tile.content.items]
-      .map((item, index) => ({
-        id: item.id,
-        text: item.text,
-        originalIndex: index
-      }))
-      .sort(() => Math.random() - 0.5);
-
+    const shuffledItems = createRandomizedPool(tile);
     setAvailableItems(shuffledItems);
     setPlacedItems(new Array(shuffledItems.length).fill(null));
     setIsChecked(false);
     setIsCorrect(null);
     setAttempts(0);
-  }, [tile.content.items]);
+  }, [tile.id, tile.content.items]);
+
+  useEffect(() => {
+    if (isEditingText && isSelected) {
+      setExperienceMode('edit');
+      if (!hasPromptBeenShown.current) {
+        setShowModePrompt(true);
+        hasPromptBeenShown.current = true;
+      }
+    } else {
+      setExperienceMode('preview');
+      setShowModePrompt(false);
+      hasPromptBeenShown.current = false;
+    }
+  }, [isEditingText, isSelected]);
 
   const resetCheckState = () => {
     if (isChecked) {
@@ -214,14 +449,7 @@ export const SequencingInteractive: React.FC<SequencingInteractiveProps> = ({
   };
 
   const resetSequence = () => {
-    const shuffledItems = [...tile.content.items]
-      .map((item, index) => ({
-        id: item.id,
-        text: item.text,
-        originalIndex: index
-      }))
-      .sort(() => Math.random() - 0.5);
-
+    const shuffledItems = createRandomizedPool(tile);
     setAvailableItems(shuffledItems);
     setPlacedItems(new Array(shuffledItems.length).fill(null));
     setIsChecked(false);
@@ -264,199 +492,275 @@ export const SequencingInteractive: React.FC<SequencingInteractiveProps> = ({
     return baseClasses;
   };
 
-  return (
-    <div className="w-full h-full">
-      <div
-        className={`w-full h-full rounded-3xl ${showBorder ? 'border border-slate-800/60' : ''} text-slate-100 shadow-2xl shadow-slate-950/40 flex flex-col gap-6 p-6 overflow-hidden`}
-        style={{
-          backgroundColor: cardBackground,
-          backgroundImage: 'linear-gradient(160deg, rgba(15, 23, 42, 0.88), rgba(15, 23, 42, 0.82))'
-        }}
-      >
-        {/* Question */}
-        <div className="flex items-start justify-between gap-4">
-          <div
-            className="text-lg font-semibold leading-snug flex-1"
-            style={{
-              fontFamily: tile.content.fontFamily,
-              fontSize: `${tile.content.fontSize}px`
-            }}
-            dangerouslySetInnerHTML={{
-              __html: tile.content.richQuestion || tile.content.question
-            }}
-          />
+  const questionHtml = tile.content.richQuestion || `<p style="margin: 0;">${tile.content.question || 'Ułóż elementy w prawidłowej kolejności'}</p>`;
 
-          <div className="flex items-center gap-2 text-xs font-medium text-slate-400">
-            <Sparkles className="w-4 h-4" />
-            <span>Ćwiczenie sekwencyjne</span>
+  const handleChooseEditMode = () => {
+    setShowModePrompt(false);
+    setExperienceMode('edit');
+  };
+
+  const handleChoosePreviewMode = () => {
+    setShowModePrompt(false);
+    setExperienceMode('preview');
+    onFinishTextEditing?.();
+    resetSequence();
+    setAttempts(0);
+  };
+
+  return (
+    <div className="relative w-full h-full">
+      {showModePrompt && isEditingText && isSelected && (
+        <div className="absolute inset-0 z-30 flex items-center justify-center bg-slate-950/60 backdrop-blur-sm px-4">
+          <div className="w-full max-w-md rounded-3xl bg-white/95 text-slate-900 shadow-2xl shadow-slate-900/40 p-6 space-y-5">
+            <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.32em] text-slate-400">
+              <Sparkles className="w-4 h-4" />
+              <span>Tryb pracy kafelka</span>
+            </div>
+            <div className="space-y-2">
+              <h3 className="text-xl font-semibold text-slate-900">Co chcesz teraz zrobić?</h3>
+              <p className="text-sm text-slate-600">
+                Wybierz, czy chcesz edytować treść polecenia, czy przetestować zadanie w trybie ucznia.
+              </p>
+            </div>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <button
+                onClick={handleChooseEditMode}
+                className="flex items-center justify-center gap-2 rounded-xl bg-blue-600 text-white font-medium py-3 px-4 shadow-lg shadow-blue-500/30 hover:bg-blue-700 transition-colors"
+              >
+                <PenSquare className="w-4 h-4" />
+                <span>Edytuj treść</span>
+              </button>
+              <button
+                onClick={handleChoosePreviewMode}
+                className="flex items-center justify-center gap-2 rounded-xl bg-emerald-500 text-emerald-950 font-semibold py-3 px-4 shadow-lg shadow-emerald-400/30 hover:bg-emerald-400 transition-colors"
+              >
+                <PlayCircle className="w-4 h-4" />
+                <span>Testuj kafelek</span>
+              </button>
+            </div>
           </div>
         </div>
+      )}
 
-        {attempts > 0 && (
-          <div className="text-xs uppercase tracking-[0.32em] text-slate-500">
-            Próba #{attempts}
-          </div>
-        )}
-
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 flex-1 min-h-0">
-          {/* Available items */}
-          <div
-            className={`flex flex-col rounded-2xl border transition-all duration-200 ${
-              isPoolHighlighted
-                ? 'border-emerald-400/70 bg-emerald-400/10 shadow-lg shadow-emerald-500/10'
-                : 'border-slate-800/70 bg-slate-900/40'
-            }`}
-            onDragOver={handlePoolDragOver}
-            onDragLeave={handlePoolDragLeave}
-            onDrop={handleDropToPool}
-          >
-            <div className="flex items-center justify-between px-5 py-4 border-b border-white/5">
-              <div className="flex items-center gap-2 text-sm font-semibold text-slate-200">
-                <Shuffle className="w-4 h-4" />
-                <span>Pula elementów</span>
-              </div>
+      <div className="w-full h-full">
+        <div
+          className={`relative w-full h-full rounded-3xl ${borderClass} ${baseTextClass} shadow-2xl shadow-slate-950/40 flex flex-col gap-6 p-6 overflow-hidden backdrop-blur-sm`}
+          style={containerStyle}
+        >
+          <div className="flex flex-wrap items-start justify-between gap-4">
+            <div className="flex-1 min-h-[2.5rem]">
+              {experienceMode === 'edit' && isEditingText && isSelected ? (
+                <SequencingQuestionEditor
+                  tile={tile}
+                  onUpdateTile={onUpdateTile}
+                  onFinishTextEditing={onFinishTextEditing}
+                  onEditorReady={onEditorReady}
+                  textColor={gradientLayers.textColor}
+                />
+              ) : (
+                <div
+                  style={{
+                    fontFamily: tile.content.fontFamily,
+                    fontSize: `${tile.content.fontSize}px`,
+                    color: gradientLayers.textColor
+                  }}
+                  dangerouslySetInnerHTML={{ __html: questionHtml }}
+                />
+              )}
             </div>
 
-            <div className="flex-1 overflow-auto px-5 py-4 space-y-3">
-              {availableItems.length === 0 ? (
-                <div className="flex flex-col items-center justify-center gap-2 text-center text-sm text-slate-500 py-10">
-                  <ArrowLeftRight className="w-5 h-5" />
-                  <span>Przeciągnij elementy na prawą stronę</span>
+            <div className="flex flex-col items-end gap-2">
+              <div className={`flex items-center gap-2 text-xs font-medium ${mutedTextClass}`}>
+                <Sparkles className="w-4 h-4" />
+                <span>Ćwiczenie sekwencyjne</span>
+              </div>
+
+              {isSelected && (
+                <div className="flex items-center gap-2">
+                  {experienceMode === 'edit' && isEditingText ? (
+                    <button
+                      onClick={handleChoosePreviewMode}
+                      className="flex items-center gap-2 rounded-xl border border-emerald-400/60 bg-emerald-500/20 text-emerald-100 px-3 py-2 text-xs font-semibold hover:bg-emerald-500/30 transition-colors"
+                    >
+                      <PlayCircle className="w-4 h-4" />
+                      <span>Tryb testu</span>
+                    </button>
+                  ) : (
+                    <button
+                      onClick={onRequestEditMode}
+                      className="flex items-center gap-2 rounded-xl border border-blue-400/60 bg-blue-500/20 text-blue-100 px-3 py-2 text-xs font-semibold hover:bg-blue-500/30 transition-colors"
+                    >
+                      <PenSquare className="w-4 h-4" />
+                      <span>Edytuj treść</span>
+                    </button>
+                  )}
                 </div>
-              ) : (
-                availableItems.map((item) => (
-                  <div
-                    key={item.id}
-                    draggable={canInteract}
-                    onDragStart={(e) => handleDragStart(e, item.id, 'pool')}
-                    onDragEnd={handleDragEnd}
-                    className={getItemClasses(item.id)}
-                  >
-                    <div className="flex items-center gap-3">
-                      <div className="flex h-8 w-8 items-center justify-center rounded-lg border border-white/5 bg-slate-900/70 text-slate-400">
-                        <GripVertical className="h-4 w-4" />
-                      </div>
-                      <span className="text-sm font-medium text-slate-100">{item.text}</span>
-                    </div>
-                  </div>
-                ))
               )}
             </div>
           </div>
 
-          {/* Sequence area */}
-          <div className="flex flex-col rounded-2xl border border-emerald-500/20 bg-emerald-500/5">
-            <div className="flex items-center justify-between px-5 py-4 border-b border-emerald-500/20">
-              <div className="flex items-center gap-2 text-sm font-semibold text-emerald-200">
-                <CheckCircle className="w-4 h-4" />
-                <span>Twoja sekwencja</span>
-              </div>
-              <span className="text-xs text-emerald-200/70">{placedItems.filter(Boolean).length} / {tile.content.items.length}</span>
+          {attempts > 0 && (
+            <div className={`text-xs uppercase tracking-[0.32em] ${subtleTextClass}`}>
+              Próba #{attempts}
             </div>
+          )}
 
-            <div className="flex-1 overflow-auto px-5 py-4 space-y-3">
-              {placedItems.map((item, index) => (
-                <div
-                  key={index}
-                  className={getSlotClasses(index, Boolean(item))}
-                  onDragOver={(e) => handleSlotDragOver(e, index)}
-                  onDragLeave={handleSlotDragLeave}
-                  onDrop={(e) => handleDropToSlot(e, index)}
-                >
-                  <div className="flex items-center justify-center w-8 h-8 rounded-lg bg-emerald-500/20 text-emerald-200 text-sm font-semibold border border-emerald-500/30">
-                    {index + 1}
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 flex-1 min-h-0">
+            <div
+              className={`flex flex-col rounded-2xl border transition-all duration-200 ${
+                isPoolHighlighted
+                  ? 'border-emerald-400/70 bg-emerald-400/10 shadow-lg shadow-emerald-500/10'
+                  : poolBaseClasses
+              }`}
+              onDragOver={handlePoolDragOver}
+              onDragLeave={handlePoolDragLeave}
+              onDrop={handleDropToPool}
+            >
+              <div className="flex items-center justify-between px-5 py-4 border-b border-white/10">
+                <div className={`flex items-center gap-2 text-sm font-semibold ${poolItemTextClass}`}>
+                  <Shuffle className="w-4 h-4" />
+                  <span>Pula elementów</span>
+                </div>
+              </div>
+
+              <div className="flex-1 overflow-auto px-5 py-4 space-y-3">
+                {availableItems.length === 0 ? (
+                  <div className={`flex flex-col items-center justify-center gap-2 text-center text-sm ${subtleTextClass} py-10`}>
+                    <ArrowLeftRight className="w-5 h-5" />
+                    <span>Przeciągnij elementy na prawą stronę</span>
                   </div>
-                  {item ? (
+                ) : (
+                  availableItems.map((item) => (
                     <div
-                      className={`flex-1 flex items-center justify-between gap-4 cursor-grab active:cursor-grabbing ${
-                        dragState?.id === item.id ? 'opacity-60 scale-[0.98]' : ''
-                      }`}
+                      key={item.id}
                       draggable={canInteract}
-                      onDragStart={(e) => handleDragStart(e, item.id, 'sequence', index)}
+                      onDragStart={(e) => handleDragStart(e, item.id, 'pool')}
                       onDragEnd={handleDragEnd}
+                      className={getItemClasses(item.id)}
                     >
                       <div className="flex items-center gap-3">
-                        <div className="flex h-8 w-8 items-center justify-center rounded-lg border border-white/5 bg-slate-900/70 text-slate-400">
+                        <div className={`flex h-8 w-8 items-center justify-center rounded-lg border ${poolHandleClasses}`}>
                           <GripVertical className="h-4 w-4" />
                         </div>
-                        <span className="text-sm font-medium text-slate-100 text-left break-words">{item.text}</span>
+                        <span className={`text-sm font-medium ${poolItemTextClass}`}>{item.text}</span>
                       </div>
                     </div>
-                  ) : (
-                    <span className="flex-1 text-sm text-slate-500 italic">
-                      Upuść element w tym miejscu
-                    </span>
-                  )}
-
-                  {isChecked && isCorrect !== null && item && (
-                    (() => {
-                      const originalItem = tile.content.items.find(original => original.id === item.id);
-                      const isInCorrectPosition = originalItem && originalItem.correctPosition === index;
-
-                      return isInCorrectPosition ? (
-                        <CheckCircle className="w-5 h-5 text-emerald-400" />
-                      ) : (
-                        <XCircle className="w-5 h-5 text-rose-400" />
-                      );
-                    })()
-                  )}
-                </div>
-              ))}
-            </div>
-          </div>
-        </div>
-
-        {/* Feedback */}
-        {isChecked && isCorrect !== null && (
-          <div className={`rounded-2xl border px-6 py-4 flex items-center justify-between ${
-            isCorrect
-              ? 'border-emerald-400/40 bg-emerald-500/10 text-emerald-100'
-              : 'border-rose-400/40 bg-rose-500/10 text-rose-100'
-          }`}>
-            <div className="flex items-center gap-3 text-sm font-medium">
-              {isCorrect ? (
-                <CheckCircle className="w-5 h-5 text-emerald-300" />
-              ) : (
-                <XCircle className="w-5 h-5 text-rose-300" />
-              )}
-              <span>
-                {isCorrect ? tile.content.correctFeedback : tile.content.incorrectFeedback}
-              </span>
-            </div>
-
-            {!isCorrect && (
-              <div className="text-xs text-slate-200/70">
-                Spróbuj ponownie, przenosząc elementy.
+                  ))
+                )}
               </div>
-            )}
-          </div>
-        )}
+            </div>
 
-        {/* Action Buttons */}
-        {!isPreview && (
-          <div className="flex flex-wrap items-center justify-between gap-4">
-            <div className="flex items-center gap-3">
-              <button
-                onClick={checkSequence}
-                disabled={!sequenceComplete || (isChecked && isCorrect)}
-                className="px-6 py-2 rounded-xl bg-emerald-500 text-slate-950 font-semibold shadow-lg shadow-emerald-500/30 transition-transform duration-200 disabled:opacity-40 disabled:cursor-not-allowed hover:-translate-y-0.5"
-              >
-                {isChecked && isCorrect ? 'Sekwencja sprawdzona' : 'Sprawdź kolejność'}
-              </button>
+            <div className="flex flex-col rounded-2xl border border-emerald-500/30 bg-emerald-500/10">
+              <div className="flex items-center justify-between px-5 py-4 border-b border-emerald-500/20">
+                <div className={`flex items-center gap-2 text-sm font-semibold ${isLightBackground ? 'text-emerald-700' : 'text-emerald-100'}`}>
+                  <CheckCircle className="w-4 h-4" />
+                  <span>Twoja sekwencja</span>
+                </div>
+                <span className={`text-xs ${isLightBackground ? 'text-emerald-700/70' : 'text-emerald-100/70'}`}>{placedItems.filter(Boolean).length} / {tile.content.items.length}</span>
+              </div>
 
-              {(isChecked && !isCorrect) && (
-                <button
-                  onClick={resetSequence}
-                  className="px-4 py-2 rounded-xl bg-slate-800 text-slate-100 font-medium border border-slate-700/80 hover:bg-slate-700 transition-colors flex items-center gap-2"
-                >
-                  <RotateCcw className="w-4 h-4" />
-                  <span>Wymieszaj ponownie</span>
-                </button>
-              )}
+              <div className="flex-1 overflow-auto px-5 py-4 space-y-3">
+                {placedItems.map((item, index) => (
+                  <div
+                    key={index}
+                    className={getSlotClasses(index, Boolean(item))}
+                    onDragOver={(e) => handleSlotDragOver(e, index)}
+                    onDragLeave={handleSlotDragLeave}
+                    onDrop={(e) => handleDropToSlot(e, index)}
+                  >
+                    <div className={`flex items-center justify-center w-8 h-8 rounded-lg bg-emerald-500/20 ${isLightBackground ? 'text-emerald-700' : 'text-emerald-100'} text-sm font-semibold border border-emerald-500/30`}>
+                      {index + 1}
+                    </div>
+                    {item ? (
+                      <div
+                        className={`flex-1 flex items-center justify-between gap-4 cursor-grab active:cursor-grabbing ${
+                          dragState?.id === item.id ? 'opacity-60 scale-[0.98]' : ''
+                        }`}
+                        draggable={canInteract}
+                        onDragStart={(e) => handleDragStart(e, item.id, 'sequence', index)}
+                        onDragEnd={handleDragEnd}
+                      >
+                        <div className="flex items-center gap-3">
+                          <div className={`flex h-8 w-8 items-center justify-center rounded-lg border ${poolHandleClasses}`}>
+                            <GripVertical className="h-4 w-4" />
+                          </div>
+                          <span className={`text-sm font-medium ${poolItemTextClass} text-left break-words`}>{item.text}</span>
+                        </div>
+                      </div>
+                    ) : (
+                      <span className={`flex-1 text-sm ${subtleTextClass} italic`}>
+                        Upuść element w tym miejscu
+                      </span>
+                    )}
+
+                    {isChecked && isCorrect !== null && item && (
+                      (() => {
+                        const originalItem = tile.content.items.find(original => original.id === item.id);
+                        const isInCorrectPosition = originalItem && originalItem.correctPosition === index;
+
+                        return isInCorrectPosition ? (
+                          <CheckCircle className="w-5 h-5 text-emerald-300" />
+                        ) : (
+                          <XCircle className="w-5 h-5 text-rose-300" />
+                        );
+                      })()
+                    )}
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
-        )}
+
+          {isChecked && isCorrect !== null && (
+            <div className={`rounded-2xl border px-6 py-4 flex items-center justify-between ${
+              isCorrect
+                ? 'border-emerald-400/40 bg-emerald-500/10 text-emerald-100'
+                : 'border-rose-400/40 bg-rose-500/10 text-rose-100'
+            }`}>
+              <div className="flex items-center gap-3 text-sm font-medium">
+                {isCorrect ? (
+                  <CheckCircle className="w-5 h-5 text-emerald-300" />
+                ) : (
+                  <XCircle className="w-5 h-5 text-rose-300" />
+                )}
+                <span>
+                  {isCorrect ? tile.content.correctFeedback : tile.content.incorrectFeedback}
+                </span>
+              </div>
+
+              {!isCorrect && (
+                <div className="text-xs text-slate-200/70">
+                  Spróbuj ponownie, przenosząc elementy.
+                </div>
+              )}
+            </div>
+          )}
+
+          {!isPreview && experienceMode === 'preview' && (
+            <div className="flex flex-wrap items-center justify-between gap-4">
+              <div className="flex items-center gap-3">
+                <button
+                  onClick={checkSequence}
+                  disabled={!sequenceComplete || (isChecked && isCorrect)}
+                  className="px-6 py-2 rounded-xl bg-emerald-500 text-slate-950 font-semibold shadow-lg shadow-emerald-500/30 transition-transform duration-200 disabled:opacity-40 disabled:cursor-not-allowed hover:-translate-y-0.5"
+                >
+                  {isChecked && isCorrect ? 'Sekwencja sprawdzona' : 'Sprawdź kolejność'}
+                </button>
+
+                {(isChecked && !isCorrect) && (
+                  <button
+                    onClick={resetSequence}
+                    className="px-4 py-2 rounded-xl bg-slate-900/70 text-slate-100 font-medium border border-slate-600/60 hover:bg-slate-900/60 transition-colors flex items-center gap-2"
+                  >
+                    <RotateCcw className="w-4 h-4" />
+                    <span>Wymieszaj ponownie</span>
+                  </button>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
       </div>
     </div>
-);
+  );
 };

--- a/src/components/admin/TileRenderer.tsx
+++ b/src/components/admin/TileRenderer.tsx
@@ -708,7 +708,15 @@ export const TileRenderer: React.FC<TileRendererProps> = ({
       case 'sequencing': {
         const sequencingTile = tile as SequencingTile;
         contentToRender = (
-          <SequencingInteractive tile={sequencingTile} />
+          <SequencingInteractive
+            tile={sequencingTile}
+            isSelected={isSelected}
+            isEditingText={isEditingText}
+            onUpdateTile={(tileId, updates) => onUpdateTile(tileId, updates)}
+            onFinishTextEditing={onFinishTextEditing}
+            onEditorReady={onEditorReady}
+            onRequestEditMode={onDoubleClick}
+          />
         );
         break;
       }

--- a/src/components/admin/side editor/SequencingEditor.tsx
+++ b/src/components/admin/side editor/SequencingEditor.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Plus, Trash2, GripVertical, ArrowUp, ArrowDown, RotateCcw } from 'lucide-react';
+import { Plus, Trash2, GripVertical, RotateCcw } from 'lucide-react';
 import { SequencingTile } from '../../../types/lessonEditor.ts';
 
 interface SequencingEditorProps {
@@ -119,18 +119,15 @@ export const SequencingEditor: React.FC<SequencingEditorProps> = ({
 
   return (
     <div className="space-y-6">
-      {/* Question Settings */}
-      <div>
-        <label className="block text-sm font-medium text-gray-700 mb-2">
-          Pytanie/Polecenie
-        </label>
-        <textarea
-          value={tile.content.question}
-          onChange={(e) => handleContentUpdate('question', e.target.value)}
-          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm resize-vertical"
-          rows={2}
-          placeholder="Wprowadź pytanie lub polecenie dla uczniów"
-        />
+      <div className="rounded-lg border border-blue-100 bg-blue-50 p-4">
+        <p className="text-sm font-medium text-blue-800">
+          Treść polecenia edytujesz bezpośrednio na kafelku.
+        </p>
+        <p className="text-xs text-blue-700 mt-1">
+          Kliknij dwukrotnie kafelek na planszy, a następnie wybierz w oknie wyboru opcję
+          <span className="font-semibold"> „Edytuj treść”</span>, aby włączyć edytor RichText lub
+          <span className="font-semibold"> „Testuj kafelek”</span>, by przejść do podglądu ćwiczenia.
+        </p>
       </div>
 
       {/* Items Management */}
@@ -203,17 +200,27 @@ export const SequencingEditor: React.FC<SequencingEditorProps> = ({
         )}
       </div>
 
-      </div>
-
       {/* Background Color */}
-      <div>
-        <label className="block text-sm font-medium text-gray-700 mb-3">Kolor tła kafelka</label>
-        <input
-          type="color"
-          value={tile.content.backgroundColor}
-          onChange={(e) => handleContentUpdate('backgroundColor', e.target.value)}
-          className="w-full h-12 border border-gray-300 rounded-lg cursor-pointer"
-        />
+      <div className="space-y-2">
+        <label className="block text-sm font-medium text-gray-700">Kolor tła kafelka</label>
+        <div className="flex items-center gap-3">
+          <input
+            type="color"
+            value={tile.content.backgroundColor}
+            onChange={(e) => handleContentUpdate('backgroundColor', e.target.value)}
+            className="w-16 h-12 border border-gray-300 rounded-lg cursor-pointer"
+          />
+          <input
+            type="text"
+            value={tile.content.backgroundColor}
+            onChange={(e) => handleContentUpdate('backgroundColor', e.target.value)}
+            className="flex-1 px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm"
+            placeholder="#0F172A"
+          />
+        </div>
+        <p className="text-xs text-gray-500">
+          Wybrany kolor wpływa również na gradient kafelka, dzięki czemu łatwo dopasujesz kafelek do motywu lekcji.
+        </p>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- prevent the sequencing tile shuffle/reset logic from ever returning the fully-correct order while keeping a deterministic fallback
- hook the sequencing tile renderer into the shared editing callbacks so the double-click prompt reliably offers edit/test modes
- refresh the sequencing side editor by removing the obsolete question textarea and providing guidance plus richer background color controls

## Testing
- npm run lint *(fails: existing repository lint errors and warnings unrelated to these changes)*

------
https://chatgpt.com/codex/tasks/task_e_68cc3c4c65808321a001be6a202527da