### PR TITLE
Implement interactive quiz tile

### DIFF
--- a/src/Pages/LessonEditor.tsx
+++ b/src/Pages/LessonEditor.tsx
@@ -224,7 +224,7 @@ export const LessonEditor: React.FC<LessonEditorProps> = ({ lesson, course, onBa
         };
         
         // Special handling for text-based tiles to ensure content properties are merged
-        if ((tile.type === 'text' || tile.type === 'programming' || tile.type === 'sequencing') && updates.content) {
+        if ((tile.type === 'text' || tile.type === 'programming' || tile.type === 'sequencing' || tile.type === 'quiz') && updates.content) {
           updatedTile.content = {
             ...tile.content,
             ...updates.content

--- a/src/hooks/useTileInteractions.ts
+++ b/src/hooks/useTileInteractions.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, RefObject } from 'react';
-import { LessonContent, LessonTile, GridPosition, EditorState, TextTile, ImageTile, SequencingTile } from '../types/lessonEditor';
+import { LessonContent, LessonTile, GridPosition, EditorState, TextTile, ImageTile } from '../types/lessonEditor';
 import { EditorAction } from '../state/editorReducer';
 import { GridUtils } from '../utils/gridUtils';
 import { logger } from '../utils/logger';
@@ -29,7 +29,7 @@ export const useTileInteractions = ({
   const [resizePreview, setResizePreview] = useState<{ tileId: string; gridPosition: GridPosition } | null>(null);
 
   const handleTileDoubleClick = (tile: LessonTile) => {
-    if (tile.type === 'text' || tile.type === 'programming' || tile.type === 'sequencing') {
+    if (tile.type === 'text' || tile.type === 'programming' || tile.type === 'sequencing' || tile.type === 'quiz') {
       dispatch({ type: 'startTextEditing', tileId: tile.id });
     } else if (tile.type === 'image') {
       dispatch({ type: 'startImageEditing', tileId: tile.id });

--- a/src/services/lessonContentService.ts
+++ b/src/services/lessonContentService.ts
@@ -244,6 +244,12 @@ export class LessonContentService {
       snapToGrid: true
     });
 
+    const createAnswer = (text: string, isCorrect: boolean) => ({
+      id: `answer-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      text,
+      isCorrect
+    });
+
     return {
       id,
       type: 'quiz',
@@ -252,10 +258,15 @@ export class LessonContentService {
       gridPosition: gridPos,
       content: {
         question: 'Przykładowe pytanie?',
+        richQuestion: '<p style="margin: 0;">Przykładowe pytanie?</p>',
+        fontFamily: 'Inter, system-ui, sans-serif',
+        fontSize: 16,
+        backgroundColor: '#f0fdf4',
+        showBorder: true,
         answers: [
-          { text: 'Odpowiedź A', isCorrect: false },
-          { text: 'Odpowiedź B', isCorrect: true },
-          { text: 'Odpowiedź C', isCorrect: false }
+          createAnswer('Odpowiedź A', false),
+          createAnswer('Odpowiedź B', true),
+          createAnswer('Odpowiedź C', false)
         ],
         multipleCorrect: false
       },

--- a/src/types/lessonEditor.ts
+++ b/src/types/lessonEditor.ts
@@ -78,7 +78,13 @@ export interface QuizTile extends LessonTile {
   type: 'quiz';
   content: {
     question: string;
+    richQuestion?: string;
+    fontFamily: string;
+    fontSize: number;
+    backgroundColor: string;
+    showBorder: boolean;
     answers: Array<{
+      id: string;
       text: string;
       isCorrect: boolean;
     }>;


### PR DESCRIPTION
## Summary
- expand quiz tile model with styling metadata and richer defaults
- render functional quiz tile with editable question panel and interactive answer buttons
- add side editor controls for quiz background, selection mode and managing answers while integrating quiz tiles with existing editing flow

## Testing
- npm run lint *(fails: existing eslint violations unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d5b5d317a483218367f56d7ecb3415