### PR TITLE
Fix layout scrolling behavior in lesson editor

### DIFF
--- a/src/Pages/LessonEditor.tsx
+++ b/src/Pages/LessonEditor.tsx
@@ -463,26 +463,8 @@ export const LessonEditor: React.FC<LessonEditorProps> = ({ lesson, course, onBa
         </div>
       </div>
 
-      <div
-        className="sticky z-40 bg-white border-b border-gray-200"
-        style={{ top: headerHeight }}
-      >
-        <TopToolbar
-          key={`toolbar-${editorState.mode}-${editorState.selectedTileId}`}
-          tilesCount={lessonContent.tiles.length}
-          gridColumns={GridUtils.GRID_COLUMNS}
-          gridRows={lessonContent.canvas_settings.height}
-          currentMode={editorState.selectedTileId ? 'Tryb edycji' : 'Tryb dodawania'}
-          isTextEditing={editorState.mode === 'textEditing'}
-          onFinishTextEditing={handleFinishTextEditing}
-          editor={activeEditor}
-          selectedTile={selectedRichTextTile}
-          onUpdateTile={handleUpdateTile}
-        />
-      </div>
-
       {/* Editor Content */}
-      <div className="flex-1 flex min-h-0 overflow-hidden">
+      <div className="flex-1 flex min-h-0">
         {/* Context-Sensitive Left Panel */}
         <div className="w-64 lg:w-80 bg-white shadow-lg border-r border-gray-200 flex-shrink-0 transition-all duration-300 flex flex-col overflow-hidden">
           {editorState.selectedTileId ? (
@@ -509,6 +491,23 @@ export const LessonEditor: React.FC<LessonEditorProps> = ({ lesson, course, onBa
 
         {/* Expanded Canvas Area */}
         <div className="flex-1 flex flex-col min-w-0">
+          <div
+            className="sticky z-40 bg-white border-b border-gray-200"
+            style={{ top: headerHeight }}
+          >
+            <TopToolbar
+              key={`toolbar-${editorState.mode}-${editorState.selectedTileId}`}
+              tilesCount={lessonContent.tiles.length}
+              gridColumns={GridUtils.GRID_COLUMNS}
+              gridRows={lessonContent.canvas_settings.height}
+              currentMode={editorState.selectedTileId ? 'Tryb edycji' : 'Tryb dodawania'}
+              isTextEditing={editorState.mode === 'textEditing'}
+              onFinishTextEditing={handleFinishTextEditing}
+              editor={activeEditor}
+              selectedTile={selectedRichTextTile}
+              onUpdateTile={handleUpdateTile}
+            />
+          </div>
           {/* Canvas */}
           <div className="flex-1 p-4 lg:p-6 overflow-auto overscroll-contain bg-gray-100">
             <LessonCanvas

--- a/src/Pages/LessonEditor.tsx
+++ b/src/Pages/LessonEditor.tsx
@@ -375,7 +375,7 @@ export const LessonEditor: React.FC<LessonEditorProps> = ({ lesson, course, onBa
   const selectedRichTextTile = isRichTextTile(selectedTile) ? selectedTile : null;
 
   return (
-    <div className="h-screen bg-gray-50 flex flex-col max-w-full overflow-hidden">
+    <div className="h-screen bg-gray-50 flex flex-col max-w-full">
       <ToastContainer toasts={toasts} onClose={removeToast} />
       
       <ConfirmDialog
@@ -463,6 +463,24 @@ export const LessonEditor: React.FC<LessonEditorProps> = ({ lesson, course, onBa
         </div>
       </div>
 
+      <div
+        className="sticky z-40 bg-white border-b border-gray-200"
+        style={{ top: headerHeight }}
+      >
+        <TopToolbar
+          key={`toolbar-${editorState.mode}-${editorState.selectedTileId}`}
+          tilesCount={lessonContent.tiles.length}
+          gridColumns={GridUtils.GRID_COLUMNS}
+          gridRows={lessonContent.canvas_settings.height}
+          currentMode={editorState.selectedTileId ? 'Tryb edycji' : 'Tryb dodawania'}
+          isTextEditing={editorState.mode === 'textEditing'}
+          onFinishTextEditing={handleFinishTextEditing}
+          editor={activeEditor}
+          selectedTile={selectedRichTextTile}
+          onUpdateTile={handleUpdateTile}
+        />
+      </div>
+
       {/* Editor Content */}
       <div className="flex-1 flex min-h-0 overflow-hidden">
         {/* Context-Sensitive Left Panel */}
@@ -491,22 +509,6 @@ export const LessonEditor: React.FC<LessonEditorProps> = ({ lesson, course, onBa
 
         {/* Expanded Canvas Area */}
         <div className="flex-1 flex flex-col min-w-0">
-          {/* Dynamic Top Toolbar */}
-          <TopToolbar
-            key={`toolbar-${editorState.mode}-${editorState.selectedTileId}`}
-            tilesCount={lessonContent.tiles.length}
-            gridColumns={GridUtils.GRID_COLUMNS}
-            gridRows={lessonContent.canvas_settings.height}
-            currentMode={editorState.selectedTileId ? 'Tryb edycji' : 'Tryb dodawania'}
-            isTextEditing={editorState.mode === 'textEditing'}
-            onFinishTextEditing={handleFinishTextEditing}
-            editor={activeEditor}
-            selectedTile={selectedRichTextTile}
-            onUpdateTile={handleUpdateTile}
-            className="sticky z-40"
-            style={{ top: headerHeight }}
-          />
-
           {/* Canvas */}
           <div className="flex-1 p-4 lg:p-6 overflow-auto overscroll-contain bg-gray-100">
             <LessonCanvas

--- a/src/Pages/LessonEditor.tsx
+++ b/src/Pages/LessonEditor.tsx
@@ -339,7 +339,7 @@ export const LessonEditor: React.FC<LessonEditorProps> = ({ lesson, course, onBa
   const selectedRichTextTile = isRichTextTile(selectedTile) ? selectedTile : null;
 
   return (
-    <div className="min-h-screen bg-gray-50 flex flex-col max-w-full overflow-hidden">
+    <div className="h-screen bg-gray-50 flex flex-col max-w-full overflow-hidden">
       <ToastContainer toasts={toasts} onClose={removeToast} />
       
       <ConfirmDialog
@@ -354,7 +354,7 @@ export const LessonEditor: React.FC<LessonEditorProps> = ({ lesson, course, onBa
       />
 
       {/* Header */}
-      <div className="bg-white shadow-sm border-b border-gray-200">
+      <div className="bg-white shadow-sm border-b border-gray-200 sticky top-0 z-50">
         <div className="px-4 lg:px-6">
           <div className="flex items-center justify-between h-16">
             <div className="flex items-center space-x-4">
@@ -428,9 +428,9 @@ export const LessonEditor: React.FC<LessonEditorProps> = ({ lesson, course, onBa
       </div>
 
       {/* Editor Content */}
-      <div className="flex-1 flex min-h-0">
+      <div className="flex-1 flex min-h-0 overflow-hidden">
         {/* Context-Sensitive Left Panel */}
-        <div className="w-64 lg:w-80 bg-white shadow-lg border-r border-gray-200 flex-shrink-0 transition-all duration-300">
+        <div className="w-64 lg:w-80 bg-white shadow-lg border-r border-gray-200 flex-shrink-0 transition-all duration-300 flex flex-col overflow-hidden">
           {editorState.selectedTileId ? (
             // Editing Panel - when tile is selected
             <div className="h-full">
@@ -467,10 +467,11 @@ export const LessonEditor: React.FC<LessonEditorProps> = ({ lesson, course, onBa
             editor={activeEditor}
             selectedTile={selectedRichTextTile}
             onUpdateTile={handleUpdateTile}
+            className="sticky top-16 z-40"
           />
 
           {/* Canvas */}
-          <div className="flex-1 p-4 lg:p-6 overflow-auto bg-gray-100">
+          <div className="flex-1 p-4 lg:p-6 overflow-auto overscroll-contain bg-gray-100">
             <LessonCanvas
               ref={canvasRef}
               content={lessonContent}

--- a/src/components/admin/side editor/TilePalette.tsx
+++ b/src/components/admin/side editor/TilePalette.tsx
@@ -84,7 +84,7 @@ export const TilePalette: React.FC<TilePaletteProps> = ({
   };
 
   return (
-    <div className="h-full flex flex-col bg-white">
+    <div className="h-full flex flex-col bg-white overflow-hidden">
       {/* Header */}
       <div className="p-6 border-b border-gray-200">
         <div className="flex items-center space-x-3 mb-2">
@@ -101,7 +101,7 @@ export const TilePalette: React.FC<TilePaletteProps> = ({
       </div>
 
       {/* Tile Types */}
-      <div className="flex-1 p-4 space-y-3">
+      <div className="flex-1 p-4 space-y-3 overflow-y-auto overscroll-contain">
         {TILE_TYPES.map((tileType) => {
           const IconComponent = getIcon(tileType.icon);
           

--- a/src/components/admin/side editor/TileSideEditor.tsx
+++ b/src/components/admin/side editor/TileSideEditor.tsx
@@ -304,7 +304,7 @@ export const TileSideEditor: React.FC<TileSideEditorProps> = ({
       </div>
 
       {/* Properties Panel */}
-      <div className="flex-1 overflow-y-auto p-6 space-y-6">
+      <div className="flex-1 overflow-y-auto overscroll-contain p-6 space-y-6">
         {renderContentEditor()}
       </div>
 

--- a/src/components/admin/top editor/TopToolbar.tsx
+++ b/src/components/admin/top editor/TopToolbar.tsx
@@ -19,6 +19,7 @@ interface TopToolbarProps {
   selectedTile?: TextTile | ProgrammingTile | SequencingTile | null;
   onUpdateTile?: (tileId: string, updates: Partial<LessonTile>) => void;
   className?: string;
+  style?: React.CSSProperties;
 }
 
 export const TopToolbar: React.FC<TopToolbarProps> = ({
@@ -31,7 +32,8 @@ export const TopToolbar: React.FC<TopToolbarProps> = ({
   editor,
   selectedTile,
   onUpdateTile,
-  className = ''
+  className = '',
+  style
 }) => {
   const [currentFont, setCurrentFont] = useState('Inter, system-ui, sans-serif');
   const [currentSize, setCurrentSize] = useState(16);
@@ -103,6 +105,7 @@ export const TopToolbar: React.FC<TopToolbarProps> = ({
     return (
       <div
         className={`top-toolbar relative z-30 flex items-center justify-between bg-white border-b border-gray-200 px-4 lg:px-6 py-3 ${className}`}
+        style={style}
         onMouseDown={(e) => e.preventDefault()}
       >
         <div className="flex items-center space-x-2 text-gray-600" onMouseDown={(e) => e.preventDefault()}>
@@ -258,7 +261,10 @@ export const TopToolbar: React.FC<TopToolbarProps> = ({
   }
 
   return (
-    <div className={`flex items-center justify-between bg-white border-b border-gray-200 px-4 lg:px-6 py-3 ${className}`}>
+    <div
+      className={`top-toolbar relative z-30 flex items-center justify-between bg-white border-b border-gray-200 px-4 lg:px-6 py-3 ${className}`}
+      style={style}
+    >
       <div className="text-sm text-gray-500">
         Kafelki: {tilesCount} • Siatka: {gridColumns}×{gridRows}
       </div>

--- a/src/components/admin/top editor/TopToolbar.tsx
+++ b/src/components/admin/top editor/TopToolbar.tsx
@@ -19,7 +19,6 @@ interface TopToolbarProps {
   selectedTile?: TextTile | ProgrammingTile | SequencingTile | null;
   onUpdateTile?: (tileId: string, updates: Partial<LessonTile>) => void;
   className?: string;
-  style?: React.CSSProperties;
 }
 
 export const TopToolbar: React.FC<TopToolbarProps> = ({
@@ -32,8 +31,7 @@ export const TopToolbar: React.FC<TopToolbarProps> = ({
   editor,
   selectedTile,
   onUpdateTile,
-  className = '',
-  style
+  className = ''
 }) => {
   const [currentFont, setCurrentFont] = useState('Inter, system-ui, sans-serif');
   const [currentSize, setCurrentSize] = useState(16);
@@ -104,8 +102,7 @@ export const TopToolbar: React.FC<TopToolbarProps> = ({
   if (isTextEditing) {
     return (
       <div
-        className={`top-toolbar relative z-30 flex items-center justify-between bg-white border-b border-gray-200 px-4 lg:px-6 py-3 ${className}`}
-        style={style}
+        className={`top-toolbar z-30 flex items-center justify-between px-4 lg:px-6 py-3 ${className}`}
         onMouseDown={(e) => e.preventDefault()}
       >
         <div className="flex items-center space-x-2 text-gray-600" onMouseDown={(e) => e.preventDefault()}>
@@ -262,8 +259,7 @@ export const TopToolbar: React.FC<TopToolbarProps> = ({
 
   return (
     <div
-      className={`top-toolbar relative z-30 flex items-center justify-between bg-white border-b border-gray-200 px-4 lg:px-6 py-3 ${className}`}
-      style={style}
+      className={`top-toolbar z-30 flex items-center justify-between px-4 lg:px-6 py-3 ${className}`}
     >
       <div className="text-sm text-gray-500">
         Kafelki: {tilesCount} • Siatka: {gridColumns}×{gridRows}


### PR DESCRIPTION
## Summary
- make the lesson editor layout fill the viewport so toolbars stay visible while scrolling
- keep the lesson header and formatting toolbar sticky and restrict scrolling to the canvas area
- confine scrolling within tile palette and tile side editor to prevent the rest of the UI from moving

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d5a05670e88321a6d880439e8cc666