### PR TITLE
Add paginated navigation for lesson canvas

### DIFF
--- a/src/components/admin/LessonCanvas.tsx
+++ b/src/components/admin/LessonCanvas.tsx
@@ -19,6 +19,7 @@ interface LessonCanvasProps {
   showGrid?: boolean;
   onEditorReady: (editor: Editor | null) => void;
   testingTileIds?: string[];
+  currentPage: number;
 }
 
 export const LessonCanvas = forwardRef<HTMLDivElement, LessonCanvasProps>(({ 
@@ -32,8 +33,11 @@ export const LessonCanvas = forwardRef<HTMLDivElement, LessonCanvasProps>(({
   onFinishTextEditing,
   showGrid = true,
   onEditorReady,
-  testingTileIds = []
+  testingTileIds = [],
+  currentPage
 }, ref) => {
+  const visibleTiles = content.tiles.filter(tile => tile.page === currentPage);
+
   const {
     dragPreview,
     handleTileDoubleClick,
@@ -45,6 +49,7 @@ export const LessonCanvas = forwardRef<HTMLDivElement, LessonCanvasProps>(({
     handleImageMouseDown,
   } = useTileInteractions({
     content,
+    tiles: visibleTiles,
     editorState,
     dispatch,
     onUpdateTile,
@@ -121,7 +126,7 @@ export const LessonCanvas = forwardRef<HTMLDivElement, LessonCanvasProps>(({
         {renderDragPreview()}
 
         {/* Render Tiles */}
-        {content.tiles.map((tile) => (
+        {visibleTiles.map((tile) => (
           <TileRenderer
             key={tile.id}
             tile={tile}
@@ -143,7 +148,7 @@ export const LessonCanvas = forwardRef<HTMLDivElement, LessonCanvasProps>(({
         ))}
 
         {/* Empty State */}
-        {content.tiles.length === 0 && (
+        {visibleTiles.length === 0 && (
           <div className="absolute inset-0 flex items-center justify-center">
             <div className="text-center text-gray-400">
               <Type className="w-16 h-16 mx-auto mb-4" />
@@ -157,7 +162,7 @@ export const LessonCanvas = forwardRef<HTMLDivElement, LessonCanvasProps>(({
       {/* Canvas Info */}
       <div className="mt-4 text-center">
         <p className="text-xs text-gray-500">
-          Siatka: {GridUtils.GRID_COLUMNS} × {content.canvas_settings.height} kafelków
+          Strona {currentPage} z {content.canvas_settings.pages || 1} • Siatka: {GridUtils.GRID_COLUMNS} × {content.canvas_settings.height} kafelków
           {showGrid && ' • Siatka włączona'}
         </p>
       </div>

--- a/src/components/admin/PageNavigator.tsx
+++ b/src/components/admin/PageNavigator.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import { ChevronLeft, ChevronRight, Plus } from 'lucide-react';
+
+interface PageNavigatorProps {
+  currentPage: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+  onAddPage?: () => void;
+  variant?: 'default' | 'subtle';
+}
+
+export const PageNavigator: React.FC<PageNavigatorProps> = ({
+  currentPage,
+  totalPages,
+  onPageChange,
+  onAddPage,
+  variant = 'default'
+}) => {
+  const safeTotal = Math.max(1, totalPages);
+  const clampedPage = Math.min(Math.max(1, currentPage), safeTotal);
+  const pages = Array.from({ length: safeTotal }, (_, index) => index + 1);
+  const canGoPrevious = clampedPage > 1;
+  const canGoNext = clampedPage < safeTotal;
+
+  const containerClasses =
+    variant === 'subtle'
+      ? 'rounded-xl border border-gray-200 bg-white/70 backdrop-blur-sm px-4 py-3 shadow-sm transition-all'
+      : 'rounded-2xl border border-gray-200 bg-white px-4 py-4 shadow-md shadow-gray-200/70 transition-all';
+
+  const buttonBase =
+    'inline-flex items-center justify-center rounded-lg border border-gray-200 px-3 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-blue-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-white';
+
+  const pageButton = (page: number) => {
+    const isActive = page === clampedPage;
+    return (
+      <button
+        key={page}
+        type="button"
+        onClick={() => {
+          if (page !== clampedPage) {
+            onPageChange(page);
+          }
+        }}
+        className={
+          'min-w-[2.75rem] px-3 py-1.5 text-sm font-medium rounded-lg transition-colors ' +
+          (isActive
+            ? 'bg-blue-600 text-white shadow-sm shadow-blue-200'
+            : 'bg-white text-gray-700 border border-gray-200 hover:bg-blue-50')
+        }
+        aria-current={isActive ? 'page' : undefined}
+      >
+        {page}
+      </button>
+    );
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className={`flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between ${containerClasses}`}>
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => canGoPrevious && onPageChange(clampedPage - 1)}
+              className={buttonBase}
+              disabled={!canGoPrevious}
+              aria-label="Poprzednia strona"
+            >
+              <ChevronLeft className="h-4 w-4" />
+            </button>
+            <div className="flex items-center gap-2 overflow-x-auto pb-1">
+              {pages.map(pageButton)}
+            </div>
+            <button
+              type="button"
+              onClick={() => canGoNext && onPageChange(clampedPage + 1)}
+              className={buttonBase}
+              disabled={!canGoNext}
+              aria-label="Następna strona"
+            >
+              <ChevronRight className="h-4 w-4" />
+            </button>
+          </div>
+        </div>
+        {onAddPage && (
+          <button
+            type="button"
+            onClick={onAddPage}
+            className="inline-flex items-center justify-center gap-2 rounded-xl bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-blue-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
+          >
+            <Plus className="h-4 w-4" />
+            Dodaj stronę
+          </button>
+        )}
+      </div>
+      <p className="text-center text-xs font-medium uppercase tracking-wide text-gray-500">
+        Strona {clampedPage} z {safeTotal}
+      </p>
+    </div>
+  );
+};

--- a/src/services/lessonContentService.ts
+++ b/src/services/lessonContentService.ts
@@ -18,7 +18,8 @@ export class LessonContentService {
           width: GridUtils.GRID_COLUMNS,
           height: 6,
           gridSize: GridUtils.GRID_CELL_SIZE,
-          snapToGrid: true
+          snapToGrid: true,
+          pages: 1
         },
         created_at: new Date().toISOString(),
         updated_at: new Date().toISOString()
@@ -38,6 +39,10 @@ export class LessonContentService {
     try {
       // Update canvas height based on tiles
       content.canvas_settings.height = GridUtils.calculateCanvasHeight(content.tiles);
+      content.canvas_settings.pages = Math.max(
+        content.canvas_settings.pages || 1,
+        content.tiles.reduce((max, tile) => Math.max(max, tile.page || 1), 1)
+      );
       content.updated_at = new Date().toISOString();
 
       // Simulate API call - replace with actual Supabase call
@@ -54,7 +59,7 @@ export class LessonContentService {
   /**
    * Create a new text tile
    */
-  static createTextTile(position: { x: number; y: number }): TextTile {
+  static createTextTile(position: { x: number; y: number }, page = 1): TextTile {
     const id = `tile-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
     const now = new Date().toISOString();
     
@@ -90,6 +95,7 @@ export class LessonContentService {
       position: pixelPos,
       size: pixelSize,
       gridPosition: gridPos,
+      page,
       content: {
         text: 'Nowy tekst',
         richText: '<p style="margin: 0;">Nowy tekst</p>',
@@ -108,7 +114,7 @@ export class LessonContentService {
   /**
    * Create a new image tile
    */
-  static createImageTile(position: { x: number; y: number }): LessonTile {
+  static createImageTile(position: { x: number; y: number }, page = 1): LessonTile {
     const id = `tile-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
     const now = new Date().toISOString();
     
@@ -143,6 +149,7 @@ export class LessonContentService {
       position: pixelPos,
       size: pixelSize,
       gridPosition: gridPos,
+      page,
       content: {
         url: 'https://images.pexels.com/photos/3184291/pexels-photo-3184291.jpeg?auto=compress&cs=tinysrgb&w=400',
         alt: 'Przykładowy obraz',
@@ -160,7 +167,7 @@ export class LessonContentService {
   /**
    * Create a new visualization tile
    */
-  static createVisualizationTile(position: { x: number; y: number }): LessonTile {
+  static createVisualizationTile(position: { x: number; y: number }, page = 1): LessonTile {
     const id = `tile-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
     const now = new Date().toISOString();
     
@@ -195,6 +202,7 @@ export class LessonContentService {
       position: pixelPos,
       size: pixelSize,
       gridPosition: gridPos,
+      page,
       content: {
         title: 'Nowa wizualizacja',
         contentType: 'chart',
@@ -215,7 +223,7 @@ export class LessonContentService {
   /**
    * Create a new quiz tile
    */
-  static createQuizTile(position: { x: number; y: number }): LessonTile {
+  static createQuizTile(position: { x: number; y: number }, page = 1): LessonTile {
     const id = `tile-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
     const now = new Date().toISOString();
     
@@ -250,6 +258,7 @@ export class LessonContentService {
       position: pixelPos,
       size: pixelSize,
       gridPosition: gridPos,
+      page,
       content: {
         question: 'Przykładowe pytanie?',
         richQuestion: '<p>Przykładowe pytanie?</p>',
@@ -273,7 +282,7 @@ export class LessonContentService {
   /**
    * Create a new programming task tile
    */
-  static createProgrammingTile(position: { x: number; y: number }): ProgrammingTile {
+  static createProgrammingTile(position: { x: number; y: number }, page = 1): ProgrammingTile {
     const id = `tile-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
     const now = new Date().toISOString();
     
@@ -308,6 +317,7 @@ export class LessonContentService {
       position: pixelPos,
       size: pixelSize,
       gridPosition: gridPos,
+      page,
       content: {
         description: 'Opis zadania programistycznego',
         richDescription: '<p style="margin: 0;">Opis zadania programistycznego</p>',
@@ -329,7 +339,7 @@ export class LessonContentService {
   /**
    * Create a new sequencing tile
    */
-  static createSequencingTile(position: { x: number; y: number }): SequencingTile {
+  static createSequencingTile(position: { x: number; y: number }, page = 1): SequencingTile {
     const id = `tile-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
     const now = new Date().toISOString();
     
@@ -364,6 +374,7 @@ export class LessonContentService {
       position: pixelPos,
       size: pixelSize,
       gridPosition: gridPos,
+      page,
       content: {
         question: 'Ułóż elementy w prawidłowej kolejności',
         richQuestion: '<p style="margin: 0;">Ułóż elementy w prawidłowej kolejności</p>',

--- a/src/types/lessonEditor.ts
+++ b/src/types/lessonEditor.ts
@@ -21,6 +21,7 @@ export interface LessonTile {
   position: Position;
   size: Size;
   gridPosition: GridPosition;
+  page: number;
   content: any;
   created_at: string;
   updated_at: string;
@@ -132,6 +133,7 @@ export interface CanvasSettings {
   height: number; // Grid rows (dynamic)
   gridSize: number; // Size of each grid cell in pixels
   snapToGrid: boolean;
+  pages: number;
 }
 
 export interface LessonContent {


### PR DESCRIPTION
## Summary
- add lesson page state management with per-page tile handling and clearing in the editor
- filter canvas rendering and tile interactions by the active page and persist page metadata in lesson content
- create a reusable page navigator component to render controls above and below the lesson canvas

## Testing
- npm run lint *(fails: repository already contains numerous lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68da9e385e7083219c36b9f13d9abe29