### PR TITLE
Improve sequencing task UI and add testing mode toggle

### DIFF
--- a/src/Pages/LessonEditor.tsx
+++ b/src/Pages/LessonEditor.tsx
@@ -244,12 +244,23 @@ export const LessonEditor: React.FC<LessonEditorProps> = ({ lesson, course, onBa
   };
 
   const handleSelectTile = (tileId: string | null) => {
+    if (editorState.testingTileId && editorState.testingTileId !== tileId) {
+      dispatch({ type: 'stopTileTesting' });
+    }
     dispatch({ type: 'selectTile', tileId });
   };
 
   const handleFinishTextEditing = () => {
     dispatch({ type: 'stopEditing' });
     setActiveEditor(null);
+  };
+
+  const handleToggleTileTesting = (tileId: string, shouldTest: boolean) => {
+    if (shouldTest) {
+      dispatch({ type: 'startTileTesting', tileId });
+    } else {
+      dispatch({ type: 'stopTileTesting' });
+    }
   };
 
   const handleToggleGrid = () => {
@@ -427,6 +438,8 @@ export const LessonEditor: React.FC<LessonEditorProps> = ({ lesson, course, onBa
                 tile={selectedTile}
                 onUpdateTile={handleUpdateTile}
                 onSelectTile={handleSelectTile}
+                isTesting={editorState.testingTileId === selectedTile?.id}
+                onToggleTesting={handleToggleTileTesting}
               />
             </div>
           ) : (

--- a/src/components/admin/InstructionPanel.tsx
+++ b/src/components/admin/InstructionPanel.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+
+interface InstructionPanelProps {
+  icon: React.ReactNode;
+  title: string;
+  className?: string;
+  containerStyle?: React.CSSProperties;
+  chipStyle?: React.CSSProperties;
+  titleStyle?: React.CSSProperties;
+  contentClassName?: string;
+  children: React.ReactNode;
+}
+
+const combineClassNames = (...classes: Array<string | undefined>): string =>
+  classes.filter(Boolean).join(' ');
+
+export const InstructionPanel: React.FC<InstructionPanelProps> = ({
+  icon,
+  title,
+  className,
+  containerStyle,
+  chipStyle,
+  titleStyle,
+  contentClassName,
+  children
+}) => {
+  return (
+    <div
+      className={combineClassNames(
+        'flex flex-col rounded-2xl border transition-colors duration-300 overflow-hidden',
+        className
+      )}
+      style={containerStyle}
+    >
+      <div className="px-5 pt-5 pb-3 flex items-center gap-3">
+        <div
+          className="w-9 h-9 rounded-xl flex items-center justify-center shadow-sm"
+          style={chipStyle}
+        >
+          {icon}
+        </div>
+        <div className="flex flex-col">
+          <span
+            className="text-lg uppercase tracking-[0.10em] font-semibold"
+            style={titleStyle}
+          >
+            {title}
+          </span>
+        </div>
+      </div>
+      <div className={combineClassNames('px-5 pb-5 h-full', contentClassName)}>
+        {children}
+      </div>
+    </div>
+  );
+};

--- a/src/components/admin/LessonCanvas.tsx
+++ b/src/components/admin/LessonCanvas.tsx
@@ -136,6 +136,7 @@ export const LessonCanvas = forwardRef<HTMLDivElement, LessonCanvasProps>(({
             onFinishTextEditing={onFinishTextEditing}
             showGrid={showGrid}
             onEditorReady={onEditorReady}
+            isTesting={editorState.testingTileId === tile.id}
           />
         ))}
 

--- a/src/components/admin/TileRenderer.tsx
+++ b/src/components/admin/TileRenderer.tsx
@@ -14,6 +14,7 @@ import OrderedList from '@tiptap/extension-ordered-list';
 import ListItem from '@tiptap/extension-list-item';
 import TextAlign from '../../extensions/TextAlign';
 import { SequencingInteractive } from './SequencingInteractive';
+import { InstructionPanel } from './InstructionPanel';
 
 const hexToRgb = (hex: string): { r: number; g: number; b: number } | null => {
   if (!hex) return null;
@@ -90,6 +91,7 @@ interface TileRendererProps {
   onFinishTextEditing: () => void;
   showGrid: boolean;
   onEditorReady: (editor: Editor | null) => void;
+  isTesting: boolean;
 }
 
 interface RichTextEditorProps {
@@ -218,7 +220,8 @@ export const TileRenderer: React.FC<TileRendererProps> = ({
   onDelete,
   onFinishTextEditing,
   showGrid,
-  onEditorReady
+  onEditorReady,
+  isTesting
 }) => {
   const [isHovered, setIsHovered] = useState(false);
 
@@ -446,27 +449,16 @@ export const TileRenderer: React.FC<TileRendererProps> = ({
         const codeLines = codeDisplayContent.split('\n');
 
         const renderDescriptionBlock = (content: React.ReactNode) => (
-          <div
-            className="flex-shrink-0 max-h-[45%] overflow-hidden rounded-2xl border transition-colors duration-300"
-            style={descriptionContainerStyle}
+          <InstructionPanel
+            icon={<Code2 className="w-4 h-4" />}
+            title="Zadanie"
+            className="flex-shrink-0 max-h-[45%]"
+            containerStyle={descriptionContainerStyle}
+            chipStyle={{ backgroundColor: chipBackground, color: textColor }}
+            titleStyle={{ color: mutedTextColor }}
           >
-            <div className="px-5 pt-5 pb-3 flex items-center gap-3">
-              <div
-                className="w-9 h-9 rounded-xl flex items-center justify-center shadow-sm"
-                style={{ backgroundColor: chipBackground, color: textColor }}
-              >
-                <Code2 className="w-4 h-4" />
-              </div>
-              <div className="flex flex-col">
-                <span className="text-lg uppercase tracking-[0.10em] font-semibold" style={{ color: mutedTextColor }}>
-                  Zadanie
-                </span>
-              </div>
-            </div>
-            <div className="px-5 pb-5 h-full">
-              {content}
-            </div>
-          </div>
+            {content}
+          </InstructionPanel>
         );
 
         // If this programming tile is being edited, use Tiptap editor for description
@@ -708,6 +700,16 @@ export const TileRenderer: React.FC<TileRendererProps> = ({
         const sequencingTile = tile as SequencingTile;
         const accentColor = sequencingTile.content.backgroundColor || '#0f172a';
         const textColor = getReadableTextColor(accentColor);
+        const instructionMutedColor = textColor === '#0f172a'
+          ? 'rgba(15, 23, 42, 0.68)'
+          : 'rgba(248, 250, 252, 0.82)';
+        const instructionChipBackground = withAlpha(textColor, textColor === '#0f172a' ? 0.16 : 0.36);
+        const instructionPanelStyle: React.CSSProperties = {
+          backgroundColor: lightenColor(accentColor, 0.05),
+          color: textColor,
+          border: `1px solid ${withAlpha(textColor, textColor === '#0f172a' ? 0.14 : 0.32)}`,
+          boxShadow: `0 22px 48px -32px ${withAlpha(textColor, textColor === '#0f172a' ? 0.28 : 0.55)}`
+        };
 
         if (isEditingText && isSelected) {
           const questionEditorTile = {
@@ -729,38 +731,35 @@ export const TileRenderer: React.FC<TileRendererProps> = ({
               tile={sequencingTile}
               isPreview
               headerSlot={
-                <div className="flex items-start justify-between gap-4">
-                  <div className="flex-1">
-                    <RichTextEditor
-                      textTile={questionEditorTile}
-                      tileId={tile.id}
-                      textColor={textColor}
-                      onUpdateTile={(tileId, updates) => {
-                        if (!updates.content) return;
+                <InstructionPanel
+                  icon={<Sparkles className="w-4 h-4" />}
+                  title="Zadanie"
+                  containerStyle={instructionPanelStyle}
+                  chipStyle={{ backgroundColor: instructionChipBackground, color: textColor }}
+                  titleStyle={{ color: instructionMutedColor }}
+                >
+                  <RichTextEditor
+                    textTile={questionEditorTile}
+                    tileId={tile.id}
+                    textColor={textColor}
+                    onUpdateTile={(tileId, updates) => {
+                      if (!updates.content) return;
 
-                        onUpdateTile(tileId, {
-                          content: {
-                            ...sequencingTile.content,
-                            question: updates.content.text ?? sequencingTile.content.question,
-                            richQuestion: updates.content.richText ?? sequencingTile.content.richQuestion,
-                            fontFamily: updates.content.fontFamily ?? sequencingTile.content.fontFamily,
-                            fontSize: updates.content.fontSize ?? sequencingTile.content.fontSize,
-                            verticalAlign: updates.content.verticalAlign ?? sequencingTile.content.verticalAlign
-                          }
-                        });
-                      }}
-                      onFinishTextEditing={onFinishTextEditing}
-                      onEditorReady={onEditorReady}
-                    />
-                  </div>
-                  <div
-                    className="flex items-center gap-2 text-xs font-medium"
-                    style={{ color: withAlpha(textColor, textColor === '#0f172a' ? 0.65 : 0.75) }}
-                  >
-                    <Sparkles className="w-4 h-4" />
-                    <span>Ćwiczenie sekwencyjne</span>
-                  </div>
-                </div>
+                      onUpdateTile(tileId, {
+                        content: {
+                          ...sequencingTile.content,
+                          question: updates.content.text ?? sequencingTile.content.question,
+                          richQuestion: updates.content.richText ?? sequencingTile.content.richQuestion,
+                          fontFamily: updates.content.fontFamily ?? sequencingTile.content.fontFamily,
+                          fontSize: updates.content.fontSize ?? sequencingTile.content.fontSize,
+                          verticalAlign: updates.content.verticalAlign ?? sequencingTile.content.verticalAlign
+                        }
+                      });
+                    }}
+                    onFinishTextEditing={onFinishTextEditing}
+                    onEditorReady={onEditorReady}
+                  />
+                </InstructionPanel>
               }
             />
           );
@@ -833,6 +832,7 @@ export const TileRenderer: React.FC<TileRendererProps> = ({
       onDoubleClick={tile.type === 'sequencing' ? undefined : onDoubleClick}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
+      data-testing={isTesting ? 'true' : undefined}
     >
       {/* Tile Content */}
       <div
@@ -853,7 +853,7 @@ export const TileRenderer: React.FC<TileRendererProps> = ({
       </div>
 
       {/* Tile Controls */}
-      {(isSelected || isHovered) && !isEditingText && !isImageEditing && (
+      {(isSelected || isHovered) && !isEditingText && !isImageEditing && !isTesting && (
         <div className="absolute -top-8 left-0 flex items-center space-x-1 bg-white rounded-md shadow-md border border-gray-200 px-2 py-1">
           <Move className="w-3 h-3 text-gray-500" />
           <span className="text-xs text-gray-600 capitalize">{tile.type}</span>
@@ -890,7 +890,7 @@ export const TileRenderer: React.FC<TileRendererProps> = ({
       )}
 
       {/* Resize Handles - Always Available When Selected */}
-      {!isEditingText && !isImageEditing && renderResizeHandles()}
+      {!isEditingText && !isImageEditing && !isTesting && renderResizeHandles()}
     </div>
   );
 };

--- a/src/components/admin/side editor/SequencingEditor.tsx
+++ b/src/components/admin/side editor/SequencingEditor.tsx
@@ -5,13 +5,20 @@ import { SequencingTile } from '../../../types/lessonEditor.ts';
 interface SequencingEditorProps {
   tile: SequencingTile;
   onUpdateTile: (tileId: string, updates: Partial<SequencingTile>) => void;
+  isTesting?: boolean;
+  onToggleTesting?: (tileId: string, shouldTest: boolean) => void;
 }
 
 export const SequencingEditor: React.FC<SequencingEditorProps> = ({
   tile,
-  onUpdateTile
+  onUpdateTile,
+  isTesting = false,
+  onToggleTesting
 }) => {
   const [draggedItem, setDraggedItem] = useState<string | null>(null);
+  const testingButtonClasses = isTesting
+    ? 'bg-emerald-600 text-white hover:bg-emerald-500'
+    : 'bg-white text-emerald-700 border border-emerald-200 hover:bg-emerald-100';
 
   const handleContentUpdate = (field: string, value: any) => {
     onUpdateTile(tile.id, {
@@ -98,8 +105,26 @@ export const SequencingEditor: React.FC<SequencingEditorProps> = ({
   return (
     <div className="space-y-6">
       <div className="p-4 rounded-lg border border-blue-100 bg-blue-50 text-sm text-blue-700">
-        Dwukrotnie kliknij kafelek, aby wybrać między testowaniem zadania a edycją polecenia w trybie RichText.
+        Dwukrotnie kliknij kafelek na płótnie, aby edytować polecenie. Użyj przycisku testowania, aby sprawdzić interakcję tak
+        jak uczeń.
       </div>
+
+      {onToggleTesting && (
+        <div className="p-4 rounded-lg border border-emerald-200 bg-emerald-50 space-y-3">
+          <div className="text-sm text-emerald-700">
+            {isTesting
+              ? 'Tryb testowania jest aktywny. Możesz przeciągać elementy w kafelku tak jak uczeń.'
+              : 'Możesz zatrzymać edycję i przetestować kafelek bez opuszczania edytora.'}
+          </div>
+          <button
+            type="button"
+            onClick={() => onToggleTesting(tile.id, !isTesting)}
+            className={`w-full px-4 py-2 rounded-lg font-semibold transition-colors ${testingButtonClasses}`}
+          >
+            {isTesting ? 'Zakończ testowanie' : 'Przetestuj zadanie'}
+          </button>
+        </div>
+      )}
 
       {/* Items Management */}
       <div>
@@ -126,8 +151,8 @@ export const SequencingEditor: React.FC<SequencingEditorProps> = ({
           </div>
         </div>
 
-        <div className="space-y-2 max-h-64 overflow-y-auto">
-          {tile.content.items.map((item, index) => (
+          <div className="space-y-2 max-h-64 overflow-y-auto">
+          {tile.content.items.map((item) => (
             <div
               key={item.id}
               draggable

--- a/src/components/admin/side editor/TileSideEditor.tsx
+++ b/src/components/admin/side editor/TileSideEditor.tsx
@@ -9,12 +9,16 @@ interface TileSideEditorProps {
   tile: LessonTile | undefined;
   onUpdateTile: (tileId: string, updates: Partial<LessonTile>) => void;
   onSelectTile?: (tileId: string | null) => void;
+  isTesting?: boolean;
+  onToggleTesting?: (tileId: string, shouldTest: boolean) => void;
 }
 
 export const TileSideEditor: React.FC<TileSideEditorProps> = ({
   tile,
   onUpdateTile,
-  onSelectTile
+  onSelectTile,
+  isTesting = false,
+  onToggleTesting
 }) => {
 
   if (!tile) {
@@ -256,7 +260,14 @@ export const TileSideEditor: React.FC<TileSideEditorProps> = ({
 
       case 'sequencing': {
         const sequencingTile = tile as SequencingTile;
-        return <SequencingEditor tile={sequencingTile} onUpdateTile={onUpdateTile} />;
+        return (
+          <SequencingEditor
+            tile={sequencingTile}
+            onUpdateTile={onUpdateTile as (tileId: string, updates: Partial<SequencingTile>) => void}
+            isTesting={isTesting}
+            onToggleTesting={onToggleTesting}
+          />
+        );
       }
 
       default:

--- a/src/hooks/useTileInteractions.ts
+++ b/src/hooks/useTileInteractions.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, RefObject } from 'react';
-import { LessonContent, LessonTile, GridPosition, EditorState, TextTile, ImageTile, SequencingTile } from '../types/lessonEditor';
+import { LessonContent, LessonTile, GridPosition, EditorState, TextTile, ImageTile } from '../types/lessonEditor';
 import { EditorAction } from '../state/editorReducer';
 import { GridUtils } from '../utils/gridUtils';
 import { logger } from '../utils/logger';
@@ -42,6 +42,9 @@ export const useTileInteractions = ({
     if (e.target === e.currentTarget) {
       onSelectTile(null);
       dispatch({ type: 'stopEditing' });
+      if (editorState.testingTileId) {
+        dispatch({ type: 'stopTileTesting' });
+      }
     }
   };
 
@@ -90,7 +93,11 @@ export const useTileInteractions = ({
   };
 
   const handleTileMouseDown = (e: React.MouseEvent, tile: LessonTile) => {
-    if (editorState.mode === 'textEditing' || editorState.mode === 'imageEditing') {
+    if (
+      editorState.mode === 'textEditing' ||
+      editorState.mode === 'imageEditing' ||
+      editorState.mode === 'testing'
+    ) {
       return;
     }
     e.preventDefault();

--- a/src/state/editorReducer.ts
+++ b/src/state/editorReducer.ts
@@ -13,7 +13,9 @@ export type EditorAction =
   | { type: 'toggleGrid' }
   | { type: 'markUnsaved' }
   | { type: 'clearUnsaved' }
-  | { type: 'setCanvasSize'; size: Size };
+  | { type: 'setCanvasSize'; size: Size }
+  | { type: 'startTileTesting'; tileId: string }
+  | { type: 'stopTileTesting' };
 
 export const initialEditorState: EditorState = {
   selectedTileId: null,
@@ -21,25 +23,31 @@ export const initialEditorState: EditorState = {
   interaction: { type: 'idle' },
   canvasSize: { width: 1000, height: 600 },
   hasUnsavedChanges: false,
-  showGrid: true
+  showGrid: true,
+  testingTileId: null
 };
 
 export function editorReducer(state: EditorState, action: EditorAction): EditorState {
   switch (action.type) {
     case 'selectTile':
-      return { ...state, selectedTileId: action.tileId, mode: action.tileId ? 'editing' : 'idle' };
+      return {
+        ...state,
+        selectedTileId: action.tileId,
+        mode: action.tileId ? 'editing' : 'idle',
+        testingTileId: action.tileId === state.testingTileId ? state.testingTileId : null
+      };
     case 'startEditing':
-      return { ...state, selectedTileId: action.tileId, mode: 'editing' };
+      return { ...state, selectedTileId: action.tileId, mode: 'editing', testingTileId: null };
     case 'startTextEditing':
-      return { ...state, selectedTileId: action.tileId, mode: 'textEditing' };
+      return { ...state, selectedTileId: action.tileId, mode: 'textEditing', testingTileId: null };
     case 'startImageEditing':
-      return { ...state, selectedTileId: action.tileId, mode: 'imageEditing' };
+      return { ...state, selectedTileId: action.tileId, mode: 'imageEditing', testingTileId: null };
     case 'stopEditing':
-      return { ...state, mode: state.selectedTileId ? 'editing' : 'idle' };
+      return { ...state, mode: state.selectedTileId ? 'editing' : 'idle', testingTileId: null };
     case 'startDrag':
-      return { ...state, mode: 'dragging', interaction: { type: 'drag', tile: action.tile, offset: action.offset } };
+      return { ...state, mode: 'dragging', interaction: { type: 'drag', tile: action.tile, offset: action.offset }, testingTileId: null };
     case 'startImageDrag':
-      return { ...state, mode: 'dragging', interaction: { type: 'imageDrag', start: action.start } };
+      return { ...state, mode: 'dragging', interaction: { type: 'imageDrag', start: action.start }, testingTileId: null };
     case 'startResize':
       return {
         ...state,
@@ -51,10 +59,11 @@ export function editorReducer(state: EditorState, action: EditorAction): EditorS
           startPosition: action.startPosition,
           startSize: action.startSize,
           startGridPosition: action.startGridPosition
-        }
+        },
+        testingTileId: null
       };
     case 'endInteraction':
-      return { ...state, mode: state.selectedTileId ? 'editing' : 'idle', interaction: { type: 'idle' } };
+      return { ...state, mode: state.selectedTileId ? 'editing' : 'idle', interaction: { type: 'idle' }, testingTileId: null };
     case 'toggleGrid':
       return { ...state, showGrid: !state.showGrid };
     case 'markUnsaved':
@@ -63,6 +72,10 @@ export function editorReducer(state: EditorState, action: EditorAction): EditorS
       return { ...state, hasUnsavedChanges: false };
     case 'setCanvasSize':
       return { ...state, canvasSize: action.size };
+    case 'startTileTesting':
+      return { ...state, selectedTileId: action.tileId, mode: 'testing', testingTileId: action.tileId };
+    case 'stopTileTesting':
+      return { ...state, mode: state.selectedTileId ? 'editing' : 'idle', testingTileId: null };
     default:
       return state;
   }

--- a/src/types/lessonEditor.ts
+++ b/src/types/lessonEditor.ts
@@ -149,7 +149,8 @@ export type EditorMode =
   | 'textEditing'
   | 'imageEditing'
   | 'dragging'
-  | 'resizing';
+  | 'resizing'
+  | 'testing';
 
 export type InteractionState =
   | { type: 'idle' }
@@ -171,6 +172,7 @@ export interface EditorState {
   canvasSize: Size;
   hasUnsavedChanges: boolean;
   showGrid: boolean;
+  testingTileId: string | null;
 }
 
 export interface TilePaletteItem {


### PR DESCRIPTION
## Summary
- extract a reusable InstructionPanel component for lesson tiles
- restyle the sequencing task tile to share the programming-style instruction header and simplify double-click behavior
- add a testing mode toggle in the side editor, wiring reducer, canvas, and tile renderer to lock layout while previewing the sequence

## Testing
- npm run lint *(fails: existing repository lint errors around legacy any usage)*

------
https://chatgpt.com/codex/tasks/task_e_68cd64afa418832190b9781681659acb