### PR TITLE
Rework sequencing task instructions and add testing toggle

### DIFF
--- a/src/Pages/LessonEditor.tsx
+++ b/src/Pages/LessonEditor.tsx
@@ -427,6 +427,8 @@ export const LessonEditor: React.FC<LessonEditorProps> = ({ lesson, course, onBa
                 tile={selectedTile}
                 onUpdateTile={handleUpdateTile}
                 onSelectTile={handleSelectTile}
+                editorState={editorState}
+                dispatch={dispatch}
               />
             </div>
           ) : (

--- a/src/components/admin/LessonCanvas.tsx
+++ b/src/components/admin/LessonCanvas.tsx
@@ -127,6 +127,7 @@ export const LessonCanvas = forwardRef<HTMLDivElement, LessonCanvasProps>(({
             isEditing={editorState.mode === 'editing' && editorState.selectedTileId === tile.id}
             isEditingText={editorState.mode === 'textEditing' && editorState.selectedTileId === tile.id}
             isImageEditing={editorState.mode === 'imageEditing' && editorState.selectedTileId === tile.id}
+            isTesting={editorState.mode === 'testing' && editorState.selectedTileId === tile.id}
             onMouseDown={(e) => handleTileMouseDown(e, tile)}
             onImageMouseDown={(e) => handleImageMouseDown(e, tile)}
             isDraggingImage={editorState.interaction.type === 'imageDrag'}

--- a/src/components/admin/TaskInstructionPanel.tsx
+++ b/src/components/admin/TaskInstructionPanel.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { Code2, LucideIcon } from 'lucide-react';
+
+interface TaskInstructionPanelProps {
+  icon?: LucideIcon;
+  title?: string;
+  textColor: string;
+  mutedTextColor?: string;
+  chipBackground?: string;
+  containerStyle?: React.CSSProperties;
+  className?: string;
+  metaSlot?: React.ReactNode;
+  onDoubleClick?: (event: React.MouseEvent<HTMLDivElement>) => void;
+  children: React.ReactNode;
+}
+
+export const TaskInstructionPanel: React.FC<TaskInstructionPanelProps> = ({
+  icon: Icon = Code2,
+  title = 'Zadanie',
+  textColor,
+  mutedTextColor,
+  chipBackground,
+  containerStyle,
+  className = '',
+  metaSlot,
+  onDoubleClick,
+  children
+}) => {
+  const resolvedMuted =
+    mutedTextColor ?? (textColor === '#0f172a' ? 'rgba(15, 23, 42, 0.65)' : 'rgba(248, 250, 252, 0.82)');
+  const resolvedChipBackground =
+    chipBackground ?? (textColor === '#0f172a' ? 'rgba(15, 23, 42, 0.12)' : 'rgba(248, 250, 252, 0.18)');
+
+  return (
+    <div
+      className={`flex-shrink-0 overflow-hidden rounded-2xl border transition-colors duration-300 ${className}`}
+      style={containerStyle}
+      onDoubleClick={onDoubleClick}
+    >
+      <div className="px-5 pt-5 pb-3 flex items-center justify-between gap-4">
+        <div className="flex items-center gap-3">
+          <div
+            className="w-9 h-9 rounded-xl flex items-center justify-center shadow-sm"
+            style={{ backgroundColor: resolvedChipBackground, color: textColor }}
+          >
+            <Icon className="w-4 h-4" />
+          </div>
+          <div className="flex flex-col">
+            <span className="text-lg uppercase tracking-[0.10em] font-semibold" style={{ color: resolvedMuted }}>
+              {title}
+            </span>
+          </div>
+        </div>
+        {metaSlot ? <div className="flex-shrink-0 text-xs font-medium" style={{ color: resolvedMuted }}>{metaSlot}</div> : null}
+      </div>
+      <div className="px-5 pb-5 h-full" style={{ color: textColor }}>
+        {children}
+      </div>
+    </div>
+  );
+};

--- a/src/components/admin/TileRenderer.tsx
+++ b/src/components/admin/TileRenderer.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { HelpCircle, Move, Trash2, Play, Square, Code2, Sparkles } from 'lucide-react';
+import { HelpCircle, Move, Trash2, Play, Square, Code2 } from 'lucide-react';
 import { LessonTile, TextTile, ImageTile, QuizTile, ProgrammingTile, SequencingTile } from '../../types/lessonEditor';
 import { GridUtils } from '../../utils/gridUtils';
 import { Editor, EditorContent, useEditor } from '@tiptap/react';
@@ -14,6 +14,7 @@ import OrderedList from '@tiptap/extension-ordered-list';
 import ListItem from '@tiptap/extension-list-item';
 import TextAlign from '../../extensions/TextAlign';
 import { SequencingInteractive } from './SequencingInteractive';
+import { TaskInstructionPanel } from './TaskInstructionPanel';
 
 const hexToRgb = (hex: string): { r: number; g: number; b: number } | null => {
   if (!hex) return null;
@@ -81,6 +82,7 @@ interface TileRendererProps {
   isEditing: boolean;
   isEditingText: boolean;
   isImageEditing: boolean;
+  isTesting: boolean;
   onMouseDown: (e: React.MouseEvent) => void;
   onImageMouseDown: (e: React.MouseEvent) => void;
   isDraggingImage: boolean;
@@ -209,6 +211,7 @@ export const TileRenderer: React.FC<TileRendererProps> = ({
   isSelected,
   isEditing,
   isImageEditing,
+  isTesting,
   onMouseDown,
   onImageMouseDown,
   isDraggingImage,
@@ -445,36 +448,18 @@ export const TileRenderer: React.FC<TileRendererProps> = ({
         
         const codeLines = codeDisplayContent.split('\n');
 
-        const renderDescriptionBlock = (content: React.ReactNode) => (
-          <div
-            className="flex-shrink-0 max-h-[45%] overflow-hidden rounded-2xl border transition-colors duration-300"
-            style={descriptionContainerStyle}
-          >
-            <div className="px-5 pt-5 pb-3 flex items-center gap-3">
-              <div
-                className="w-9 h-9 rounded-xl flex items-center justify-center shadow-sm"
-                style={{ backgroundColor: chipBackground, color: textColor }}
-              >
-                <Code2 className="w-4 h-4" />
-              </div>
-              <div className="flex flex-col">
-                <span className="text-lg uppercase tracking-[0.10em] font-semibold" style={{ color: mutedTextColor }}>
-                  Zadanie
-                </span>
-              </div>
-            </div>
-            <div className="px-5 pb-5 h-full">
-              {content}
-            </div>
-          </div>
-        );
-
         // If this programming tile is being edited, use Tiptap editor for description
         if (isEditingText && isSelected) {
           contentToRender = (
             <div className="w-full h-full flex flex-col rounded-2xl transition-all duration-300" style={containerStyle}>
               <div className="flex flex-col flex-1 gap-5 p-5">
-                {renderDescriptionBlock(
+                <TaskInstructionPanel
+                  textColor={textColor}
+                  mutedTextColor={mutedTextColor}
+                  chipBackground={chipBackground}
+                  containerStyle={descriptionContainerStyle}
+                  className="max-h-[45%]"
+                >
                   <RichTextEditor
                     textTile={{
                       ...tile,
@@ -505,7 +490,7 @@ export const TileRenderer: React.FC<TileRendererProps> = ({
                     onFinishTextEditing={onFinishTextEditing}
                     onEditorReady={onEditorReady}
                   />
-                )}
+                </TaskInstructionPanel>
 
                 <div
                   className="flex-1 flex flex-col rounded-2xl overflow-hidden border backdrop-blur-sm transition-colors duration-300"
@@ -592,7 +577,13 @@ export const TileRenderer: React.FC<TileRendererProps> = ({
           contentToRender = (
             <div className="w-full h-full flex flex-col rounded-2xl transition-all duration-300" style={containerStyle}>
               <div className="flex flex-col flex-1 gap-5 p-5">
-                {renderDescriptionBlock(
+                <TaskInstructionPanel
+                  textColor={textColor}
+                  mutedTextColor={mutedTextColor}
+                  chipBackground={chipBackground}
+                  containerStyle={descriptionContainerStyle}
+                  className="max-h-[45%]"
+                >
                   <div
                     className="break-words rich-text-content tile-formatted-text w-full h-full overflow-auto"
                     style={{
@@ -606,7 +597,7 @@ export const TileRenderer: React.FC<TileRendererProps> = ({
                       __html: programmingTile.content.richDescription || `<p style="margin: 0;">${programmingTile.content.description || 'Kliknij dwukrotnie, aby edytować opis zadania'}</p>`
                     }}
                   />
-                )}
+                </TaskInstructionPanel>
 
                 <div
                   className="flex-1 flex flex-col rounded-2xl overflow-hidden border backdrop-blur-sm transition-colors duration-300"
@@ -729,44 +720,33 @@ export const TileRenderer: React.FC<TileRendererProps> = ({
               tile={sequencingTile}
               isPreview
               headerSlot={
-                <div className="flex items-start justify-between gap-4">
-                  <div className="flex-1">
-                    <RichTextEditor
-                      textTile={questionEditorTile}
-                      tileId={tile.id}
-                      textColor={textColor}
-                      onUpdateTile={(tileId, updates) => {
-                        if (!updates.content) return;
+                <RichTextEditor
+                  textTile={questionEditorTile}
+                  tileId={tile.id}
+                  textColor={textColor}
+                  onUpdateTile={(tileId, updates) => {
+                    if (!updates.content) return;
 
-                        onUpdateTile(tileId, {
-                          content: {
-                            ...sequencingTile.content,
-                            question: updates.content.text ?? sequencingTile.content.question,
-                            richQuestion: updates.content.richText ?? sequencingTile.content.richQuestion,
-                            fontFamily: updates.content.fontFamily ?? sequencingTile.content.fontFamily,
-                            fontSize: updates.content.fontSize ?? sequencingTile.content.fontSize,
-                            verticalAlign: updates.content.verticalAlign ?? sequencingTile.content.verticalAlign
-                          }
-                        });
-                      }}
-                      onFinishTextEditing={onFinishTextEditing}
-                      onEditorReady={onEditorReady}
-                    />
-                  </div>
-                  <div
-                    className="flex items-center gap-2 text-xs font-medium"
-                    style={{ color: withAlpha(textColor, textColor === '#0f172a' ? 0.65 : 0.75) }}
-                  >
-                    <Sparkles className="w-4 h-4" />
-                    <span>Ćwiczenie sekwencyjne</span>
-                  </div>
-                </div>
+                    onUpdateTile(tileId, {
+                      content: {
+                        ...sequencingTile.content,
+                        question: updates.content.text ?? sequencingTile.content.question,
+                        richQuestion: updates.content.richText ?? sequencingTile.content.richQuestion,
+                        fontFamily: updates.content.fontFamily ?? sequencingTile.content.fontFamily,
+                        fontSize: updates.content.fontSize ?? sequencingTile.content.fontSize,
+                        verticalAlign: updates.content.verticalAlign ?? sequencingTile.content.verticalAlign
+                      }
+                    });
+                  }}
+                  onFinishTextEditing={onFinishTextEditing}
+                  onEditorReady={onEditorReady}
+                />
               }
             />
           );
         } else {
           contentToRender = (
-            <SequencingInteractive tile={sequencingTile} onRequestTextEditing={onDoubleClick} />
+            <SequencingInteractive tile={sequencingTile} />
           );
         }
         break;
@@ -784,7 +764,7 @@ export const TileRenderer: React.FC<TileRendererProps> = ({
     return contentToRender;
   };
   const renderResizeHandles = () => {
-    if (!isSelected || isEditingText || isImageEditing) return null;
+    if (!isSelected || isEditingText || isImageEditing || isTesting) return null;
 
     const handles = GridUtils.getResizeHandles(tile.gridPosition);
     
@@ -830,7 +810,7 @@ export const TileRenderer: React.FC<TileRendererProps> = ({
         height: tile.size.height
       }}
       onMouseDown={isDraggingImage ? undefined : onMouseDown}
-      onDoubleClick={tile.type === 'sequencing' ? undefined : onDoubleClick}
+        onDoubleClick={onDoubleClick}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
     >
@@ -853,7 +833,7 @@ export const TileRenderer: React.FC<TileRendererProps> = ({
       </div>
 
       {/* Tile Controls */}
-      {(isSelected || isHovered) && !isEditingText && !isImageEditing && (
+      {(isSelected || isHovered) && !isEditingText && !isImageEditing && !isTesting && (
         <div className="absolute -top-8 left-0 flex items-center space-x-1 bg-white rounded-md shadow-md border border-gray-200 px-2 py-1">
           <Move className="w-3 h-3 text-gray-500" />
           <span className="text-xs text-gray-600 capitalize">{tile.type}</span>

--- a/src/components/admin/side editor/TileSideEditor.tsx
+++ b/src/components/admin/side editor/TileSideEditor.tsx
@@ -1,20 +1,32 @@
 import React from 'react';
 import { Type, X } from 'lucide-react';
-import { TextTile, ImageTile, LessonTile, ProgrammingTile, SequencingTile } from '../../../types/lessonEditor.ts';
+import {
+  TextTile,
+  ImageTile,
+  LessonTile,
+  ProgrammingTile,
+  SequencingTile,
+  EditorState
+} from '../../../types/lessonEditor.ts';
 import { ImageUploadComponent } from './ImageUploadComponent.tsx';
 import { ImagePositionControl } from './ImagePositionControl.tsx';
 import { SequencingEditor } from './SequencingEditor.tsx';
+import { EditorAction } from '../../../state/editorReducer.ts';
 
 interface TileSideEditorProps {
   tile: LessonTile | undefined;
   onUpdateTile: (tileId: string, updates: Partial<LessonTile>) => void;
   onSelectTile?: (tileId: string | null) => void;
+  editorState: EditorState;
+  dispatch: React.Dispatch<EditorAction>;
 }
 
 export const TileSideEditor: React.FC<TileSideEditorProps> = ({
   tile,
   onUpdateTile,
-  onSelectTile
+  onSelectTile,
+  editorState,
+  dispatch
 }) => {
 
   if (!tile) {
@@ -268,6 +280,21 @@ export const TileSideEditor: React.FC<TileSideEditorProps> = ({
     }
   };
 
+  const isSequencingTile = tile.type === 'sequencing';
+  const isTestingTile =
+    isSequencingTile && editorState.mode === 'testing' && editorState.selectedTileId === tile.id;
+
+  const handleToggleTesting = () => {
+    if (!isSequencingTile) return;
+
+    if (isTestingTile) {
+      dispatch({ type: 'stopTesting' });
+    } else {
+      dispatch({ type: 'startTesting', tileId: tile.id });
+      onSelectTile?.(tile.id);
+    }
+  };
+
   return (
     <div className="h-full flex flex-col">
       {/* Header */}
@@ -294,6 +321,27 @@ export const TileSideEditor: React.FC<TileSideEditorProps> = ({
 
       {/* Properties Panel */}
       <div className="flex-1 overflow-y-auto p-6 space-y-6">
+        {isSequencingTile && (
+          <div className="rounded-xl border border-slate-200 bg-slate-50 p-4 space-y-3">
+            <div className="space-y-1">
+              <h4 className="text-sm font-semibold text-slate-900">Tryb testowania</h4>
+              <p className="text-xs text-slate-600">
+                Zablokuj pozycję kafelka i sprawdź działanie przeciągania tak jak uczeń.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={handleToggleTesting}
+              className={`w-full px-4 py-2 rounded-lg text-sm font-medium transition-colors duration-200 ${
+                isTestingTile
+                  ? 'bg-slate-900 text-slate-100 hover:bg-slate-800'
+                  : 'bg-blue-600 text-white hover:bg-blue-500'
+              }`}
+            >
+              {isTestingTile ? 'Zakończ testowanie' : 'Przetestuj zadanie'}
+            </button>
+          </div>
+        )}
         {renderContentEditor()}
       </div>
 

--- a/src/hooks/useTileInteractions.ts
+++ b/src/hooks/useTileInteractions.ts
@@ -90,7 +90,11 @@ export const useTileInteractions = ({
   };
 
   const handleTileMouseDown = (e: React.MouseEvent, tile: LessonTile) => {
-    if (editorState.mode === 'textEditing' || editorState.mode === 'imageEditing') {
+    if (
+      editorState.mode === 'textEditing' ||
+      editorState.mode === 'imageEditing' ||
+      editorState.mode === 'testing'
+    ) {
       return;
     }
     e.preventDefault();

--- a/src/state/editorReducer.ts
+++ b/src/state/editorReducer.ts
@@ -5,6 +5,8 @@ export type EditorAction =
   | { type: 'startEditing'; tileId: string }
   | { type: 'startTextEditing'; tileId: string }
   | { type: 'startImageEditing'; tileId: string }
+  | { type: 'startTesting'; tileId: string }
+  | { type: 'stopTesting' }
   | { type: 'stopEditing' }
   | { type: 'startDrag'; tile: LessonTile; offset: Position }
   | { type: 'startImageDrag'; start: { x: number; y: number; imageX: number; imageY: number } }
@@ -34,6 +36,10 @@ export function editorReducer(state: EditorState, action: EditorAction): EditorS
       return { ...state, selectedTileId: action.tileId, mode: 'textEditing' };
     case 'startImageEditing':
       return { ...state, selectedTileId: action.tileId, mode: 'imageEditing' };
+    case 'startTesting':
+      return { ...state, selectedTileId: action.tileId, mode: 'testing', interaction: { type: 'idle' } };
+    case 'stopTesting':
+      return { ...state, mode: state.selectedTileId ? 'editing' : 'idle', interaction: { type: 'idle' } };
     case 'stopEditing':
       return { ...state, mode: state.selectedTileId ? 'editing' : 'idle' };
     case 'startDrag':

--- a/src/types/lessonEditor.ts
+++ b/src/types/lessonEditor.ts
@@ -148,6 +148,7 @@ export type EditorMode =
   | 'editing'
   | 'textEditing'
   | 'imageEditing'
+  | 'testing'
   | 'dragging'
   | 'resizing';
 


### PR DESCRIPTION
## Summary
- create a reusable task instruction panel and apply it to programming and sequencing tiles
- restyle the sequencing tile header to match programming tasks and remove the redundant action prompt
- add a testing toggle in the side editor that locks tile movement while previewing the sequencing task

## Testing
- npm run lint *(fails: existing TypeScript lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cd64afa418832190b9781681659acb