### PR TITLE
Improve sequencing tile editing and appearance

### DIFF
--- a/src/components/admin/LessonCanvas.tsx
+++ b/src/components/admin/LessonCanvas.tsx
@@ -1,6 +1,6 @@
 import React, { forwardRef } from 'react';
 import { Type } from 'lucide-react';
-import { LessonContent, LessonTile, EditorState } from '../../types/lessonEditor.ts';
+import { LessonContent, LessonTile, EditorState, SequencingTile } from '../../types/lessonEditor.ts';
 import { EditorAction } from '../../state/editorReducer.ts';
 import { TileRenderer } from './TileRenderer.tsx';
 import { GridUtils } from '../../utils/gridUtils.ts';
@@ -18,6 +18,7 @@ interface LessonCanvasProps {
   onFinishTextEditing: () => void;
   showGrid?: boolean;
   onEditorReady: (editor: Editor | null) => void;
+  onSequencingDoubleClick?: (tile: SequencingTile) => void;
 }
 
 export const LessonCanvas = forwardRef<HTMLDivElement, LessonCanvasProps>(({ 
@@ -30,7 +31,8 @@ export const LessonCanvas = forwardRef<HTMLDivElement, LessonCanvasProps>(({
   onAddTile,
   onFinishTextEditing,
   showGrid = true,
-  onEditorReady
+  onEditorReady,
+  onSequencingDoubleClick
 }, ref) => {
   const {
     dragPreview,
@@ -50,6 +52,7 @@ export const LessonCanvas = forwardRef<HTMLDivElement, LessonCanvasProps>(({
     onDeleteTile,
     onAddTile,
     canvasRef: ref as React.RefObject<HTMLDivElement>,
+    onSequencingDoubleClick,
   });
 
   // Calculate canvas dimensions

--- a/src/components/admin/side editor/SequencingEditor.tsx
+++ b/src/components/admin/side editor/SequencingEditor.tsx
@@ -119,18 +119,8 @@ export const SequencingEditor: React.FC<SequencingEditorProps> = ({
 
   return (
     <div className="space-y-6">
-      {/* Question Settings */}
-      <div>
-        <label className="block text-sm font-medium text-gray-700 mb-2">
-          Pytanie/Polecenie
-        </label>
-        <textarea
-          value={tile.content.question}
-          onChange={(e) => handleContentUpdate('question', e.target.value)}
-          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm resize-vertical"
-          rows={2}
-          placeholder="Wprowadź pytanie lub polecenie dla uczniów"
-        />
+      <div className="p-4 rounded-lg bg-blue-50 border border-blue-100 text-sm text-blue-700">
+        Tekst polecenia edytuj teraz bezpośrednio na kafelku. Dwukrotne kliknięcie otworzy edycję RichText.
       </div>
 
       {/* Items Management */}
@@ -201,8 +191,6 @@ export const SequencingEditor: React.FC<SequencingEditorProps> = ({
             ⚠️ Dodaj co najmniej 2 elementy, aby ćwiczenie było funkcjonalne
           </div>
         )}
-      </div>
-
       </div>
 
       {/* Background Color */}

--- a/src/hooks/useTileInteractions.ts
+++ b/src/hooks/useTileInteractions.ts
@@ -13,6 +13,7 @@ interface UseTileInteractionsProps {
   onDeleteTile: (tileId: string) => void;
   onAddTile: (tileType: string, position: { x: number; y: number }) => void;
   canvasRef: RefObject<HTMLDivElement>;
+  onSequencingDoubleClick?: (tile: SequencingTile) => void;
 }
 
 export const useTileInteractions = ({
@@ -23,13 +24,20 @@ export const useTileInteractions = ({
   onSelectTile,
   onDeleteTile,
   onAddTile,
-  canvasRef
+  canvasRef,
+  onSequencingDoubleClick
 }: UseTileInteractionsProps) => {
   const [dragPreview, setDragPreview] = useState<GridPosition | null>(null);
   const [resizePreview, setResizePreview] = useState<{ tileId: string; gridPosition: GridPosition } | null>(null);
 
   const handleTileDoubleClick = (tile: LessonTile) => {
-    if (tile.type === 'text' || tile.type === 'programming' || tile.type === 'sequencing') {
+    if (tile.type === 'sequencing') {
+      onSelectTile(tile.id);
+      onSequencingDoubleClick?.(tile as SequencingTile);
+      return;
+    }
+
+    if (tile.type === 'text' || tile.type === 'programming') {
       dispatch({ type: 'startTextEditing', tileId: tile.id });
     } else if (tile.type === 'image') {
       dispatch({ type: 'startImageEditing', tileId: tile.id });


### PR DESCRIPTION
## Summary
- ensure the sequencing task shuffle never starts in the correct order and adjust styling to respect custom background colours
- add a double-click prompt that lets editors switch between rich-text editing and previewing the sequencing tile, reusing the canvas top toolbar
- remove the redundant question field from the side editor and embed the rich text editor directly in the tile layout when editing

## Testing
- npm run lint *(fails: repository contains pre-existing lint errors unrelated to these changes)*

------
https://chatgpt.com/codex/tasks/task_e_68cc3c4c65808321a001be6a202527da