### PR TITLE
Revamp sequencing tile UI and testing mode

### DIFF
--- a/src/components/admin/SequencingInteractive.tsx
+++ b/src/components/admin/SequencingInteractive.tsx
@@ -108,9 +108,18 @@ export const SequencingInteractive: React.FC<SequencingInteractiveProps> = ({
   const [dragOverSlot, setDragOverSlot] = useState<number | null>(null);
   const [isPoolHighlighted, setIsPoolHighlighted] = useState(false);
   const [isModePromptVisible, setIsModePromptVisible] = useState(false);
+  const [isTestingMode, setIsTestingMode] = useState(false);
   const modePromptRef = useRef<HTMLDivElement>(null);
 
-  const canInteract = !isPreview;
+  useEffect(() => {
+    if (isPreview) {
+      setIsTestingMode(false);
+    } else {
+      setIsTestingMode(true);
+    }
+  }, [isPreview]);
+
+  const canInteract = isTestingMode || !isPreview;
   const sequenceComplete = placedItems.length > 0 && placedItems.every(item => item !== null);
 
   const accentColor = tile.content.backgroundColor || '#0f172a';
@@ -122,6 +131,63 @@ export const SequencingInteractive: React.FC<SequencingInteractiveProps> = ({
     [textColor]
   );
   const showBorder = tile.content.showBorder !== false;
+
+  const palette = useMemo(() => {
+    const isDarkText = textColor === '#0f172a';
+
+    const baseSurface = isDarkText ? darkenColor(accentColor, 0.08) : lightenColor(accentColor, 0.08);
+    const elevatedSurface = isDarkText ? darkenColor(accentColor, 0.16) : lightenColor(accentColor, 0.16);
+    const strongSurface = isDarkText ? darkenColor(accentColor, 0.24) : lightenColor(accentColor, 0.24);
+    const highlightSurface = isDarkText ? darkenColor(accentColor, 0.28) : lightenColor(accentColor, 0.28);
+
+    return {
+      isDarkText,
+      containerShadow: `0 30px 88px -48px ${withAlpha(textColor, isDarkText ? 0.32 : 0.58)}`,
+      panelBackground: baseSurface,
+      panelBorder: withAlpha(textColor, isDarkText ? 0.2 : 0.26),
+      panelHeaderBackground: isDarkText ? darkenColor(accentColor, 0.12) : lightenColor(accentColor, 0.12),
+      panelHeaderDivider: withAlpha(textColor, isDarkText ? 0.16 : 0.2),
+      panelShadow: `0 22px 60px -44px ${withAlpha(textColor, isDarkText ? 0.36 : 0.5)}`,
+      mutedText: withAlpha(textColor, isDarkText ? 0.68 : 0.72),
+      softerText: withAlpha(textColor, isDarkText ? 0.48 : 0.55),
+      placeholderText: withAlpha(textColor, isDarkText ? 0.42 : 0.5),
+      itemBackground: elevatedSurface,
+      itemBorder: withAlpha(textColor, isDarkText ? 0.24 : 0.3),
+      itemShadow: `0 20px 48px -36px ${withAlpha(textColor, isDarkText ? 0.5 : 0.58)}`,
+      itemHandleBackground: isDarkText ? darkenColor(accentColor, 0.22) : lightenColor(accentColor, 0.2),
+      itemHandleBorder: withAlpha(textColor, isDarkText ? 0.26 : 0.32),
+      itemHandleIcon: withAlpha(textColor, isDarkText ? 0.76 : 0.58),
+      slotEmptyBackground: baseSurface,
+      slotFilledBackground: elevatedSurface,
+      slotHoverBackground: highlightSurface,
+      slotBorder: withAlpha(textColor, isDarkText ? 0.26 : 0.32),
+      slotDashedBorder: withAlpha(textColor, isDarkText ? 0.22 : 0.26),
+      slotShadow: `inset 0 1px 0 ${withAlpha(textColor, isDarkText ? 0.08 : 0.12)}`,
+      highlightBackground: strongSurface,
+      highlightBorder: withAlpha(textColor, isDarkText ? 0.48 : 0.52),
+      highlightShadow: `0 26px 64px -48px ${withAlpha(textColor, isDarkText ? 0.52 : 0.6)}`,
+      correctBackground: strongSurface,
+      correctBorder: withAlpha(textColor, isDarkText ? 0.52 : 0.5),
+      incorrectBackground: isDarkText ? darkenColor(accentColor, 0.04) : lightenColor(accentColor, 0.04),
+      incorrectBorder: withAlpha(textColor, isDarkText ? 0.32 : 0.34),
+      correctIcon: withAlpha(textColor, isDarkText ? 0.92 : 0.75),
+      incorrectIcon: withAlpha(textColor, isDarkText ? 0.7 : 0.6),
+      badgeBackground: strongSurface,
+      badgeBorder: withAlpha(textColor, isDarkText ? 0.3 : 0.36),
+      primaryButtonBackground: isDarkText ? darkenColor(accentColor, 0.32) : '#f8fafc',
+      primaryButtonText: isDarkText ? '#f8fafc' : '#0f172a',
+      primaryButtonShadow: `0 20px 52px -36px ${withAlpha(textColor, isDarkText ? 0.6 : 0.42)}`,
+      primaryButtonDisabledBackground: isDarkText ? darkenColor(accentColor, 0.18) : lightenColor(accentColor, 0.18),
+      secondaryButtonBackground: isDarkText ? darkenColor(accentColor, 0.2) : lightenColor(accentColor, 0.2),
+      secondaryButtonBorder: withAlpha(textColor, isDarkText ? 0.28 : 0.32),
+      secondaryButtonText: textColor,
+      secondaryButtonShadow: `0 18px 46px -36px ${withAlpha(textColor, isDarkText ? 0.45 : 0.5)}`,
+      dividerColor: withAlpha(textColor, isDarkText ? 0.2 : 0.24),
+      infoChipBackground: isDarkText ? darkenColor(accentColor, 0.2) : lightenColor(accentColor, 0.2),
+      infoChipText: textColor,
+      feedbackHintText: withAlpha(textColor, isDarkText ? 0.62 : 0.64)
+    };
+  }, [accentColor, textColor]);
 
   const correctOrderIds = useMemo(
     () =>
@@ -356,39 +422,52 @@ export const SequencingInteractive: React.FC<SequencingInteractiveProps> = ({
     setIsCorrect(null);
   };
 
-  const getItemClasses = (itemId: string) => {
-    let baseClasses =
-      'flex items-center gap-4 px-4 py-3 rounded-xl border border-slate-800/70 bg-slate-800/60 text-slate-100 shadow-sm shadow-slate-900/30 transition-transform duration-200 select-none cursor-grab active:cursor-grabbing';
+  const getItemStyles = (itemId: string): React.CSSProperties => {
+    const isDragging = dragState?.id === itemId;
 
-    if (dragState?.id === itemId) {
-      baseClasses += ' opacity-60 scale-[0.98]';
-    }
-
-    return baseClasses;
+    return {
+      backgroundColor: palette.itemBackground,
+      border: `1px solid ${palette.itemBorder}`,
+      color: textColor,
+      boxShadow: palette.itemShadow,
+      opacity: isDragging ? 0.6 : 1,
+      transform: `scale(${isDragging ? 0.98 : 1})`,
+      transition: 'transform 0.2s ease, opacity 0.2s ease, box-shadow 0.2s ease'
+    };
   };
 
-  const getSlotClasses = (index: number, hasItem: boolean) => {
-    let baseClasses = 'relative flex items-center gap-4 px-4 py-3 rounded-xl border-2 transition-all duration-200 min-h-[72px]';
+  const getSlotStyles = (index: number, hasItem: boolean): React.CSSProperties => {
+    const style: React.CSSProperties = {
+      backgroundColor: hasItem ? palette.slotFilledBackground : palette.slotEmptyBackground,
+      border: `1px ${hasItem ? 'solid' : 'dashed'} ${hasItem ? palette.slotBorder : palette.slotDashedBorder}`,
+      boxShadow: palette.slotShadow,
+      transition: 'all 0.2s ease',
+      color: textColor
+    };
 
     if (dragOverSlot === index) {
-      baseClasses += ' border-emerald-400/70 bg-emerald-400/10 shadow-lg shadow-emerald-500/10';
-    } else if (isChecked && isCorrect !== null) {
-      const placedItem = placedItems[index];
-      const originalItem = placedItem ? tile.content.items.find(item => item.id === placedItem.id) : null;
-      const isInCorrectPosition = originalItem && originalItem.correctPosition === index;
-
-      if (isInCorrectPosition) {
-        baseClasses += ' border-emerald-400/60 bg-emerald-400/5';
-      } else {
-        baseClasses += ' border-rose-400/60 bg-rose-400/5';
-      }
-    } else if (hasItem) {
-      baseClasses += ' border-slate-700/80 bg-slate-800/40';
-    } else {
-      baseClasses += ' border-dashed border-slate-700/80 bg-slate-900/30 hover:border-emerald-400/60 hover:bg-emerald-400/5';
+      style.backgroundColor = palette.highlightBackground;
+      style.border = `1px solid ${palette.highlightBorder}`;
+      style.boxShadow = palette.highlightShadow;
+      return style;
     }
 
-    return baseClasses;
+    if (isChecked && isCorrect !== null) {
+      const placedItem = placedItems[index];
+      const originalItem = placedItem ? tile.content.items.find(item => item.id === placedItem.id) : null;
+      const isInCorrectPosition = Boolean(originalItem && originalItem.correctPosition === index);
+
+      if (isInCorrectPosition) {
+        style.backgroundColor = palette.correctBackground;
+        style.border = `1px solid ${palette.correctBorder}`;
+        style.boxShadow = palette.highlightShadow;
+      } else {
+        style.backgroundColor = palette.incorrectBackground;
+        style.border = `1px solid ${palette.incorrectBorder}`;
+      }
+    }
+
+    return style;
   };
 
   const handleTileDoubleClick = (event: React.MouseEvent) => {
@@ -403,7 +482,16 @@ export const SequencingInteractive: React.FC<SequencingInteractiveProps> = ({
     setIsModePromptVisible(true);
   };
 
+  const handleTestSelection = () => {
+    setIsModePromptVisible(false);
+    if (isPreview) {
+      resetSequence();
+    }
+    setIsTestingMode(true);
+  };
+
   const handleEditSelection = () => {
+    setIsTestingMode(false);
     setIsModePromptVisible(false);
     onRequestTextEditing?.();
   };
@@ -411,12 +499,13 @@ export const SequencingInteractive: React.FC<SequencingInteractiveProps> = ({
   return (
     <div className="relative w-full h-full" onDoubleClick={handleTileDoubleClick}>
       <div
-        className={`w-full h-full rounded-3xl ${showBorder ? 'border' : ''} shadow-2xl shadow-slate-950/40 flex flex-col gap-6 p-6 overflow-hidden`}
+        className="w-full h-full rounded-3xl flex flex-col gap-6 p-6 overflow-hidden"
         style={{
           backgroundColor: accentColor,
           backgroundImage: `linear-gradient(135deg, ${gradientStart}, ${gradientEnd})`,
           color: textColor,
-          borderColor: showBorder ? borderColor : undefined
+          border: showBorder ? `1px solid ${borderColor}` : 'none',
+          boxShadow: palette.containerShadow
         }}
       >
         {headerSlot ? (
@@ -434,7 +523,13 @@ export const SequencingInteractive: React.FC<SequencingInteractiveProps> = ({
               }}
             />
 
-            <div className="flex items-center gap-2 text-xs font-medium" style={{ color: withAlpha(textColor, 0.7) }}>
+            <div
+              className="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-medium"
+              style={{
+                backgroundColor: palette.infoChipBackground,
+                color: palette.infoChipText
+              }}
+            >
               <Sparkles className="w-4 h-4" />
               <span>Ćwiczenie sekwencyjne</span>
             </div>
@@ -442,32 +537,39 @@ export const SequencingInteractive: React.FC<SequencingInteractiveProps> = ({
         )}
 
         {attempts > 0 && (
-          <div className="text-xs uppercase tracking-[0.32em]" style={{ color: withAlpha(textColor, 0.55) }}>
+          <div className="text-xs uppercase tracking-[0.32em]" style={{ color: palette.softerText }}>
             Próba #{attempts}
           </div>
         )}
 
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 flex-1 min-h-0">
           <div
-            className={`flex flex-col rounded-2xl border transition-all duration-200 ${
-              isPoolHighlighted
-                ? 'border-emerald-400/70 bg-emerald-400/10 shadow-lg shadow-emerald-500/10'
-                : 'border-slate-800/70 bg-slate-900/40'
-            }`}
+            className="flex flex-col rounded-2xl transition-all duration-200"
+            style={{
+              backgroundColor: isPoolHighlighted ? palette.highlightBackground : palette.panelBackground,
+              border: `1px solid ${isPoolHighlighted ? palette.highlightBorder : palette.panelBorder}`,
+              boxShadow: isPoolHighlighted ? palette.highlightShadow : palette.panelShadow
+            }}
             onDragOver={handlePoolDragOver}
             onDragLeave={handlePoolDragLeave}
             onDrop={handleDropToPool}
           >
-            <div className="flex items-center justify-between px-5 py-4 border-b border-white/5">
-              <div className="flex items-center gap-2 text-sm font-semibold text-slate-200">
-                <Shuffle className="w-4 h-4" />
+            <div
+              className="flex items-center justify-between px-5 py-4 rounded-t-2xl"
+              style={{
+                borderBottom: `1px solid ${palette.panelHeaderDivider}`,
+                backgroundColor: palette.panelHeaderBackground
+              }}
+            >
+              <div className="flex items-center gap-2 text-sm font-semibold" style={{ color: palette.mutedText }}>
+                <Shuffle className="w-4 h-4" style={{ color: palette.infoChipText }} />
                 <span>Pula elementów</span>
               </div>
             </div>
 
             <div className="flex-1 overflow-auto px-5 py-4 space-y-3">
               {availableItems.length === 0 ? (
-                <div className="flex flex-col items-center justify-center gap-2 text-center text-sm text-slate-500 py-10">
+                <div className="flex flex-col items-center justify-center gap-2 text-center text-sm py-10" style={{ color: palette.placeholderText }}>
                   <ArrowLeftRight className="w-5 h-5" />
                   <span>Przeciągnij elementy na prawą stronę</span>
                 </div>
@@ -478,13 +580,23 @@ export const SequencingInteractive: React.FC<SequencingInteractiveProps> = ({
                     draggable={canInteract}
                     onDragStart={e => handleDragStart(e, item.id, 'pool')}
                     onDragEnd={handleDragEnd}
-                    className={getItemClasses(item.id)}
+                    className="flex items-center gap-4 px-4 py-3 rounded-xl select-none cursor-grab active:cursor-grabbing"
+                    style={getItemStyles(item.id)}
                   >
                     <div className="flex items-center gap-3">
-                      <div className="flex h-8 w-8 items-center justify-center rounded-lg border border-white/5 bg-slate-900/70 text-slate-400">
+                      <div
+                        className="flex h-8 w-8 items-center justify-center rounded-lg"
+                        style={{
+                          backgroundColor: palette.itemHandleBackground,
+                          border: `1px solid ${palette.itemHandleBorder}`,
+                          color: palette.itemHandleIcon
+                        }}
+                      >
                         <GripVertical className="h-4 w-4" />
                       </div>
-                      <span className="text-sm font-medium text-slate-100">{item.text}</span>
+                      <span className="text-sm font-medium" style={{ color: textColor }}>
+                        {item.text}
+                      </span>
                     </div>
                   </div>
                 ))
@@ -492,13 +604,26 @@ export const SequencingInteractive: React.FC<SequencingInteractiveProps> = ({
             </div>
           </div>
 
-          <div className="flex flex-col rounded-2xl border border-emerald-500/20 bg-emerald-500/5">
-            <div className="flex items-center justify-between px-5 py-4 border-b border-emerald-500/20">
-              <div className="flex items-center gap-2 text-sm font-semibold text-emerald-200">
-                <CheckCircle className="w-4 h-4" />
+          <div
+            className="flex flex-col rounded-2xl transition-all duration-200"
+            style={{
+              backgroundColor: palette.panelBackground,
+              border: `1px solid ${palette.panelBorder}`,
+              boxShadow: palette.panelShadow
+            }}
+          >
+            <div
+              className="flex items-center justify-between px-5 py-4 rounded-t-2xl"
+              style={{
+                borderBottom: `1px solid ${palette.panelHeaderDivider}`,
+                backgroundColor: palette.panelHeaderBackground
+              }}
+            >
+              <div className="flex items-center gap-2 text-sm font-semibold" style={{ color: palette.mutedText }}>
+                <CheckCircle className="w-4 h-4" style={{ color: palette.infoChipText }} />
                 <span>Twoja sekwencja</span>
               </div>
-              <span className="text-xs text-emerald-200/70">
+              <span className="text-xs" style={{ color: palette.softerText }}>
                 {placedItems.filter(Boolean).length} / {tile.content.items.length}
               </span>
             </div>
@@ -507,32 +632,54 @@ export const SequencingInteractive: React.FC<SequencingInteractiveProps> = ({
               {placedItems.map((item, index) => (
                 <div
                   key={index}
-                  className={getSlotClasses(index, Boolean(item))}
+                  className="relative flex items-center gap-4 px-4 py-3 rounded-xl min-h-[72px]"
+                  style={getSlotStyles(index, Boolean(item))}
                   onDragOver={e => handleSlotDragOver(e, index)}
                   onDragLeave={handleSlotDragLeave}
                   onDrop={e => handleDropToSlot(e, index)}
                 >
-                  <div className="flex items-center justify-center w-8 h-8 rounded-lg bg-emerald-500/20 text-emerald-200 text-sm font-semibold border border-emerald-500/30">
+                  <div
+                    className="flex items-center justify-center w-8 h-8 rounded-lg text-sm font-semibold"
+                    style={{
+                      backgroundColor: palette.badgeBackground,
+                      border: `1px solid ${palette.badgeBorder}`,
+                      color: textColor
+                    }}
+                  >
                     {index + 1}
                   </div>
                   {item ? (
                     <div
-                      className={`flex-1 flex items-center justify-between gap-4 cursor-grab active:cursor-grabbing ${
-                        dragState?.id === item.id ? 'opacity-60 scale-[0.98]' : ''
-                      }`}
+                      className="flex-1 flex items-center justify-between gap-4 cursor-grab active:cursor-grabbing px-3 py-2 rounded-lg"
                       draggable={canInteract}
                       onDragStart={e => handleDragStart(e, item.id, 'sequence', index)}
                       onDragEnd={handleDragEnd}
+                      style={{
+                        ...getItemStyles(item.id),
+                        margin: 0,
+                        width: '100%'
+                      }}
                     >
-                      <div className="flex items-center gap-3">
-                        <div className="flex h-8 w-8 items-center justify-center rounded-lg border border-white/5 bg-slate-900/70 text-slate-400">
+                      <div className="flex items-center gap-3 w-full">
+                        <div
+                          className="flex h-8 w-8 items-center justify-center rounded-lg"
+                          style={{
+                            backgroundColor: palette.itemHandleBackground,
+                            border: `1px solid ${palette.itemHandleBorder}`,
+                            color: palette.itemHandleIcon
+                          }}
+                        >
                           <GripVertical className="h-4 w-4" />
                         </div>
-                        <span className="text-sm font-medium text-slate-100 text-left break-words">{item.text}</span>
+                        <span className="text-sm font-medium text-left break-words" style={{ color: textColor }}>
+                          {item.text}
+                        </span>
                       </div>
                     </div>
                   ) : (
-                    <span className="flex-1 text-sm text-slate-500 italic">Upuść element w tym miejscu</span>
+                    <span className="flex-1 text-sm italic" style={{ color: palette.placeholderText }}>
+                      Upuść element w tym miejscu
+                    </span>
                   )}
 
                   {isChecked && isCorrect !== null && item && (() => {
@@ -540,9 +687,9 @@ export const SequencingInteractive: React.FC<SequencingInteractiveProps> = ({
                     const isInCorrectPosition = originalItem && originalItem.correctPosition === index;
 
                     return isInCorrectPosition ? (
-                      <CheckCircle className="w-5 h-5 text-emerald-400" />
+                      <CheckCircle className="w-5 h-5" style={{ color: palette.correctIcon }} />
                     ) : (
-                      <XCircle className="w-5 h-5 text-rose-400" />
+                      <XCircle className="w-5 h-5" style={{ color: palette.incorrectIcon }} />
                     );
                   })()}
                 </div>
@@ -553,32 +700,46 @@ export const SequencingInteractive: React.FC<SequencingInteractiveProps> = ({
 
         {isChecked && isCorrect !== null && (
           <div
-            className={`rounded-2xl border px-6 py-4 flex items-center justify-between ${
-              isCorrect
-                ? 'border-emerald-400/40 bg-emerald-500/10 text-emerald-100'
-                : 'border-rose-400/40 bg-rose-500/10 text-rose-100'
-            }`}
+            className="rounded-2xl px-6 py-4 flex items-center justify-between"
+            style={{
+              border: `1px solid ${isCorrect ? palette.correctBorder : palette.incorrectBorder}`,
+              backgroundColor: isCorrect ? palette.correctBackground : palette.incorrectBackground,
+              color: textColor
+            }}
           >
             <div className="flex items-center gap-3 text-sm font-medium">
               {isCorrect ? (
-                <CheckCircle className="w-5 h-5 text-emerald-300" />
+                <CheckCircle className="w-5 h-5" style={{ color: palette.correctIcon }} />
               ) : (
-                <XCircle className="w-5 h-5 text-rose-300" />
+                <XCircle className="w-5 h-5" style={{ color: palette.incorrectIcon }} />
               )}
               <span>{isCorrect ? tile.content.correctFeedback : tile.content.incorrectFeedback}</span>
             </div>
 
-            {!isCorrect && <div className="text-xs text-slate-200/70">Spróbuj ponownie, przenosząc elementy.</div>}
+            {!isCorrect && (
+              <div className="text-xs" style={{ color: palette.feedbackHintText }}>
+                Spróbuj ponownie, przenosząc elementy.
+              </div>
+            )}
           </div>
         )}
 
-        {!isPreview && (
+        {canInteract && (
           <div className="flex flex-wrap items-center justify-between gap-4">
             <div className="flex items-center gap-3">
               <button
                 onClick={checkSequence}
                 disabled={!sequenceComplete || (isChecked && isCorrect)}
-                className="px-6 py-2 rounded-xl bg-emerald-500 text-slate-950 font-semibold shadow-lg shadow-emerald-500/30 transition-transform duration-200 disabled:opacity-40 disabled:cursor-not-allowed hover:-translate-y-0.5"
+                className="px-6 py-2 rounded-xl font-semibold transition-all duration-200 disabled:cursor-not-allowed hover:-translate-y-0.5"
+                style={{
+                  backgroundColor:
+                    !sequenceComplete || (isChecked && isCorrect)
+                      ? palette.primaryButtonDisabledBackground
+                      : palette.primaryButtonBackground,
+                  color: palette.primaryButtonText,
+                  boxShadow:
+                    !sequenceComplete || (isChecked && isCorrect) ? 'none' : palette.primaryButtonShadow
+                }}
               >
                 {isChecked && isCorrect ? 'Sekwencja sprawdzona' : 'Sprawdź kolejność'}
               </button>
@@ -586,13 +747,34 @@ export const SequencingInteractive: React.FC<SequencingInteractiveProps> = ({
               {isChecked && !isCorrect && (
                 <button
                   onClick={resetSequence}
-                  className="px-4 py-2 rounded-xl bg-slate-800 text-slate-100 font-medium border border-slate-700/80 hover:bg-slate-700 transition-colors flex items-center gap-2"
+                  className="px-4 py-2 rounded-xl font-medium transition-all duration-200 flex items-center gap-2"
+                  style={{
+                    backgroundColor: palette.secondaryButtonBackground,
+                    border: `1px solid ${palette.secondaryButtonBorder}`,
+                    color: palette.secondaryButtonText,
+                    boxShadow: palette.secondaryButtonShadow
+                  }}
                 >
                   <RotateCcw className="w-4 h-4" />
                   <span>Wymieszaj ponownie</span>
                 </button>
               )}
             </div>
+
+            {isPreview && isTestingMode && (
+              <button
+                type="button"
+                className="px-4 py-2 rounded-xl text-sm font-medium transition-all duration-200"
+                style={{
+                  backgroundColor: palette.secondaryButtonBackground,
+                  border: `1px solid ${palette.secondaryButtonBorder}`,
+                  color: palette.secondaryButtonText
+                }}
+                onClick={() => setIsTestingMode(false)}
+              >
+                Zakończ testowanie
+              </button>
+            )}
           </div>
         )}
       </div>
@@ -614,7 +796,7 @@ export const SequencingInteractive: React.FC<SequencingInteractiveProps> = ({
               <button
                 type="button"
                 className="w-full px-4 py-3 rounded-xl border border-slate-200 bg-slate-50 text-slate-700 hover:bg-slate-100 transition-colors duration-200 flex items-center justify-between"
-                onClick={() => setIsModePromptVisible(false)}
+                onClick={handleTestSelection}
               >
                 <span className="font-medium">Przetestuj zadanie</span>
                 <Sparkles className="w-4 h-4 text-slate-400" />


### PR DESCRIPTION
## Summary
- refresh the sequencing task tile with a neutral, solid-surface palette that adapts to any background color
- restyle pool, sequence slots, feedback, and controls for better contrast and remove translucent accents
- add a dedicated testing mode so editors can try the exercise, including reset and exit affordances from the prompt

## Testing
- npm run lint *(fails: repository already contains pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cc499b5b648321b87f5a797ad481b5