### PR TITLE
Refine sequencing task tile instructions and preview

### DIFF
--- a/src/Pages/LessonEditor.tsx
+++ b/src/Pages/LessonEditor.tsx
@@ -247,6 +247,14 @@ export const LessonEditor: React.FC<LessonEditorProps> = ({ lesson, course, onBa
     dispatch({ type: 'selectTile', tileId });
   };
 
+  const handleStartTileTesting = (tileId: string) => {
+    dispatch({ type: 'startTestingTile', tileId });
+  };
+
+  const handleStopTileTesting = () => {
+    dispatch({ type: 'stopTestingTile' });
+  };
+
   const handleFinishTextEditing = () => {
     dispatch({ type: 'stopEditing' });
     setActiveEditor(null);
@@ -427,6 +435,9 @@ export const LessonEditor: React.FC<LessonEditorProps> = ({ lesson, course, onBa
                 tile={selectedTile}
                 onUpdateTile={handleUpdateTile}
                 onSelectTile={handleSelectTile}
+                onStartTestingTile={handleStartTileTesting}
+                onStopTestingTile={handleStopTileTesting}
+                testingTileId={editorState.testingTileId}
               />
             </div>
           ) : (

--- a/src/components/admin/LessonCanvas.tsx
+++ b/src/components/admin/LessonCanvas.tsx
@@ -119,25 +119,33 @@ export const LessonCanvas = forwardRef<HTMLDivElement, LessonCanvasProps>(({
         {renderDragPreview()}
 
         {/* Render Tiles */}
-        {content.tiles.map((tile) => (
-          <TileRenderer
-            key={tile.id}
-            tile={tile}
-            isSelected={editorState.selectedTileId === tile.id}
-            isEditing={editorState.mode === 'editing' && editorState.selectedTileId === tile.id}
-            isEditingText={editorState.mode === 'textEditing' && editorState.selectedTileId === tile.id}
-            isImageEditing={editorState.mode === 'imageEditing' && editorState.selectedTileId === tile.id}
-            onMouseDown={(e) => handleTileMouseDown(e, tile)}
-            onImageMouseDown={(e) => handleImageMouseDown(e, tile)}
-            isDraggingImage={editorState.interaction.type === 'imageDrag'}
-            onDoubleClick={() => handleTileDoubleClick(tile)}
-            onUpdateTile={onUpdateTile}
-            onDelete={onDeleteTile}
-            onFinishTextEditing={onFinishTextEditing}
-            showGrid={showGrid}
-            onEditorReady={onEditorReady}
-          />
-        ))}
+        {content.tiles.map((tile) => {
+          const isTileBeingTested = editorState.testingTileId === tile.id;
+
+          return (
+            <TileRenderer
+              key={tile.id}
+              tile={tile}
+              isSelected={editorState.selectedTileId === tile.id}
+              isEditing={
+                (editorState.mode === 'editing' || editorState.mode === 'testing') &&
+                editorState.selectedTileId === tile.id
+              }
+              isEditingText={editorState.mode === 'textEditing' && editorState.selectedTileId === tile.id}
+              isImageEditing={editorState.mode === 'imageEditing' && editorState.selectedTileId === tile.id}
+              isTestingTile={isTileBeingTested}
+              onMouseDown={isTileBeingTested ? undefined : (e) => handleTileMouseDown(e, tile)}
+              onImageMouseDown={(e) => handleImageMouseDown(e, tile)}
+              isDraggingImage={editorState.interaction.type === 'imageDrag'}
+              onDoubleClick={() => handleTileDoubleClick(tile)}
+              onUpdateTile={onUpdateTile}
+              onDelete={onDeleteTile}
+              onFinishTextEditing={onFinishTextEditing}
+              showGrid={showGrid}
+              onEditorReady={onEditorReady}
+            />
+          );
+        })}
 
         {/* Empty State */}
         {content.tiles.length === 0 && (

--- a/src/components/admin/SequencingInteractive.tsx
+++ b/src/components/admin/SequencingInteractive.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo, useCallback, useRef } from 'react';
+import React, { useState, useMemo, useCallback } from 'react';
 import {
   CheckCircle,
   XCircle,
@@ -6,9 +6,11 @@ import {
   Sparkles,
   Shuffle,
   ArrowLeftRight,
-  GripVertical
+  GripVertical,
+  Code2
 } from 'lucide-react';
 import { SequencingTile } from '../../types/lessonEditor';
+import { TileInstructionPanel } from './TileInstructionPanel';
 
 interface SequencingInteractiveProps {
   tile: SequencingTile;
@@ -107,9 +109,6 @@ export const SequencingInteractive: React.FC<SequencingInteractiveProps> = ({
   const [dragState, setDragState] = useState<DragState | null>(null);
   const [dragOverSlot, setDragOverSlot] = useState<number | null>(null);
   const [isPoolHighlighted, setIsPoolHighlighted] = useState(false);
-  const [isModePromptVisible, setIsModePromptVisible] = useState(false);
-  const modePromptRef = useRef<HTMLDivElement>(null);
-
   const canInteract = !isPreview;
   const sequenceComplete = placedItems.length > 0 && placedItems.every(item => item !== null);
 
@@ -173,30 +172,6 @@ export const SequencingInteractive: React.FC<SequencingInteractiveProps> = ({
     setIsCorrect(null);
     setAttempts(0);
   }, [buildInitialPool]);
-
-  useEffect(() => {
-    if (!isModePromptVisible) return;
-
-    const handleClickOutside = (event: MouseEvent) => {
-      if (modePromptRef.current && !modePromptRef.current.contains(event.target as Node)) {
-        setIsModePromptVisible(false);
-      }
-    };
-
-    const handleEscape = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        setIsModePromptVisible(false);
-      }
-    };
-
-    document.addEventListener('mousedown', handleClickOutside);
-    document.addEventListener('keydown', handleEscape);
-
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-      document.removeEventListener('keydown', handleEscape);
-    };
-  }, [isModePromptVisible]);
 
   const resetCheckState = () => {
     if (isChecked) {
@@ -396,17 +371,76 @@ export const SequencingInteractive: React.FC<SequencingInteractiveProps> = ({
 
     event.preventDefault();
     event.stopPropagation();
-    if (!onRequestTextEditing) {
-      return;
-    }
-
-    setIsModePromptVisible(true);
-  };
-
-  const handleEditSelection = () => {
-    setIsModePromptVisible(false);
     onRequestTextEditing?.();
   };
+
+  const instructionBorderColor = useMemo(
+    () => withAlpha(textColor, textColor === '#0f172a' ? 0.18 : 0.24),
+    [textColor]
+  );
+
+  const instructionBackground = useMemo(
+    () => withAlpha(textColor, textColor === '#0f172a' ? 0.12 : 0.18),
+    [textColor]
+  );
+
+  const instructionIconBackground = useMemo(
+    () => withAlpha(textColor, textColor === '#0f172a' ? 0.14 : 0.26),
+    [textColor]
+  );
+
+  const instructionLabelColor = useMemo(
+    () => withAlpha(textColor, textColor === '#0f172a' ? 0.7 : 0.85),
+    [textColor]
+  );
+
+  const instructionTextColor = useMemo(
+    () => withAlpha(textColor, textColor === '#0f172a' ? 0.9 : 0.96),
+    [textColor]
+  );
+
+  const instructionMeta = (
+    <div
+      className="flex items-center gap-2 text-xs font-medium"
+      style={{ color: withAlpha(textColor, textColor === '#0f172a' ? 0.65 : 0.75) }}
+    >
+      <Sparkles className="w-4 h-4" />
+      <span>Ćwiczenie sekwencyjne</span>
+    </div>
+  );
+
+  const instructionPanel = headerSlot ?? (
+    <div
+      className="rounded-2xl border backdrop-blur-sm"
+      style={{
+        borderColor: instructionBorderColor,
+        backgroundColor: instructionBackground
+      }}
+    >
+      <TileInstructionPanel
+        icon={Code2}
+        label="Zadanie"
+        className="px-5 pt-5 pb-4"
+        contentClassName="text-sm lg:text-base"
+        iconBackground={instructionIconBackground}
+        iconColor={textColor}
+        labelColor={instructionLabelColor}
+        meta={instructionMeta}
+      >
+        <div
+          className="font-medium leading-relaxed"
+          style={{
+            fontFamily: tile.content.fontFamily,
+            fontSize: `${tile.content.fontSize}px`,
+            color: instructionTextColor
+          }}
+          dangerouslySetInnerHTML={{
+            __html: tile.content.richQuestion || tile.content.question
+          }}
+        />
+      </TileInstructionPanel>
+    </div>
+  );
 
   return (
     <div className="relative w-full h-full" onDoubleClick={handleTileDoubleClick}>
@@ -419,27 +453,7 @@ export const SequencingInteractive: React.FC<SequencingInteractiveProps> = ({
           borderColor: showBorder ? borderColor : undefined
         }}
       >
-        {headerSlot ? (
-          headerSlot
-        ) : (
-          <div className="flex items-start justify-between gap-4">
-            <div
-              className="text-lg font-semibold leading-snug flex-1"
-              style={{
-                fontFamily: tile.content.fontFamily,
-                fontSize: `${tile.content.fontSize}px`
-              }}
-              dangerouslySetInnerHTML={{
-                __html: tile.content.richQuestion || tile.content.question
-              }}
-            />
-
-            <div className="flex items-center gap-2 text-xs font-medium" style={{ color: withAlpha(textColor, 0.7) }}>
-              <Sparkles className="w-4 h-4" />
-              <span>Ćwiczenie sekwencyjne</span>
-            </div>
-          </div>
-        )}
+        {instructionPanel}
 
         {attempts > 0 && (
           <div className="text-xs uppercase tracking-[0.32em]" style={{ color: withAlpha(textColor, 0.55) }}>
@@ -597,49 +611,6 @@ export const SequencingInteractive: React.FC<SequencingInteractiveProps> = ({
         )}
       </div>
 
-      {isModePromptVisible && (
-        <div className="absolute inset-0 z-20 flex items-center justify-center bg-black/40 backdrop-blur-[2px]">
-          <div
-            ref={modePromptRef}
-            className="w-full max-w-md mx-4 rounded-2xl bg-white shadow-2xl border border-slate-200 p-6 space-y-4"
-          >
-            <div className="space-y-1">
-              <h3 className="text-lg font-semibold text-slate-900">Co chcesz zrobić?</h3>
-              <p className="text-sm text-slate-500">
-                Możesz przetestować zadanie jak uczeń lub przejść do edycji polecenia w trybie RichText.
-              </p>
-            </div>
-
-            <div className="grid gap-3">
-              <button
-                type="button"
-                className="w-full px-4 py-3 rounded-xl border border-slate-200 bg-slate-50 text-slate-700 hover:bg-slate-100 transition-colors duration-200 flex items-center justify-between"
-                onClick={() => setIsModePromptVisible(false)}
-              >
-                <span className="font-medium">Przetestuj zadanie</span>
-                <Sparkles className="w-4 h-4 text-slate-400" />
-              </button>
-
-              <button
-                type="button"
-                className="w-full px-4 py-3 rounded-xl bg-blue-600 text-white hover:bg-blue-500 transition-colors duration-200 flex items-center justify-between"
-                onClick={handleEditSelection}
-              >
-                <span className="font-medium">Edytuj polecenie</span>
-                <Shuffle className="w-4 h-4 text-white/90" />
-              </button>
-            </div>
-
-            <button
-              type="button"
-              className="w-full text-sm text-slate-400 hover:text-slate-600 transition-colors duration-200"
-              onClick={() => setIsModePromptVisible(false)}
-            >
-              Anuluj
-            </button>
-          </div>
-        </div>
-      )}
     </div>
   );
 };

--- a/src/components/admin/TileInstructionPanel.tsx
+++ b/src/components/admin/TileInstructionPanel.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import type { LucideIcon } from 'lucide-react';
+
+interface TileInstructionPanelProps {
+  icon: LucideIcon;
+  label: string;
+  children: React.ReactNode;
+  className?: string;
+  contentClassName?: string;
+  iconBackground?: string;
+  iconColor?: string;
+  labelColor?: string;
+  meta?: React.ReactNode;
+}
+
+const combineClasses = (...classes: Array<string | undefined>) =>
+  classes.filter(Boolean).join(' ');
+
+export const TileInstructionPanel: React.FC<TileInstructionPanelProps> = ({
+  icon: Icon,
+  label,
+  children,
+  className,
+  contentClassName,
+  iconBackground,
+  iconColor,
+  labelColor,
+  meta
+}) => {
+  return (
+    <div className={combineClasses('flex flex-col', className)}>
+      <div className="flex items-start justify-between gap-4 pb-3">
+        <div className="flex items-center gap-3">
+          <div
+            className="w-9 h-9 rounded-xl flex items-center justify-center shadow-sm"
+            style={{ backgroundColor: iconBackground, color: iconColor }}
+          >
+            <Icon className="w-4 h-4" />
+          </div>
+          <span
+            className="text-lg uppercase tracking-[0.10em] font-semibold"
+            style={{ color: labelColor }}
+          >
+            {label}
+          </span>
+        </div>
+        {meta ? <div className="flex-shrink-0">{meta}</div> : null}
+      </div>
+
+      <div className={combineClasses('leading-relaxed', contentClassName)}>{children}</div>
+    </div>
+  );
+};

--- a/src/components/admin/TileRenderer.tsx
+++ b/src/components/admin/TileRenderer.tsx
@@ -14,6 +14,7 @@ import OrderedList from '@tiptap/extension-ordered-list';
 import ListItem from '@tiptap/extension-list-item';
 import TextAlign from '../../extensions/TextAlign';
 import { SequencingInteractive } from './SequencingInteractive';
+import { TileInstructionPanel } from './TileInstructionPanel';
 
 const hexToRgb = (hex: string): { r: number; g: number; b: number } | null => {
   if (!hex) return null;
@@ -79,6 +80,7 @@ interface TileRendererProps {
   tile: LessonTile;
   isSelected: boolean;
   isEditing: boolean;
+  isTestingTile: boolean;
   isEditingText: boolean;
   isImageEditing: boolean;
   onMouseDown: (e: React.MouseEvent) => void;
@@ -208,6 +210,7 @@ export const TileRenderer: React.FC<TileRendererProps> = ({
   tile,
   isSelected,
   isEditing,
+  isTestingTile,
   isImageEditing,
   onMouseDown,
   onImageMouseDown,
@@ -450,22 +453,17 @@ export const TileRenderer: React.FC<TileRendererProps> = ({
             className="flex-shrink-0 max-h-[45%] overflow-hidden rounded-2xl border transition-colors duration-300"
             style={descriptionContainerStyle}
           >
-            <div className="px-5 pt-5 pb-3 flex items-center gap-3">
-              <div
-                className="w-9 h-9 rounded-xl flex items-center justify-center shadow-sm"
-                style={{ backgroundColor: chipBackground, color: textColor }}
-              >
-                <Code2 className="w-4 h-4" />
-              </div>
-              <div className="flex flex-col">
-                <span className="text-lg uppercase tracking-[0.10em] font-semibold" style={{ color: mutedTextColor }}>
-                  Zadanie
-                </span>
-              </div>
-            </div>
-            <div className="px-5 pb-5 h-full">
+            <TileInstructionPanel
+              icon={Code2}
+              label="Zadanie"
+              className="px-5 pt-5 pb-5 h-full"
+              contentClassName="h-full text-sm leading-relaxed text-slate-100"
+              iconBackground={chipBackground}
+              iconColor={textColor}
+              labelColor={mutedTextColor}
+            >
               {content}
-            </div>
+            </TileInstructionPanel>
           </div>
         );
 
@@ -709,6 +707,12 @@ export const TileRenderer: React.FC<TileRendererProps> = ({
         const accentColor = sequencingTile.content.backgroundColor || '#0f172a';
         const textColor = getReadableTextColor(accentColor);
 
+        const instructionBorderColor = withAlpha(textColor, textColor === '#0f172a' ? 0.18 : 0.24);
+        const instructionBackground = withAlpha(textColor, textColor === '#0f172a' ? 0.12 : 0.18);
+        const instructionIconBackground = withAlpha(textColor, textColor === '#0f172a' ? 0.14 : 0.26);
+        const instructionLabelColor = withAlpha(textColor, textColor === '#0f172a' ? 0.7 : 0.85);
+        const instructionMetaColor = withAlpha(textColor, textColor === '#0f172a' ? 0.65 : 0.75);
+
         if (isEditingText && isSelected) {
           const questionEditorTile = {
             ...tile,
@@ -729,8 +733,28 @@ export const TileRenderer: React.FC<TileRendererProps> = ({
               tile={sequencingTile}
               isPreview
               headerSlot={
-                <div className="flex items-start justify-between gap-4">
-                  <div className="flex-1">
+                <div
+                  className="rounded-2xl border backdrop-blur-sm"
+                  style={{
+                    borderColor: instructionBorderColor,
+                    backgroundColor: instructionBackground
+                  }}
+                >
+                  <TileInstructionPanel
+                    icon={Code2}
+                    label="Zadanie"
+                    className="px-5 pt-5 pb-4"
+                    contentClassName="text-sm lg:text-base"
+                    iconBackground={instructionIconBackground}
+                    iconColor={textColor}
+                    labelColor={instructionLabelColor}
+                    meta={(
+                      <div className="flex items-center gap-2 text-xs font-medium" style={{ color: instructionMetaColor }}>
+                        <Sparkles className="w-4 h-4" />
+                        <span>Ćwiczenie sekwencyjne</span>
+                      </div>
+                    )}
+                  >
                     <RichTextEditor
                       textTile={questionEditorTile}
                       tileId={tile.id}
@@ -752,14 +776,7 @@ export const TileRenderer: React.FC<TileRendererProps> = ({
                       onFinishTextEditing={onFinishTextEditing}
                       onEditorReady={onEditorReady}
                     />
-                  </div>
-                  <div
-                    className="flex items-center gap-2 text-xs font-medium"
-                    style={{ color: withAlpha(textColor, textColor === '#0f172a' ? 0.65 : 0.75) }}
-                  >
-                    <Sparkles className="w-4 h-4" />
-                    <span>Ćwiczenie sekwencyjne</span>
-                  </div>
+                  </TileInstructionPanel>
                 </div>
               }
             />
@@ -784,7 +801,7 @@ export const TileRenderer: React.FC<TileRendererProps> = ({
     return contentToRender;
   };
   const renderResizeHandles = () => {
-    if (!isSelected || isEditingText || isImageEditing) return null;
+    if (!isSelected || isEditingText || isImageEditing || isTestingTile) return null;
 
     const handles = GridUtils.getResizeHandles(tile.gridPosition);
     
@@ -815,7 +832,7 @@ export const TileRenderer: React.FC<TileRendererProps> = ({
   return (
     <div
       className={`absolute select-none transition-all duration-200 ${
-        isEditing || isImageEditing || isEditingText ? 'z-20' : 'z-10'
+        isEditing || isImageEditing || isEditingText || isTestingTile ? 'z-20' : 'z-10'
       } ${
         isSelected ? 'ring-2 ring-blue-500 ring-opacity-75' : ''
       } ${
@@ -853,7 +870,7 @@ export const TileRenderer: React.FC<TileRendererProps> = ({
       </div>
 
       {/* Tile Controls */}
-      {(isSelected || isHovered) && !isEditingText && !isImageEditing && (
+      {(isSelected || isHovered) && !isEditingText && !isImageEditing && !isTestingTile && (
         <div className="absolute -top-8 left-0 flex items-center space-x-1 bg-white rounded-md shadow-md border border-gray-200 px-2 py-1">
           <Move className="w-3 h-3 text-gray-500" />
           <span className="text-xs text-gray-600 capitalize">{tile.type}</span>

--- a/src/components/admin/side editor/SequencingEditor.tsx
+++ b/src/components/admin/side editor/SequencingEditor.tsx
@@ -5,11 +5,13 @@ import { SequencingTile } from '../../../types/lessonEditor.ts';
 interface SequencingEditorProps {
   tile: SequencingTile;
   onUpdateTile: (tileId: string, updates: Partial<SequencingTile>) => void;
+  isTesting?: boolean;
 }
 
 export const SequencingEditor: React.FC<SequencingEditorProps> = ({
   tile,
-  onUpdateTile
+  onUpdateTile,
+  isTesting = false
 }) => {
   const [draggedItem, setDraggedItem] = useState<string | null>(null);
 
@@ -97,8 +99,12 @@ export const SequencingEditor: React.FC<SequencingEditorProps> = ({
 
   return (
     <div className="space-y-6">
-      <div className="p-4 rounded-lg border border-blue-100 bg-blue-50 text-sm text-blue-700">
-        Dwukrotnie kliknij kafelek, aby wybrać między testowaniem zadania a edycją polecenia w trybie RichText.
+      <div className="p-4 rounded-lg border border-blue-100 bg-blue-50 text-sm text-blue-700 space-y-2">
+        <p>Dwukrotnie kliknij kafelek, aby przejść do edycji polecenia w trybie RichText.</p>
+        <p>Użyj przycisku „Przetestuj zadanie”, aby chwilowo zablokować kafelek i sprawdzić przeciąganie jak uczeń.</p>
+        {isTesting && (
+          <p className="text-emerald-700 font-medium">Tryb testowania jest aktywny – kliknięcia nie przesuną kafelka.</p>
+        )}
       </div>
 
       {/* Items Management */}

--- a/src/components/admin/side editor/TileSideEditor.tsx
+++ b/src/components/admin/side editor/TileSideEditor.tsx
@@ -9,12 +9,18 @@ interface TileSideEditorProps {
   tile: LessonTile | undefined;
   onUpdateTile: (tileId: string, updates: Partial<LessonTile>) => void;
   onSelectTile?: (tileId: string | null) => void;
+  onStartTestingTile?: (tileId: string) => void;
+  onStopTestingTile?: () => void;
+  testingTileId?: string | null;
 }
 
 export const TileSideEditor: React.FC<TileSideEditorProps> = ({
   tile,
   onUpdateTile,
-  onSelectTile
+  onSelectTile,
+  onStartTestingTile,
+  onStopTestingTile,
+  testingTileId
 }) => {
 
   if (!tile) {
@@ -256,7 +262,37 @@ export const TileSideEditor: React.FC<TileSideEditorProps> = ({
 
       case 'sequencing': {
         const sequencingTile = tile as SequencingTile;
-        return <SequencingEditor tile={sequencingTile} onUpdateTile={onUpdateTile} />;
+        const isTesting = testingTileId === tile.id;
+
+        const handleToggleTesting = () => {
+          if (isTesting) {
+            onStopTestingTile?.();
+          } else {
+            onStartTestingTile?.(tile.id);
+          }
+        };
+
+        return (
+          <div className="space-y-4">
+            <button
+              type="button"
+              onClick={handleToggleTesting}
+              className={`w-full px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
+                isTesting
+                  ? 'bg-emerald-600 text-white hover:bg-emerald-500'
+                  : 'bg-slate-900 text-white hover:bg-slate-700'
+              }`}
+            >
+              {isTesting ? 'Zakończ testowanie zadania' : 'Przetestuj zadanie'}
+            </button>
+
+            <SequencingEditor
+              tile={sequencingTile}
+              onUpdateTile={onUpdateTile}
+              isTesting={isTesting}
+            />
+          </div>
+        );
       }
 
       default:

--- a/src/hooks/useTileInteractions.ts
+++ b/src/hooks/useTileInteractions.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, RefObject } from 'react';
-import { LessonContent, LessonTile, GridPosition, EditorState, TextTile, ImageTile, SequencingTile } from '../types/lessonEditor';
+import { LessonContent, LessonTile, GridPosition, EditorState, TextTile, ImageTile } from '../types/lessonEditor';
 import { EditorAction } from '../state/editorReducer';
 import { GridUtils } from '../utils/gridUtils';
 import { logger } from '../utils/logger';
@@ -90,7 +90,11 @@ export const useTileInteractions = ({
   };
 
   const handleTileMouseDown = (e: React.MouseEvent, tile: LessonTile) => {
-    if (editorState.mode === 'textEditing' || editorState.mode === 'imageEditing') {
+    if (
+      editorState.mode === 'textEditing' ||
+      editorState.mode === 'imageEditing' ||
+      (editorState.mode === 'testing' && editorState.testingTileId === tile.id)
+    ) {
       return;
     }
     e.preventDefault();

--- a/src/state/editorReducer.ts
+++ b/src/state/editorReducer.ts
@@ -5,6 +5,8 @@ export type EditorAction =
   | { type: 'startEditing'; tileId: string }
   | { type: 'startTextEditing'; tileId: string }
   | { type: 'startImageEditing'; tileId: string }
+  | { type: 'startTestingTile'; tileId: string }
+  | { type: 'stopTestingTile' }
   | { type: 'stopEditing' }
   | { type: 'startDrag'; tile: LessonTile; offset: Position }
   | { type: 'startImageDrag'; start: { x: number; y: number; imageX: number; imageY: number } }
@@ -21,29 +23,85 @@ export const initialEditorState: EditorState = {
   interaction: { type: 'idle' },
   canvasSize: { width: 1000, height: 600 },
   hasUnsavedChanges: false,
-  showGrid: true
+  showGrid: true,
+  testingTileId: null
 };
 
 export function editorReducer(state: EditorState, action: EditorAction): EditorState {
   switch (action.type) {
     case 'selectTile':
-      return { ...state, selectedTileId: action.tileId, mode: action.tileId ? 'editing' : 'idle' };
+      return {
+        ...state,
+        selectedTileId: action.tileId,
+        mode: action.tileId ? 'editing' : 'idle',
+        testingTileId: null,
+        interaction: { type: 'idle' }
+      };
     case 'startEditing':
-      return { ...state, selectedTileId: action.tileId, mode: 'editing' };
+      return {
+        ...state,
+        selectedTileId: action.tileId,
+        mode: 'editing',
+        testingTileId: null,
+        interaction: { type: 'idle' }
+      };
     case 'startTextEditing':
-      return { ...state, selectedTileId: action.tileId, mode: 'textEditing' };
+      return {
+        ...state,
+        selectedTileId: action.tileId,
+        mode: 'textEditing',
+        testingTileId: null,
+        interaction: { type: 'idle' }
+      };
     case 'startImageEditing':
-      return { ...state, selectedTileId: action.tileId, mode: 'imageEditing' };
+      return {
+        ...state,
+        selectedTileId: action.tileId,
+        mode: 'imageEditing',
+        testingTileId: null,
+        interaction: { type: 'idle' }
+      };
+    case 'startTestingTile':
+      return {
+        ...state,
+        selectedTileId: action.tileId,
+        mode: 'testing',
+        testingTileId: action.tileId,
+        interaction: { type: 'idle' }
+      };
+    case 'stopTestingTile':
+      return {
+        ...state,
+        mode: state.selectedTileId ? 'editing' : 'idle',
+        testingTileId: null,
+        interaction: { type: 'idle' }
+      };
     case 'stopEditing':
-      return { ...state, mode: state.selectedTileId ? 'editing' : 'idle' };
+      return {
+        ...state,
+        mode: state.selectedTileId ? 'editing' : 'idle',
+        testingTileId: null,
+        interaction: { type: 'idle' }
+      };
     case 'startDrag':
-      return { ...state, mode: 'dragging', interaction: { type: 'drag', tile: action.tile, offset: action.offset } };
+      return {
+        ...state,
+        mode: 'dragging',
+        testingTileId: null,
+        interaction: { type: 'drag', tile: action.tile, offset: action.offset }
+      };
     case 'startImageDrag':
-      return { ...state, mode: 'dragging', interaction: { type: 'imageDrag', start: action.start } };
+      return {
+        ...state,
+        mode: 'dragging',
+        testingTileId: null,
+        interaction: { type: 'imageDrag', start: action.start }
+      };
     case 'startResize':
       return {
         ...state,
         mode: 'resizing',
+        testingTileId: null,
         interaction: {
           type: 'resize',
           tileId: action.tileId,
@@ -54,7 +112,11 @@ export function editorReducer(state: EditorState, action: EditorAction): EditorS
         }
       };
     case 'endInteraction':
-      return { ...state, mode: state.selectedTileId ? 'editing' : 'idle', interaction: { type: 'idle' } };
+      return {
+        ...state,
+        mode: state.selectedTileId ? 'editing' : 'idle',
+        interaction: { type: 'idle' }
+      };
     case 'toggleGrid':
       return { ...state, showGrid: !state.showGrid };
     case 'markUnsaved':

--- a/src/types/lessonEditor.ts
+++ b/src/types/lessonEditor.ts
@@ -146,6 +146,7 @@ export type ResizeHandle = 'nw' | 'ne' | 'sw' | 'se' | 'n' | 's' | 'e' | 'w';
 export type EditorMode =
   | 'idle'
   | 'editing'
+  | 'testing'
   | 'textEditing'
   | 'imageEditing'
   | 'dragging'
@@ -171,6 +172,7 @@ export interface EditorState {
   canvasSize: Size;
   hasUnsavedChanges: boolean;
   showGrid: boolean;
+  testingTileId: string | null;
 }
 
 export interface TilePaletteItem {


### PR DESCRIPTION
## Summary
- introduce a reusable TileInstructionPanel for consistent task headers
- restyle the sequencing tile to mirror the programming task layout and remove the double-click mode prompt
- add a testing toggle from the side editor backed by new editor state so tiles can be safely previewed

## Testing
- `npm run lint` *(fails: repository has pre-existing lint errors around explicit any usage and unused symbols)*

------
https://chatgpt.com/codex/tasks/task_e_68cd64afa418832190b9781681659acb