### PR TITLE
Add matching exercise tile

### DIFF
--- a/src/Pages/LessonEditor.tsx
+++ b/src/Pages/LessonEditor.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import { ArrowLeft, Save, RotateCcw, Grid, Edit } from 'lucide-react';
 import { Lesson, Course } from '../types/course.ts';
 import { LessonContent, LessonTile, ProgrammingTile, TextTile } from '../types/lessonEditor.ts';
-import { SequencingTile } from '../types/lessonEditor.ts';
+import { SequencingTile, MatchingTile } from '../types/lessonEditor.ts';
 import { useLessonEditor } from '../hooks/useLessonEditor.ts';
 import { LessonContentService } from '../services/lessonContentService.ts';
 import { TilePalette } from '../components/admin/side editor/TilePalette.tsx';
@@ -24,8 +24,8 @@ interface LessonEditorProps {
   onBack: () => void;
 }
 
-const isRichTextTile = (tile: LessonTile | null): tile is TextTile | ProgrammingTile | SequencingTile => {
-  return !!tile && (tile.type === 'text' || tile.type === 'programming' || tile.type === 'sequencing');
+const isRichTextTile = (tile: LessonTile | null): tile is TextTile | ProgrammingTile | SequencingTile | MatchingTile => {
+  return !!tile && (tile.type === 'text' || tile.type === 'programming' || tile.type === 'sequencing' || tile.type === 'matching');
 };
 
 export const LessonEditor: React.FC<LessonEditorProps> = ({ lesson, course, onBack }) => {
@@ -253,6 +253,9 @@ export const LessonEditor: React.FC<LessonEditorProps> = ({ lesson, course, onBa
       case 'sequencing':
         newTile = LessonContentService.createSequencingTile(position, currentPage);
         break;
+      case 'matching':
+        newTile = LessonContentService.createMatchingTile(position, currentPage);
+        break;
       default:
         logger.warn(`Tile type ${tileType} not implemented yet`);
         warning('Funkcja niedostępna', `Typ kafelka "${tileType}" nie jest jeszcze dostępny`);
@@ -313,7 +316,7 @@ export const LessonEditor: React.FC<LessonEditorProps> = ({ lesson, course, onBa
         };
 
         // Special handling for text-based tiles to ensure content properties are merged
-        if ((tile.type === 'text' || tile.type === 'programming' || tile.type === 'sequencing') && updates.content) {
+        if ((tile.type === 'text' || tile.type === 'programming' || tile.type === 'sequencing' || tile.type === 'matching') && updates.content) {
           updatedTile.content = {
             ...tile.content,
             ...updates.content

--- a/src/components/admin/MatchingInteractive.tsx
+++ b/src/components/admin/MatchingInteractive.tsx
@@ -1,0 +1,793 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { CheckCircle, Link2, RotateCcw, Shuffle, Sparkles, XCircle } from 'lucide-react';
+import { MatchingTile } from '../../types/lessonEditor';
+import { TaskInstructionPanel } from './common/TaskInstructionPanel';
+
+interface MatchingInteractiveProps {
+  tile: MatchingTile;
+  isPreview?: boolean;
+  isTestingMode?: boolean;
+  onRequestTextEditing?: () => void;
+  instructionContent?: React.ReactNode;
+  variant?: 'standalone' | 'embedded';
+}
+
+interface MatchingItem {
+  pairId: string;
+  text: string;
+}
+
+interface Connection {
+  leftId: string;
+  rightId: string;
+}
+
+interface LineSegment {
+  leftId: string;
+  rightId: string;
+  start: { x: number; y: number };
+  end: { x: number; y: number };
+  isCorrect: boolean | null;
+}
+
+const hexToRgb = (hex: string): { r: number; g: number; b: number } | null => {
+  if (!hex) return null;
+
+  let normalized = hex.replace('#', '').trim();
+  if (normalized.length === 3) {
+    normalized = normalized
+      .split('')
+      .map(char => `${char}${char}`)
+      .join('');
+  }
+
+  if (normalized.length !== 6) return null;
+
+  const intValue = Number.parseInt(normalized, 16);
+  if (Number.isNaN(intValue)) return null;
+
+  return {
+    r: (intValue >> 16) & 255,
+    g: (intValue >> 8) & 255,
+    b: intValue & 255
+  };
+};
+
+const channelToLinear = (value: number): number => {
+  const scaled = value / 255;
+  return scaled <= 0.03928 ? scaled / 12.92 : Math.pow((scaled + 0.055) / 1.055, 2.4);
+};
+
+const getReadableTextColor = (hex: string): string => {
+  const rgb = hexToRgb(hex);
+  if (!rgb) return '#f8fafc';
+
+  const luminance =
+    0.2126 * channelToLinear(rgb.r) +
+    0.7152 * channelToLinear(rgb.g) +
+    0.0722 * channelToLinear(rgb.b);
+
+  return luminance > 0.6 ? '#0f172a' : '#f8fafc';
+};
+
+const lightenColor = (hex: string, amount: number): string => {
+  const rgb = hexToRgb(hex);
+  if (!rgb) return hex;
+
+  const lightenChannel = (channel: number) => Math.round(channel + (255 - channel) * amount);
+  return `rgb(${lightenChannel(rgb.r)}, ${lightenChannel(rgb.g)}, ${lightenChannel(rgb.b)})`;
+};
+
+const darkenColor = (hex: string, amount: number): string => {
+  const rgb = hexToRgb(hex);
+  if (!rgb) return hex;
+
+  const darkenChannel = (channel: number) => Math.round(channel * (1 - amount));
+  return `rgb(${darkenChannel(rgb.r)}, ${darkenChannel(rgb.g)}, ${darkenChannel(rgb.b)})`;
+};
+
+const surfaceColor = (accent: string, textColor: string, lightenAmount: number, darkenAmount: number): string =>
+  textColor === '#0f172a' ? lightenColor(accent, lightenAmount) : darkenColor(accent, darkenAmount);
+
+export const MatchingInteractive: React.FC<MatchingInteractiveProps> = ({
+  tile,
+  isPreview = false,
+  isTestingMode = false,
+  onRequestTextEditing,
+  instructionContent,
+  variant = 'embedded'
+}) => {
+  const [rightItems, setRightItems] = useState<MatchingItem[]>([]);
+  const [connections, setConnections] = useState<Connection[]>([]);
+  const [isChecked, setIsChecked] = useState(false);
+  const [isCorrect, setIsCorrect] = useState<boolean | null>(null);
+  const [attempts, setAttempts] = useState(0);
+  const [activeLeftId, setActiveLeftId] = useState<string | null>(null);
+  const [pointerPosition, setPointerPosition] = useState<{ x: number; y: number } | null>(null);
+  const [lineSegments, setLineSegments] = useState<LineSegment[]>([]);
+
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const leftRefs = useRef<Record<string, HTMLDivElement | null>>({});
+  const rightRefs = useRef<Record<string, HTMLDivElement | null>>({});
+
+  const accentColor = tile.content.backgroundColor || '#0f172a';
+  const textColor = useMemo(() => getReadableTextColor(accentColor), [accentColor]);
+  const gradientStart = useMemo(() => lightenColor(accentColor, 0.08), [accentColor]);
+  const gradientEnd = useMemo(() => darkenColor(accentColor, 0.08), [accentColor]);
+  const frameBorderColor = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.52, 0.6),
+    [accentColor, textColor]
+  );
+  const panelBackground = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.64, 0.45),
+    [accentColor, textColor]
+  );
+  const panelBorder = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.5, 0.58),
+    [accentColor, textColor]
+  );
+  const iconBackground = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.56, 0.5),
+    [accentColor, textColor]
+  );
+  const mutedLabelColor = textColor === '#0f172a' ? '#475569' : '#dbeafe';
+  const subtleCaptionColor = textColor === '#0f172a' ? '#64748b' : '#e2e8f0';
+  const testingCaptionColor = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.42, 0.4),
+    [accentColor, textColor]
+  );
+  const boardBackground = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.6, 0.42),
+    [accentColor, textColor]
+  );
+  const boardBorder = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.5, 0.56),
+    [accentColor, textColor]
+  );
+  const columnBackground = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.64, 0.4),
+    [accentColor, textColor]
+  );
+  const columnBorder = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.54, 0.52),
+    [accentColor, textColor]
+  );
+  const itemBackground = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.56, 0.48),
+    [accentColor, textColor]
+  );
+  const itemBorder = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.46, 0.6),
+    [accentColor, textColor]
+  );
+  const itemActiveBackground = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.7, 0.34),
+    [accentColor, textColor]
+  );
+  const itemActiveBorder = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.62, 0.42),
+    [accentColor, textColor]
+  );
+  const itemConnectedBackground = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.52, 0.5),
+    [accentColor, textColor]
+  );
+  const itemConnectedBorder = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.46, 0.62),
+    [accentColor, textColor]
+  );
+  const itemCorrectBackground = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.72, 0.26),
+    [accentColor, textColor]
+  );
+  const itemCorrectBorder = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.62, 0.36),
+    [accentColor, textColor]
+  );
+  const badgeBackground = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.54, 0.48),
+    [accentColor, textColor]
+  );
+  const badgeBorder = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.46, 0.58),
+    [accentColor, textColor]
+  );
+  const badgeTextColor = textColor === '#0f172a' ? '#1f2937' : '#f8fafc';
+  const successIconColor = textColor === '#0f172a' ? darkenColor(accentColor, 0.2) : lightenColor(accentColor, 0.32);
+  const successFeedbackBackground = surfaceColor(accentColor, textColor, 0.7, 0.34);
+  const successFeedbackBorder = surfaceColor(accentColor, textColor, 0.6, 0.44);
+  const failureFeedbackBackground = '#fee2e2';
+  const failureFeedbackBorder = '#fca5a5';
+  const primaryButtonBackground = textColor === '#0f172a' ? darkenColor(accentColor, 0.25) : lightenColor(accentColor, 0.28);
+  const primaryButtonTextColor = textColor === '#0f172a' ? '#f8fafc' : '#0f172a';
+  const secondaryButtonBackground = surfaceColor(accentColor, textColor, 0.52, 0.5);
+  const secondaryButtonBorder = surfaceColor(accentColor, textColor, 0.46, 0.58);
+  const lineColor = surfaceColor(accentColor, textColor, 0.44, 0.58);
+  const pointerLineColor = textColor === '#0f172a' ? darkenColor(accentColor, 0.3) : lightenColor(accentColor, 0.3);
+  const showBorder = tile.content.showBorder !== false;
+  const isEmbedded = variant === 'embedded';
+  const canInteract = !isPreview;
+
+  const leftItems = useMemo<MatchingItem[]>(
+    () => tile.content.pairs.map(pair => ({ pairId: pair.id, text: pair.left })),
+    [tile.content.pairs]
+  );
+  const baseRightItems = useMemo<MatchingItem[]>(
+    () => tile.content.pairs.map(pair => ({ pairId: pair.id, text: pair.right })),
+    [tile.content.pairs]
+  );
+  const leftOrder = useMemo(() => tile.content.pairs.map(pair => pair.id), [tile.content.pairs]);
+
+  const connectionMap = useMemo(
+    () => new Map(connections.map(conn => [conn.leftId, conn.rightId])),
+    [connections]
+  );
+  const rightConnectionMap = useMemo(
+    () => new Map(connections.map(conn => [conn.rightId, conn.leftId])),
+    [connections]
+  );
+
+  const shuffleRightItems = useCallback((): MatchingItem[] => {
+    if (baseRightItems.length <= 1) return baseRightItems;
+
+    let shuffled = [...baseRightItems];
+    const isAligned = (items: MatchingItem[]) =>
+      items.every((item, index) => item.pairId === leftOrder[index]);
+
+    let attempt = 0;
+    const maxAttempts = 24;
+    do {
+      shuffled = [...baseRightItems].sort(() => Math.random() - 0.5);
+      attempt += 1;
+    } while (attempt < maxAttempts && isAligned(shuffled));
+
+    if (isAligned(shuffled)) {
+      const [first, ...rest] = shuffled;
+      shuffled = [...rest, first];
+    }
+
+    return shuffled;
+  }, [baseRightItems, leftOrder]);
+
+  const initializeExercise = useCallback(() => {
+    const shuffled = shuffleRightItems();
+    setRightItems(shuffled);
+    setConnections([]);
+    setIsChecked(false);
+    setIsCorrect(null);
+    setAttempts(0);
+    setActiveLeftId(null);
+    setPointerPosition(null);
+  }, [shuffleRightItems]);
+
+  const resetConnections = useCallback(() => {
+    const shuffled = shuffleRightItems();
+    setRightItems(shuffled);
+    setConnections([]);
+    setIsChecked(false);
+    setIsCorrect(null);
+    setActiveLeftId(null);
+    setPointerPosition(null);
+  }, [shuffleRightItems]);
+
+  const getRelativePosition = useCallback((clientX: number, clientY: number) => {
+    const rect = containerRef.current?.getBoundingClientRect();
+    if (!rect) {
+      return { x: clientX, y: clientY };
+    }
+    return { x: clientX - rect.left, y: clientY - rect.top };
+  }, []);
+
+  useEffect(() => {
+    initializeExercise();
+  }, [initializeExercise]);
+
+  useEffect(() => {
+    if (isTestingMode) {
+      initializeExercise();
+    }
+  }, [isTestingMode, initializeExercise]);
+
+  const updateLineSegments = useCallback(() => {
+    const rect = containerRef.current?.getBoundingClientRect();
+    if (!rect) {
+      setLineSegments([]);
+      return;
+    }
+
+    const segments: LineSegment[] = [];
+    connections.forEach(connection => {
+      const leftElement = leftRefs.current[connection.leftId];
+      const rightElement = rightRefs.current[connection.rightId];
+
+      if (!leftElement || !rightElement) {
+        return;
+      }
+
+      const leftRect = leftElement.getBoundingClientRect();
+      const rightRect = rightElement.getBoundingClientRect();
+
+      const start = {
+        x: leftRect.right - rect.left,
+        y: leftRect.top + leftRect.height / 2 - rect.top
+      };
+      const end = {
+        x: rightRect.left - rect.left,
+        y: rightRect.top + rightRect.height / 2 - rect.top
+      };
+
+      const isConnectionCorrect = tile.content.pairs.some(
+        pair => pair.id === connection.leftId && connection.rightId === pair.id
+      );
+
+      segments.push({
+        leftId: connection.leftId,
+        rightId: connection.rightId,
+        start,
+        end,
+        isCorrect: isChecked ? isConnectionCorrect : null
+      });
+    });
+
+    setLineSegments(segments);
+  }, [connections, isChecked, tile.content.pairs]);
+
+  useEffect(() => {
+    updateLineSegments();
+  }, [updateLineSegments]);
+
+  useEffect(() => {
+    const handleResize = () => {
+      updateLineSegments();
+    };
+
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, [updateLineSegments]);
+
+  const [pointerLine, setPointerLine] = useState<LineSegment | null>(null);
+
+  useEffect(() => {
+    if (!activeLeftId || !pointerPosition) {
+      setPointerLine(null);
+      return;
+    }
+
+    const rect = containerRef.current?.getBoundingClientRect();
+    const originElement = rect ? leftRefs.current[activeLeftId] : null;
+    if (!rect || !originElement) {
+      setPointerLine(null);
+      return;
+    }
+
+    const originRect = originElement.getBoundingClientRect();
+    setPointerLine({
+      leftId: activeLeftId,
+      rightId: '__pointer__',
+      start: {
+        x: originRect.right - rect.left,
+        y: originRect.top + originRect.height / 2 - rect.top
+      },
+      end: pointerPosition,
+      isCorrect: null
+    });
+  }, [activeLeftId, pointerPosition]);
+
+  useEffect(() => {
+    if (!activeLeftId || !canInteract) return;
+
+    const handlePointerMove = (event: PointerEvent) => {
+      setPointerPosition(getRelativePosition(event.clientX, event.clientY));
+    };
+
+    const handlePointerUp = () => {
+      setActiveLeftId(null);
+      setPointerPosition(null);
+    };
+
+    window.addEventListener('pointermove', handlePointerMove);
+    window.addEventListener('pointerup', handlePointerUp);
+
+    return () => {
+      window.removeEventListener('pointermove', handlePointerMove);
+      window.removeEventListener('pointerup', handlePointerUp);
+    };
+  }, [activeLeftId, canInteract, getRelativePosition]);
+
+  const resetCheckState = useCallback(() => {
+    if (isChecked) {
+      setIsChecked(false);
+      setIsCorrect(null);
+    }
+  }, [isChecked]);
+
+  const handleLeftPointerDown = (event: React.PointerEvent<HTMLButtonElement>, pairId: string) => {
+    if (!canInteract) return;
+
+    event.preventDefault();
+    event.stopPropagation();
+
+    const position = getRelativePosition(event.clientX, event.clientY);
+    setPointerPosition(position);
+    setActiveLeftId(pairId);
+    setConnections(prev => prev.filter(connection => connection.leftId !== pairId));
+    resetCheckState();
+  };
+
+  const handleRightPointerUp = (event: React.PointerEvent<HTMLButtonElement>, pairId: string) => {
+    if (!canInteract || !activeLeftId) return;
+
+    event.preventDefault();
+    event.stopPropagation();
+
+    setConnections(prev => {
+      const filtered = prev.filter(
+        connection => connection.leftId !== activeLeftId && connection.rightId !== pairId
+      );
+      return [...filtered, { leftId: activeLeftId, rightId: pairId }];
+    });
+
+    setActiveLeftId(null);
+    setPointerPosition(null);
+    resetCheckState();
+  };
+
+  const isComplete = connections.length === tile.content.pairs.length;
+
+  const handleCheck = () => {
+    if (!canInteract) return;
+
+    const allCorrect = tile.content.pairs.every(pair => connectionMap.get(pair.id) === pair.id);
+    setIsCorrect(allCorrect);
+    setIsChecked(true);
+    setAttempts(prev => prev + 1);
+  };
+
+  const handleReset = () => {
+    resetConnections();
+  };
+
+  const getLeftItemStyles = (pairId: string): React.CSSProperties => {
+    const connectedRightId = connectionMap.get(pairId);
+    const isActive = activeLeftId === pairId;
+    const connectionCorrect = isChecked && connectedRightId ? connectedRightId === pairId : null;
+
+    if (connectionCorrect) {
+      return {
+        backgroundColor: itemCorrectBackground,
+        borderColor: itemCorrectBorder,
+        boxShadow: '0 18px 36px rgba(15, 23, 42, 0.16)'
+      };
+    }
+
+    if (isChecked && connectedRightId && connectedRightId !== pairId) {
+      return {
+        backgroundColor: '#fee2e2',
+        borderColor: '#f87171'
+      };
+    }
+
+    if (isActive) {
+      return {
+        backgroundColor: itemActiveBackground,
+        borderColor: itemActiveBorder,
+        boxShadow: '0 18px 36px rgba(15, 23, 42, 0.2)'
+      };
+    }
+
+    if (connectedRightId) {
+      return {
+        backgroundColor: itemConnectedBackground,
+        borderColor: itemConnectedBorder
+      };
+    }
+
+    return {
+      backgroundColor: itemBackground,
+      borderColor: itemBorder
+    };
+  };
+
+  const getRightItemStyles = (pairId: string): React.CSSProperties => {
+    const connectedLeftId = rightConnectionMap.get(pairId);
+    const connectionCorrect = isChecked && connectedLeftId ? connectedLeftId === pairId : null;
+
+    if (connectionCorrect) {
+      return {
+        backgroundColor: itemCorrectBackground,
+        borderColor: itemCorrectBorder,
+        boxShadow: '0 18px 36px rgba(15, 23, 42, 0.16)'
+      };
+    }
+
+    if (isChecked && connectedLeftId && connectedLeftId !== pairId) {
+      return {
+        backgroundColor: '#fee2e2',
+        borderColor: '#f87171'
+      };
+    }
+
+    if (connectedLeftId) {
+      return {
+        backgroundColor: itemConnectedBackground,
+        borderColor: itemConnectedBorder
+      };
+    }
+
+    return {
+      backgroundColor: itemBackground,
+      borderColor: itemBorder
+    };
+  };
+
+  const segmentsToRender = pointerLine ? [...lineSegments, pointerLine] : lineSegments;
+
+  const getLineStroke = (segment: LineSegment) => {
+    if (segment.rightId === '__pointer__') {
+      return pointerLineColor;
+    }
+
+    if (segment.isCorrect === true) {
+      return successIconColor;
+    }
+
+    if (segment.isCorrect === false) {
+      return '#ef4444';
+    }
+
+    return lineColor;
+  };
+
+  const handleTileDoubleClick = (event: React.MouseEvent) => {
+    if (isPreview || isTestingMode) return;
+
+    event.preventDefault();
+    event.stopPropagation();
+    onRequestTextEditing?.();
+  };
+
+  return (
+    <div className="relative w-full h-full" onDoubleClick={handleTileDoubleClick}>
+      <div
+        className={`w-full h-full flex flex-col gap-6 transition-all duration-300 ${
+          isEmbedded
+            ? 'p-6'
+            : `rounded-3xl ${showBorder ? 'border' : ''} shadow-2xl shadow-slate-950/40 p-6 overflow-hidden`
+        }`}
+        style={{
+          backgroundColor: isEmbedded ? 'transparent' : accentColor,
+          backgroundImage: isEmbedded ? undefined : `linear-gradient(135deg, ${gradientStart}, ${gradientEnd})`,
+          color: textColor,
+          borderColor: !isEmbedded && showBorder ? frameBorderColor : undefined
+        }}
+      >
+        <TaskInstructionPanel
+          icon={<Sparkles className="w-4 h-4" />}
+          label="Zadanie"
+          className="border"
+          style={{
+            backgroundColor: panelBackground,
+            borderColor: panelBorder,
+            color: textColor
+          }}
+          iconWrapperClassName="w-9 h-9 rounded-xl flex items-center justify-center shadow-sm"
+          iconWrapperStyle={{
+            backgroundColor: iconBackground,
+            color: textColor
+          }}
+          labelStyle={{ color: mutedLabelColor }}
+          bodyClassName="px-5 pb-5"
+        >
+          {instructionContent ?? (
+            <div
+              className="text-base leading-relaxed"
+              style={{
+                fontFamily: tile.content.fontFamily,
+                fontSize: `${tile.content.fontSize}px`
+              }}
+              dangerouslySetInnerHTML={{
+                __html: tile.content.richQuestion || tile.content.question
+              }}
+            />
+          )}
+        </TaskInstructionPanel>
+
+        <div
+          className="rounded-2xl border px-5 py-4 flex items-center justify-between"
+          style={{ backgroundColor: columnBackground, borderColor: columnBorder, color: subtleCaptionColor }}
+        >
+          <div className="flex items-center gap-2 text-sm font-semibold" style={{ color: subtleCaptionColor }}>
+            <Link2 className="w-4 h-4" />
+            <span>Połącz elementy z lewej i prawej kolumny</span>
+          </div>
+          <div className="flex items-center gap-2 text-xs uppercase tracking-[0.28em]" style={{ color: subtleCaptionColor }}>
+            <Shuffle className="w-4 h-4" />
+            <span>Zacznij przeciągając z lewej</span>
+          </div>
+        </div>
+
+        {isTestingMode && (
+          <div className="text-[11px] uppercase tracking-[0.32em]" style={{ color: testingCaptionColor }}>
+            Tryb testowania
+          </div>
+        )}
+
+        {attempts > 0 && (
+          <div className="text-xs uppercase tracking-[0.32em]" style={{ color: testingCaptionColor }}>
+            Próba #{attempts}
+          </div>
+        )}
+
+        <div className="relative flex-1 min-h-[260px]">
+          <div
+            ref={containerRef}
+            className="relative h-full w-full rounded-3xl border overflow-hidden"
+            style={{ backgroundColor: boardBackground, borderColor: boardBorder }}
+          >
+            <svg className="absolute inset-0 w-full h-full pointer-events-none" fill="none">
+              {segmentsToRender.map((segment, index) => {
+                const stroke = getLineStroke(segment);
+                const controlOffset = Math.max(Math.abs(segment.end.x - segment.start.x) * 0.45, 80);
+
+                return (
+                  <g key={`${segment.leftId}-${segment.rightId}-${index}`}>
+                    <path
+                      d={`M ${segment.start.x} ${segment.start.y} C ${segment.start.x + controlOffset} ${segment.start.y}, ${segment.end.x - controlOffset} ${segment.end.y}, ${segment.end.x} ${segment.end.y}`}
+                      stroke={stroke}
+                      strokeWidth={segment.rightId === '__pointer__' ? 2.5 : 3.5}
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeDasharray={segment.rightId === '__pointer__' ? '8 8' : undefined}
+                      opacity={segment.rightId === '__pointer__' ? 0.8 : 1}
+                    />
+                    {segment.rightId !== '__pointer__' && (
+                      <circle cx={segment.end.x} cy={segment.end.y} r={5} fill={stroke} />
+                    )}
+                    <circle cx={segment.start.x} cy={segment.start.y} r={segment.rightId === '__pointer__' ? 4 : 5} fill={stroke} />
+                  </g>
+                );
+              })}
+            </svg>
+
+            <div className="relative grid grid-cols-1 lg:grid-cols-2 gap-6 h-full px-6 py-6">
+              <div className="flex flex-col space-y-4">
+                <div className="flex items-center justify-between text-xs uppercase tracking-[0.3em]" style={{ color: subtleCaptionColor }}>
+                  <span>Lewa kolumna</span>
+                  <span>Element</span>
+                </div>
+                <div className="space-y-3 overflow-auto pr-1">
+                  {leftItems.map((item, index) => (
+                    <button
+                      key={item.pairId}
+                      type="button"
+                      className="w-full text-left rounded-2xl border-2 shadow-sm px-4 py-3 transition-all duration-200 cursor-pointer"
+                      style={getLeftItemStyles(item.pairId)}
+                      onPointerDown={event => handleLeftPointerDown(event, item.pairId)}
+                      disabled={!canInteract}
+                    >
+                      <div
+                        className="flex items-center gap-3"
+                        ref={element => {
+                          if (element) {
+                            leftRefs.current[item.pairId] = element;
+                          } else {
+                            delete leftRefs.current[item.pairId];
+                          }
+                        }}
+                      >
+                        <div
+                          className="flex h-8 w-8 items-center justify-center rounded-xl border text-xs font-semibold"
+                          style={{ backgroundColor: badgeBackground, borderColor: badgeBorder, color: badgeTextColor }}
+                        >
+                          {index + 1}
+                        </div>
+                        <span className="text-sm font-medium" style={{ color: textColor }}>
+                          {item.text}
+                        </span>
+                      </div>
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              <div className="flex flex-col space-y-4">
+                <div className="flex items-center justify-between text-xs uppercase tracking-[0.3em]" style={{ color: subtleCaptionColor }}>
+                  <span>Prawa kolumna</span>
+                  <span>Odpowiedź</span>
+                </div>
+                <div className="space-y-3 overflow-auto pr-1">
+                  {rightItems.map((item, index) => (
+                    <button
+                      key={item.pairId}
+                      type="button"
+                      className="w-full text-left rounded-2xl border-2 shadow-sm px-4 py-3 transition-all duration-200"
+                      style={getRightItemStyles(item.pairId)}
+                      onPointerUp={event => handleRightPointerUp(event, item.pairId)}
+                      disabled={!canInteract}
+                    >
+                      <div
+                        className="flex items-center gap-3"
+                        ref={element => {
+                          if (element) {
+                            rightRefs.current[item.pairId] = element;
+                          } else {
+                            delete rightRefs.current[item.pairId];
+                          }
+                        }}
+                      >
+                        <div
+                          className="flex h-8 w-8 items-center justify-center rounded-xl border text-xs font-semibold"
+                          style={{ backgroundColor: badgeBackground, borderColor: badgeBorder, color: badgeTextColor }}
+                        >
+                          {String.fromCharCode(65 + index)}
+                        </div>
+                        <span className="text-sm font-medium" style={{ color: textColor }}>
+                          {item.text}
+                        </span>
+                      </div>
+                    </button>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4">
+          <div className="flex flex-wrap items-center gap-3">
+            <button
+              type="button"
+              onClick={handleCheck}
+              disabled={!canInteract || !isComplete}
+              className={`inline-flex items-center gap-2 px-5 py-3 rounded-xl font-semibold shadow-sm transition-all duration-200 ${
+                !canInteract || !isComplete ? 'opacity-60 cursor-not-allowed' : 'hover:brightness-105'
+              }`}
+              style={{
+                backgroundColor: primaryButtonBackground,
+                color: primaryButtonTextColor
+              }}
+            >
+              <CheckCircle className="w-4 h-4" />
+              <span>Sprawdź odpowiedź</span>
+            </button>
+
+            <button
+              type="button"
+              onClick={handleReset}
+              disabled={!canInteract}
+              className={`inline-flex items-center gap-2 px-5 py-3 rounded-xl font-semibold border transition-all duration-200 ${
+                !canInteract ? 'opacity-60 cursor-not-allowed' : 'hover:brightness-105'
+              }`}
+              style={{
+                backgroundColor: secondaryButtonBackground,
+                borderColor: secondaryButtonBorder,
+                color: textColor
+              }}
+            >
+              <RotateCcw className="w-4 h-4" />
+              <span>Resetuj</span>
+            </button>
+          </div>
+
+          {isChecked && (
+            <div
+              className={`flex items-center gap-3 rounded-2xl border px-4 py-3 text-sm font-medium ${
+                isCorrect ? 'bg-emerald-100/90 text-emerald-900' : 'bg-rose-100/90 text-rose-900'
+              }`}
+              style={{
+                backgroundColor: isCorrect ? successFeedbackBackground : failureFeedbackBackground,
+                borderColor: isCorrect ? successFeedbackBorder : failureFeedbackBorder,
+                color: isCorrect ? successIconColor : '#b91c1c'
+              }}
+            >
+              {isCorrect ? <CheckCircle className="w-4 h-4" /> : <XCircle className="w-4 h-4" />}
+              <span>
+                {isCorrect ? tile.content.correctFeedback : tile.content.incorrectFeedback}
+              </span>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/admin/TileRenderer.tsx
+++ b/src/components/admin/TileRenderer.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Move, Trash2, Play, Code2 } from 'lucide-react';
-import { LessonTile, TextTile, ImageTile, QuizTile, ProgrammingTile, SequencingTile } from '../../types/lessonEditor';
+import { LessonTile, TextTile, ImageTile, QuizTile, ProgrammingTile, SequencingTile, MatchingTile } from '../../types/lessonEditor';
 import { GridUtils } from '../../utils/gridUtils';
 import { Editor, EditorContent, useEditor } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
@@ -14,6 +14,7 @@ import OrderedList from '@tiptap/extension-ordered-list';
 import ListItem from '@tiptap/extension-list-item';
 import TextAlign from '../../extensions/TextAlign';
 import { SequencingInteractive } from './SequencingInteractive';
+import { MatchingInteractive } from './MatchingInteractive';
 import { TaskInstructionPanel } from './common/TaskInstructionPanel';
 import { QuizInteractive } from './QuizInteractive';
 
@@ -690,6 +691,66 @@ export const TileRenderer: React.FC<TileRendererProps> = ({
         }
         break;
       }
+
+      case 'matching': {
+        const matchingTile = tile as MatchingTile;
+        const accentColor = matchingTile.content.backgroundColor || computedBackground;
+        const textColor = getReadableTextColor(accentColor);
+
+        const renderMatchingContent = (instructionContent?: React.ReactNode, isPreviewMode = false) => (
+          <MatchingInteractive
+            tile={matchingTile}
+            isTestingMode={isTestingMode}
+            instructionContent={instructionContent}
+            isPreview={isPreviewMode}
+            onRequestTextEditing={isPreviewMode ? undefined : onDoubleClick}
+          />
+        );
+
+        if (isEditingText && isSelected) {
+          const questionEditorTile = {
+            ...tile,
+            type: 'text',
+            content: {
+              text: matchingTile.content.question,
+              richText: matchingTile.content.richQuestion,
+              fontFamily: matchingTile.content.fontFamily,
+              fontSize: matchingTile.content.fontSize,
+              verticalAlign: matchingTile.content.verticalAlign,
+              backgroundColor: matchingTile.content.backgroundColor,
+              showBorder: matchingTile.content.showBorder
+            }
+          } as TextTile;
+
+          contentToRender = renderMatchingContent(
+            <RichTextEditor
+              textTile={questionEditorTile}
+              tileId={tile.id}
+              textColor={textColor}
+              onUpdateTile={(tileId, updates) => {
+                if (!updates.content) return;
+
+                onUpdateTile(tileId, {
+                  content: {
+                    ...matchingTile.content,
+                    question: updates.content.text ?? matchingTile.content.question,
+                    richQuestion: updates.content.richText ?? matchingTile.content.richQuestion,
+                    fontFamily: updates.content.fontFamily ?? matchingTile.content.fontFamily,
+                    fontSize: updates.content.fontSize ?? matchingTile.content.fontSize,
+                    verticalAlign: updates.content.verticalAlign ?? matchingTile.content.verticalAlign
+                  }
+                });
+              }}
+              onFinishTextEditing={onFinishTextEditing}
+              onEditorReady={onEditorReady}
+            />,
+            true
+          );
+        } else {
+          contentToRender = renderMatchingContent();
+        }
+        break;
+      }
       default:
         contentToRender = (
           <div className="w-full h-full flex items-center justify-center">
@@ -746,7 +807,7 @@ export const TileRenderer: React.FC<TileRendererProps> = ({
         height: tile.size.height
       }}
       onMouseDown={isDraggingImage || isTestingMode ? undefined : onMouseDown}
-      onDoubleClick={tile.type === 'sequencing' ? undefined : onDoubleClick}
+      onDoubleClick={tile.type === 'sequencing' || tile.type === 'matching' ? undefined : onDoubleClick}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
     >

--- a/src/components/admin/side editor/MatchingEditor.tsx
+++ b/src/components/admin/side editor/MatchingEditor.tsx
@@ -1,0 +1,222 @@
+import React, { useState } from 'react';
+import { Plus, Trash2, GripVertical, Sparkles, Square } from 'lucide-react';
+import { MatchingTile } from '../../../types/lessonEditor.ts';
+
+interface MatchingEditorProps {
+  tile: MatchingTile;
+  onUpdateTile: (tileId: string, updates: Partial<MatchingTile>) => void;
+  isTesting?: boolean;
+  onToggleTesting?: (tileId: string) => void;
+}
+
+export const MatchingEditor: React.FC<MatchingEditorProps> = ({
+  tile,
+  onUpdateTile,
+  isTesting = false,
+  onToggleTesting
+}) => {
+  const [draggedPair, setDraggedPair] = useState<string | null>(null);
+
+  const handleContentUpdate = (field: string, value: any) => {
+    onUpdateTile(tile.id, {
+      content: {
+        ...tile.content,
+        [field]: value
+      },
+      updated_at: new Date().toISOString()
+    });
+  };
+
+  const handlePairUpdate = (pairId: string, field: 'left' | 'right', value: string) => {
+    const updatedPairs = tile.content.pairs.map(pair =>
+      pair.id === pairId ? { ...pair, [field]: value } : pair
+    );
+    handleContentUpdate('pairs', updatedPairs);
+  };
+
+  const addNewPair = () => {
+    const newIndex = tile.content.pairs.length + 1;
+    const newPair = {
+      id: `pair-${Date.now()}`,
+      left: `Element ${newIndex}`,
+      right: `Dopasowanie ${newIndex}`
+    };
+    handleContentUpdate('pairs', [...tile.content.pairs, newPair]);
+  };
+
+  const removePair = (pairId: string) => {
+    if (tile.content.pairs.length <= 2) return;
+    const updatedPairs = tile.content.pairs.filter(pair => pair.id !== pairId);
+    handleContentUpdate('pairs', updatedPairs);
+  };
+
+  const handleDragStart = (event: React.DragEvent, pairId: string) => {
+    setDraggedPair(pairId);
+    event.dataTransfer.effectAllowed = 'move';
+  };
+
+  const handleDragOver = (event: React.DragEvent) => {
+    event.preventDefault();
+    event.dataTransfer.dropEffect = 'move';
+  };
+
+  const handleDrop = (event: React.DragEvent, targetPairId: string) => {
+    event.preventDefault();
+
+    if (!draggedPair || draggedPair === targetPairId) {
+      setDraggedPair(null);
+      return;
+    }
+
+    const pairs = [...tile.content.pairs];
+    const draggedIndex = pairs.findIndex(pair => pair.id === draggedPair);
+    const targetIndex = pairs.findIndex(pair => pair.id === targetPairId);
+
+    if (draggedIndex === -1 || targetIndex === -1) {
+      setDraggedPair(null);
+      return;
+    }
+
+    const [draggedPairData] = pairs.splice(draggedIndex, 1);
+    pairs.splice(targetIndex, 0, draggedPairData);
+
+    handleContentUpdate('pairs', pairs);
+    setDraggedPair(null);
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="p-4 rounded-lg border border-gray-200 bg-white shadow-sm">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <h3 className="text-sm font-semibold text-gray-900">Tryb testowania</h3>
+            <p className="text-xs text-gray-600 mt-1">
+              {isTesting
+                ? 'Tryb ucznia jest aktywny. Kafelek na płótnie jest zablokowany przed przypadkową edycją.'
+                : 'Wyłącz interakcje edycyjne kafelka i sprawdź zadanie dokładnie tak, jak zobaczy je uczeń.'}
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => onToggleTesting?.(tile.id)}
+            disabled={!onToggleTesting}
+            className={`inline-flex items-center gap-2 px-3 py-2 text-xs font-medium rounded-lg transition-colors shadow-sm ${
+              isTesting
+                ? 'bg-slate-900 text-white hover:bg-slate-800'
+                : 'bg-blue-600 text-white hover:bg-blue-500'
+            } disabled:opacity-60 disabled:cursor-not-allowed`}
+          >
+            {isTesting ? <Square className="w-4 h-4" /> : <Sparkles className="w-4 h-4" />}
+            <span>{isTesting ? 'Zakończ testowanie' : 'Przetestuj zadanie'}</span>
+          </button>
+        </div>
+      </div>
+
+      <div>
+        <div className="flex items-center justify-between mb-3">
+          <label className="block text-sm font-medium text-gray-700">
+            Parowanie ({tile.content.pairs.length})
+          </label>
+          <button
+            onClick={addNewPair}
+            className="flex items-center space-x-1 px-3 py-1 bg-blue-600 text-white text-xs rounded hover:bg-blue-700 transition-colors"
+          >
+            <Plus className="w-3 h-3" />
+            <span>Dodaj</span>
+          </button>
+        </div>
+
+        <div className="space-y-2 max-h-72 overflow-y-auto">
+          {tile.content.pairs.map((pair, index) => (
+            <div
+              key={pair.id}
+              draggable
+              onDragStart={event => handleDragStart(event, pair.id)}
+              onDragOver={handleDragOver}
+              onDrop={event => handleDrop(event, pair.id)}
+              className={`flex flex-col gap-2 p-3 bg-white border rounded-lg transition-all ${
+                draggedPair === pair.id ? 'opacity-60 scale-95' : 'hover:shadow-sm'
+              }`}
+            >
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-2 text-xs text-gray-500 uppercase tracking-[0.2em]">
+                  <GripVertical className="w-4 h-4 text-gray-400 cursor-grab" />
+                  <span>Para {index + 1}</span>
+                </div>
+                <button
+                  onClick={() => removePair(pair.id)}
+                  disabled={tile.content.pairs.length <= 2}
+                  className="p-1 text-red-400 hover:text-red-600 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                  title="Usuń parę"
+                >
+                  <Trash2 className="w-3 h-3" />
+                </button>
+              </div>
+
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
+                <div className="flex flex-col gap-1">
+                  <label className="text-xs font-semibold text-gray-600">Lewa kolumna</label>
+                  <input
+                    type="text"
+                    value={pair.left}
+                    onChange={event => handlePairUpdate(pair.id, 'left', event.target.value)}
+                    className="w-full px-3 py-2 text-sm border border-gray-200 rounded focus:ring-1 focus:ring-blue-500 focus:border-transparent"
+                    placeholder="Tekst elementu"
+                  />
+                </div>
+                <div className="flex flex-col gap-1">
+                  <label className="text-xs font-semibold text-gray-600">Prawa kolumna</label>
+                  <input
+                    type="text"
+                    value={pair.right}
+                    onChange={event => handlePairUpdate(pair.id, 'right', event.target.value)}
+                    className="w-full px-3 py-2 text-sm border border-gray-200 rounded focus:ring-1 focus:ring-blue-500 focus:border-transparent"
+                    placeholder="Tekst dopasowania"
+                  />
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {tile.content.pairs.length < 2 && (
+          <div className="text-xs text-amber-600 bg-amber-50 p-2 rounded mt-2">
+            ⚠️ Dodaj co najmniej 2 pary, aby ćwiczenie było funkcjonalne
+          </div>
+        )}
+      </div>
+
+      <div className="space-y-4">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-3">Kolor tła kafelka</label>
+          <input
+            type="color"
+            value={tile.content.backgroundColor}
+            onChange={event => handleContentUpdate('backgroundColor', event.target.value)}
+            className="w-full h-12 border border-gray-300 rounded-lg cursor-pointer"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-2">Komunikat poprawnej odpowiedzi</label>
+          <textarea
+            value={tile.content.correctFeedback}
+            onChange={event => handleContentUpdate('correctFeedback', event.target.value)}
+            className="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:ring-1 focus:ring-blue-500 focus:border-transparent resize-vertical"
+            rows={3}
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-2">Komunikat niepoprawnej odpowiedzi</label>
+          <textarea
+            value={tile.content.incorrectFeedback}
+            onChange={event => handleContentUpdate('incorrectFeedback', event.target.value)}
+            className="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:ring-1 focus:ring-blue-500 focus:border-transparent resize-vertical"
+            rows={3}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/admin/side editor/TilePalette.tsx
+++ b/src/components/admin/side editor/TilePalette.tsx
@@ -37,6 +37,11 @@ const TILE_TYPES: TilePaletteItem[] = [
     type: 'sequencing',
     title: 'Ćwiczenie sekwencyjne',
     icon: 'ArrowUpDown'
+  },
+  {
+    type: 'matching',
+    title: 'Ćwiczenie dopasowywania',
+    icon: 'Puzzle'
   }
 ];
 

--- a/src/components/admin/side editor/TileSideEditor.tsx
+++ b/src/components/admin/side editor/TileSideEditor.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { Plus, Trash2, Type, X } from 'lucide-react';
-import { TextTile, ImageTile, LessonTile, ProgrammingTile, SequencingTile, QuizTile } from '../../../types/lessonEditor.ts';
+import { TextTile, ImageTile, LessonTile, ProgrammingTile, SequencingTile, QuizTile, MatchingTile } from '../../../types/lessonEditor.ts';
 import { ImageUploadComponent } from './ImageUploadComponent.tsx';
 import { ImagePositionControl } from './ImagePositionControl.tsx';
 import { SequencingEditor } from './SequencingEditor.tsx';
+import { MatchingEditor } from './MatchingEditor.tsx';
 
 interface TileSideEditorProps {
   tile: LessonTile | undefined;
@@ -263,6 +264,18 @@ export const TileSideEditor: React.FC<TileSideEditorProps> = ({
         return (
           <SequencingEditor
             tile={sequencingTile}
+            onUpdateTile={onUpdateTile}
+            isTesting={isTesting}
+            onToggleTesting={onToggleTesting}
+          />
+        );
+      }
+
+      case 'matching': {
+        const matchingTile = tile as MatchingTile;
+        return (
+          <MatchingEditor
+            tile={matchingTile}
             onUpdateTile={onUpdateTile}
             isTesting={isTesting}
             onToggleTesting={onToggleTesting}

--- a/src/components/admin/top editor/TopToolbar.tsx
+++ b/src/components/admin/top editor/TopToolbar.tsx
@@ -5,7 +5,7 @@ import { FontSizeSelector } from './FontSizeSelector.tsx';
 import { TextColorPicker } from './TextColorPicker.tsx';
 import { FontSelector } from './FontSelector.tsx';
 import { AlignmentControls } from './AlignmentControls.tsx';
-import { LessonTile, ProgrammingTile, TextTile, SequencingTile } from '../../../types/lessonEditor.ts';
+import { LessonTile, ProgrammingTile, TextTile, SequencingTile, MatchingTile } from '../../../types/lessonEditor.ts';
 
 
 interface TopToolbarProps {
@@ -16,7 +16,7 @@ interface TopToolbarProps {
   isTextEditing: boolean;
   onFinishTextEditing?: () => void;
   editor?: Editor | null;
-  selectedTile?: TextTile | ProgrammingTile | SequencingTile | null;
+  selectedTile?: TextTile | ProgrammingTile | SequencingTile | MatchingTile | null;
   onUpdateTile?: (tileId: string, updates: Partial<LessonTile>) => void;
   className?: string;
 }
@@ -65,7 +65,7 @@ export const TopToolbar: React.FC<TopToolbarProps> = ({
   }, [editor]);
 
   useEffect(() => {
-    if (selectedTile?.type === 'text' || selectedTile?.type === 'sequencing') {
+    if (selectedTile?.type === 'text' || selectedTile?.type === 'sequencing' || selectedTile?.type === 'matching') {
       setVerticalAlign(selectedTile.content.verticalAlign || 'top');
     }
   }, [selectedTile]);

--- a/src/hooks/useTileInteractions.ts
+++ b/src/hooks/useTileInteractions.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, RefObject } from 'react';
-import { LessonContent, LessonTile, GridPosition, EditorState, TextTile, ImageTile, SequencingTile } from '../types/lessonEditor';
+import { LessonContent, LessonTile, GridPosition, EditorState, TextTile, ImageTile } from '../types/lessonEditor';
 import { EditorAction } from '../state/editorReducer';
 import { GridUtils } from '../utils/gridUtils';
 import { logger } from '../utils/logger';
@@ -33,6 +33,7 @@ export const useTileInteractions = ({
       tile.type === 'text' ||
       tile.type === 'programming' ||
       tile.type === 'sequencing' ||
+      tile.type === 'matching' ||
       tile.type === 'quiz'
     ) {
       dispatch({ type: 'startTextEditing', tileId: tile.id });

--- a/src/services/lessonContentService.ts
+++ b/src/services/lessonContentService.ts
@@ -1,5 +1,5 @@
 import { LessonContent, LessonTile, TextTile } from '../types/lessonEditor';
-import { ProgrammingTile, SequencingTile } from '../types/lessonEditor';
+import { ProgrammingTile, SequencingTile, MatchingTile } from '../types/lessonEditor';
 import { GridUtils } from '../utils/gridUtils';
 import { logger } from '../utils/logger';
 
@@ -397,6 +397,66 @@ export class LessonContentService {
         ],
         correctFeedback: 'Świetnie! Prawidłowa kolejność.',
         incorrectFeedback: 'Spróbuj ponownie. Sprawdź kolejność elementów.'
+      },
+      created_at: now,
+      updated_at: now,
+      z_index: 1
+    };
+  }
+
+  /**
+   * Create a new matching tile
+   */
+  static createMatchingTile(position: { x: number; y: number }, page = 1): MatchingTile {
+    const id = `tile-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+    const now = new Date().toISOString();
+
+    const gridPos = GridUtils.pixelToGrid(position, {
+      width: GridUtils.GRID_COLUMNS,
+      height: 6,
+      gridSize: GridUtils.GRID_CELL_SIZE,
+      snapToGrid: true
+    });
+
+    gridPos.colSpan = 4;
+    gridPos.rowSpan = 5;
+
+    const pixelPos = GridUtils.gridToPixel(gridPos, {
+      width: GridUtils.GRID_COLUMNS,
+      height: 6,
+      gridSize: GridUtils.GRID_CELL_SIZE,
+      snapToGrid: true
+    });
+
+    const pixelSize = GridUtils.gridSizeToPixel(gridPos, {
+      width: GridUtils.GRID_COLUMNS,
+      height: 6,
+      gridSize: GridUtils.GRID_CELL_SIZE,
+      snapToGrid: true
+    });
+
+    return {
+      id,
+      type: 'matching',
+      position: pixelPos,
+      size: pixelSize,
+      gridPosition: gridPos,
+      page,
+      content: {
+        question: 'Połącz elementy w pasujące pary',
+        richQuestion: '<p style="margin: 0;">Połącz elementy w pasujące pary</p>',
+        fontFamily: 'Inter, system-ui, sans-serif',
+        fontSize: 16,
+        verticalAlign: 'top',
+        backgroundColor: '#D4D4D4',
+        showBorder: true,
+        pairs: [
+          { id: 'pair-1', left: 'Element A', right: 'Dopasowanie 1' },
+          { id: 'pair-2', left: 'Element B', right: 'Dopasowanie 2' },
+          { id: 'pair-3', left: 'Element C', right: 'Dopasowanie 3' }
+        ],
+        correctFeedback: 'Świetnie! Wszystkie połączenia są prawidłowe.',
+        incorrectFeedback: 'Sprawdź ponownie. Niektóre połączenia są niepoprawne.'
       },
       created_at: now,
       updated_at: now,

--- a/src/types/lessonEditor.ts
+++ b/src/types/lessonEditor.ts
@@ -17,7 +17,7 @@ export interface GridPosition {
 
 export interface LessonTile {
   id: string;
-  type: 'text' | 'image' | 'visualization' | 'quiz' | 'programming' | 'sequencing';
+  type: 'text' | 'image' | 'visualization' | 'quiz' | 'programming' | 'sequencing' | 'matching';
   position: Position;
   size: Size;
   gridPosition: GridPosition;
@@ -122,6 +122,26 @@ export interface SequencingTile extends LessonTile {
       id: string;
       text: string;
       correctPosition: number; // 0-based index for correct order
+    }>;
+    correctFeedback: string;
+    incorrectFeedback: string;
+  };
+}
+
+export interface MatchingTile extends LessonTile {
+  type: 'matching';
+  content: {
+    question: string; // The main question/prompt
+    richQuestion?: string; // HTML content with formatting for the question
+    fontFamily: string;
+    fontSize: number;
+    verticalAlign: 'top' | 'center' | 'bottom';
+    backgroundColor: string;
+    showBorder: boolean;
+    pairs: Array<{
+      id: string;
+      left: string;
+      right: string;
     }>;
     correctFeedback: string;
     incorrectFeedback: string;


### PR DESCRIPTION
## Summary
- add a matching tile type, default content factory, and palette option so editors can place the new task
- implement a MatchingInteractive tile experience with drag-to-connect links, validation, and testing feedback aligned with existing styling
- extend editor tooling with a matching side editor, toolbar support, and renderer integration for rich text editing of the tile prompt

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68dacef254f08321a4655b50ae96ea10