### PR TITLE
Adjust toast positioning and animations

### DIFF
--- a/src/components/common/Toast.tsx
+++ b/src/components/common/Toast.tsx
@@ -151,11 +151,17 @@ const ToastComponent: React.FC<ToastProps> = ({ toast, onClose }) => {
 interface ToastContainerProps {
   toasts: Toast[];
   onClose: (id: string) => void;
+  topOffset?: number;
 }
 
-export const ToastContainer: React.FC<ToastContainerProps> = ({ toasts, onClose }) => {
+export const ToastContainer: React.FC<ToastContainerProps> = ({ toasts, onClose, topOffset }) => {
+  const computedTop = Math.max(topOffset ?? 16, 16);
+
   return (
-    <div className="fixed top-4 right-4 z-50">
+    <div
+      className="fixed right-4 z-50 flex flex-col items-end"
+      style={{ top: computedTop }}
+    >
       {toasts.map(toast => (
         <ToastComponent key={toast.id} toast={toast} onClose={onClose} />
       ))}

--- a/src/hooks/useToast.ts
+++ b/src/hooks/useToast.ts
@@ -17,11 +17,6 @@ export const useToast = () => {
     
     setToasts(prev => [...prev, newToast]);
     
-    // Auto remove after duration
-    setTimeout(() => {
-      setToasts(prev => prev.filter(t => t.id !== id));
-    }, toast.duration || 5000);
-    
     return id;
   }, []);
 


### PR DESCRIPTION
## Summary
- offset toast notifications so they appear below the fixed header and toolbar
- track dynamic header and toolbar heights to keep toast placement responsive
- let toast components control their own dismissal timing so exit animations play for auto-closed toasts

## Testing
- npm run lint *(fails: existing lint errors about explicit any / unused vars in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d5b70b663c83219a5b49b6f7943b01