### PR TITLE
Add matching pairs interactive tile to lesson editor

### DIFF
--- a/src/Pages/LessonEditor.tsx
+++ b/src/Pages/LessonEditor.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import { ArrowLeft, Save, RotateCcw, Grid, Edit } from 'lucide-react';
 import { Lesson, Course } from '../types/course.ts';
 import { LessonContent, LessonTile, ProgrammingTile, TextTile } from '../types/lessonEditor.ts';
-import { SequencingTile } from '../types/lessonEditor.ts';
+import { SequencingTile, MatchingTile } from '../types/lessonEditor.ts';
 import { useLessonEditor } from '../hooks/useLessonEditor.ts';
 import { LessonContentService } from '../services/lessonContentService.ts';
 import { TilePalette } from '../components/admin/side editor/TilePalette.tsx';
@@ -24,8 +24,13 @@ interface LessonEditorProps {
   onBack: () => void;
 }
 
-const isRichTextTile = (tile: LessonTile | null): tile is TextTile | ProgrammingTile | SequencingTile => {
-  return !!tile && (tile.type === 'text' || tile.type === 'programming' || tile.type === 'sequencing');
+const isRichTextTile = (
+  tile: LessonTile | null
+): tile is TextTile | ProgrammingTile | SequencingTile | MatchingTile => {
+  return (
+    !!tile &&
+    (tile.type === 'text' || tile.type === 'programming' || tile.type === 'sequencing' || tile.type === 'matching')
+  );
 };
 
 export const LessonEditor: React.FC<LessonEditorProps> = ({ lesson, course, onBack }) => {
@@ -253,6 +258,9 @@ export const LessonEditor: React.FC<LessonEditorProps> = ({ lesson, course, onBa
       case 'sequencing':
         newTile = LessonContentService.createSequencingTile(position, currentPage);
         break;
+      case 'matching':
+        newTile = LessonContentService.createMatchingTile(position, currentPage);
+        break;
       default:
         logger.warn(`Tile type ${tileType} not implemented yet`);
         warning('Funkcja niedostępna', `Typ kafelka "${tileType}" nie jest jeszcze dostępny`);
@@ -313,7 +321,13 @@ export const LessonEditor: React.FC<LessonEditorProps> = ({ lesson, course, onBa
         };
 
         // Special handling for text-based tiles to ensure content properties are merged
-        if ((tile.type === 'text' || tile.type === 'programming' || tile.type === 'sequencing') && updates.content) {
+        if (
+          (tile.type === 'text' ||
+            tile.type === 'programming' ||
+            tile.type === 'sequencing' ||
+            tile.type === 'matching') &&
+          updates.content
+        ) {
           updatedTile.content = {
             ...tile.content,
             ...updates.content

--- a/src/components/admin/MatchingInteractive.tsx
+++ b/src/components/admin/MatchingInteractive.tsx
@@ -1,0 +1,765 @@
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState
+} from 'react';
+import { CheckCircle, XCircle, RotateCcw, Sparkles, Link2, Shuffle } from 'lucide-react';
+import { MatchingTile } from '../../types/lessonEditor';
+import { TaskInstructionPanel } from './common/TaskInstructionPanel';
+
+interface MatchingInteractiveProps {
+  tile: MatchingTile;
+  isPreview?: boolean;
+  isTestingMode?: boolean;
+  onRequestTextEditing?: () => void;
+  instructionContent?: React.ReactNode;
+  variant?: 'standalone' | 'embedded';
+}
+
+interface MatchingOption {
+  id: string;
+  text: string;
+}
+
+interface Connection {
+  leftId: string;
+  rightId: string;
+}
+
+interface ActiveConnection {
+  leftId: string;
+  start: { x: number; y: number };
+  pointer: { x: number; y: number };
+}
+
+interface ConnectionLine extends Connection {
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+}
+
+const hexToRgb = (hex: string): { r: number; g: number; b: number } | null => {
+  if (!hex) return null;
+
+  let normalized = hex.replace('#', '').trim();
+  if (normalized.length === 3) {
+    normalized = normalized
+      .split('')
+      .map(char => `${char}${char}`)
+      .join('');
+  }
+
+  if (normalized.length !== 6) return null;
+
+  const intValue = Number.parseInt(normalized, 16);
+  if (Number.isNaN(intValue)) return null;
+
+  return {
+    r: (intValue >> 16) & 255,
+    g: (intValue >> 8) & 255,
+    b: intValue & 255
+  };
+};
+
+const channelToLinear = (value: number): number => {
+  const scaled = value / 255;
+  return scaled <= 0.03928 ? scaled / 12.92 : Math.pow((scaled + 0.055) / 1.055, 2.4);
+};
+
+const getReadableTextColor = (hex: string): string => {
+  const rgb = hexToRgb(hex);
+  if (!rgb) return '#0f172a';
+
+  const luminance =
+    0.2126 * channelToLinear(rgb.r) +
+    0.7152 * channelToLinear(rgb.g) +
+    0.0722 * channelToLinear(rgb.b);
+
+  return luminance > 0.6 ? '#0f172a' : '#f8fafc';
+};
+
+const lightenColor = (hex: string, amount: number): string => {
+  const rgb = hexToRgb(hex);
+  if (!rgb) return hex;
+
+  const lightenChannel = (channel: number) => Math.round(channel + (255 - channel) * amount);
+  return `rgb(${lightenChannel(rgb.r)}, ${lightenChannel(rgb.g)}, ${lightenChannel(rgb.b)})`;
+};
+
+const darkenColor = (hex: string, amount: number): string => {
+  const rgb = hexToRgb(hex);
+  if (!rgb) return hex;
+
+  const darkenChannel = (channel: number) => Math.round(channel * (1 - amount));
+  return `rgb(${darkenChannel(rgb.r)}, ${darkenChannel(rgb.g)}, ${darkenChannel(rgb.b)})`;
+};
+
+const surfaceColor = (accent: string, textColor: string, lightenAmount: number, darkenAmount: number): string =>
+  textColor === '#0f172a' ? lightenColor(accent, lightenAmount) : darkenColor(accent, darkenAmount);
+
+export const MatchingInteractive: React.FC<MatchingInteractiveProps> = ({
+  tile,
+  isPreview = false,
+  isTestingMode = false,
+  onRequestTextEditing,
+  instructionContent,
+  variant = 'embedded'
+}) => {
+  const canInteract = !isPreview;
+
+  const leftItems = useMemo<MatchingOption[]>(
+    () => tile.content.pairs.map(pair => ({ id: pair.id, text: pair.left })),
+    [tile.content.pairs]
+  );
+
+  const buildInitialRight = useCallback((): MatchingOption[] => {
+    const normalized = tile.content.pairs.map(pair => ({ id: pair.id, text: pair.right }));
+
+    if (normalized.length <= 1) {
+      return normalized;
+    }
+
+    const isCorrectOrder = (items: MatchingOption[]) =>
+      items.every((item, index) => item.id === normalized[index].id);
+
+    let shuffled = [...normalized];
+    let attempts = 0;
+
+    do {
+      shuffled = [...normalized].sort(() => Math.random() - 0.5);
+      attempts += 1;
+    } while (attempts < 12 && isCorrectOrder(shuffled));
+
+    if (isCorrectOrder(shuffled)) {
+      const [first, ...rest] = shuffled;
+      shuffled = [...rest, first];
+    }
+
+    return shuffled;
+  }, [tile.content.pairs]);
+
+  const [rightItems, setRightItems] = useState<MatchingOption[]>(() => buildInitialRight());
+  const [connections, setConnections] = useState<Connection[]>([]);
+  const [activeConnection, setActiveConnection] = useState<ActiveConnection | null>(null);
+  const [hoveredRight, setHoveredRight] = useState<string | null>(null);
+  const [isChecked, setIsChecked] = useState(false);
+  const [isCorrect, setIsCorrect] = useState<boolean | null>(null);
+  const [attempts, setAttempts] = useState(0);
+  const [connectionLines, setConnectionLines] = useState<ConnectionLine[]>([]);
+
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const leftItemRefs = useRef<Map<string, HTMLDivElement | null>>(new Map());
+  const rightItemRefs = useRef<Map<string, HTMLDivElement | null>>(new Map());
+  const hoveredRightRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    hoveredRightRef.current = hoveredRight;
+  }, [hoveredRight]);
+
+  const initializeExercise = useCallback(() => {
+    const shuffled = buildInitialRight();
+    setRightItems(shuffled);
+    setConnections([]);
+    setActiveConnection(null);
+    setHoveredRight(null);
+    setIsChecked(false);
+    setIsCorrect(null);
+    setAttempts(0);
+  }, [buildInitialRight]);
+
+  useEffect(() => {
+    initializeExercise();
+  }, [initializeExercise]);
+
+  useEffect(() => {
+    if (isTestingMode) {
+      initializeExercise();
+    }
+  }, [isTestingMode, initializeExercise]);
+
+  const accentColor = tile.content.backgroundColor || '#0f172a';
+  const textColor = useMemo(() => getReadableTextColor(accentColor), [accentColor]);
+  const gradientStart = useMemo(() => lightenColor(accentColor, 0.08), [accentColor]);
+  const gradientEnd = useMemo(() => darkenColor(accentColor, 0.08), [accentColor]);
+  const frameBorderColor = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.5, 0.58),
+    [accentColor, textColor]
+  );
+  const panelBackground = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.64, 0.45),
+    [accentColor, textColor]
+  );
+  const panelBorder = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.5, 0.58),
+    [accentColor, textColor]
+  );
+  const iconBackground = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.56, 0.5),
+    [accentColor, textColor]
+  );
+  const mutedLabelColor = textColor === '#0f172a' ? '#475569' : '#dbeafe';
+  const subtleCaptionColor = textColor === '#0f172a' ? '#64748b' : '#e2e8f0';
+  const testingCaptionColor = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.44, 0.4),
+    [accentColor, textColor]
+  );
+  const columnBackground = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.62, 0.46),
+    [accentColor, textColor]
+  );
+  const columnBorder = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.54, 0.54),
+    [accentColor, textColor]
+  );
+  const columnHighlightBackground = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.72, 0.34),
+    [accentColor, textColor]
+  );
+  const itemBackground = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.6, 0.44),
+    [accentColor, textColor]
+  );
+  const itemBorder = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.5, 0.54),
+    [accentColor, textColor]
+  );
+  const itemActiveBackground = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.7, 0.34),
+    [accentColor, textColor]
+  );
+  const itemActiveBorder = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.6, 0.46),
+    [accentColor, textColor]
+  );
+  const itemConnectedBackground = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.66, 0.4),
+    [accentColor, textColor]
+  );
+  const itemConnectedBorder = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.58, 0.48),
+    [accentColor, textColor]
+  );
+  const successIconColor = textColor === '#0f172a' ? darkenColor(accentColor, 0.18) : lightenColor(accentColor, 0.32);
+  const successFeedbackBackground = surfaceColor(accentColor, textColor, 0.72, 0.32);
+  const successFeedbackBorder = surfaceColor(accentColor, textColor, 0.62, 0.42);
+  const failureFeedbackBackground = '#fee2e2';
+  const failureFeedbackBorder = '#fca5a5';
+  const primaryButtonBackground = textColor === '#0f172a' ? darkenColor(accentColor, 0.25) : lightenColor(accentColor, 0.28);
+  const primaryButtonTextColor = textColor === '#0f172a' ? '#f8fafc' : '#0f172a';
+  const secondaryButtonBackground = surfaceColor(accentColor, textColor, 0.54, 0.5);
+  const secondaryButtonBorder = surfaceColor(accentColor, textColor, 0.46, 0.56);
+  const connectionBaseColor = textColor === '#0f172a' ? darkenColor(accentColor, 0.22) : lightenColor(accentColor, 0.32);
+  const connectionActiveColor = textColor === '#0f172a' ? darkenColor(accentColor, 0.12) : lightenColor(accentColor, 0.24);
+  const connectionSuccessColor = textColor === '#0f172a' ? darkenColor(accentColor, 0.06) : lightenColor(accentColor, 0.2);
+  const connectionErrorColor = '#f97316';
+
+  const registerLeftRef = useCallback((id: string, node: HTMLDivElement | null) => {
+    if (node) {
+      leftItemRefs.current.set(id, node);
+    } else {
+      leftItemRefs.current.delete(id);
+    }
+  }, []);
+
+  const registerRightRef = useCallback((id: string, node: HTMLDivElement | null) => {
+    if (node) {
+      rightItemRefs.current.set(id, node);
+    } else {
+      rightItemRefs.current.delete(id);
+    }
+  }, []);
+
+  const updateConnectionLines = useCallback(() => {
+    if (!containerRef.current) return;
+    const containerRect = containerRef.current.getBoundingClientRect();
+
+    const lines: ConnectionLine[] = connections
+      .map(connection => {
+        const leftNode = leftItemRefs.current.get(connection.leftId);
+        const rightNode = rightItemRefs.current.get(connection.rightId);
+        if (!leftNode || !rightNode) return null;
+
+        const leftRect = leftNode.getBoundingClientRect();
+        const rightRect = rightNode.getBoundingClientRect();
+
+        return {
+          ...connection,
+          x1: leftRect.right - containerRect.left,
+          y1: leftRect.top + leftRect.height / 2 - containerRect.top,
+          x2: rightRect.left - containerRect.left,
+          y2: rightRect.top + rightRect.height / 2 - containerRect.top
+        };
+      })
+      .filter((line): line is ConnectionLine => Boolean(line));
+
+    setConnectionLines(lines);
+  }, [connections]);
+
+  useEffect(() => {
+    updateConnectionLines();
+  }, [connections, rightItems, leftItems, updateConnectionLines]);
+
+  useEffect(() => {
+    const handleResize = () => updateConnectionLines();
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, [updateConnectionLines]);
+
+  const finalizeConnection = useCallback(
+    (leftId: string, rightId: string | null) => {
+      setActiveConnection(null);
+      setHoveredRight(null);
+
+      if (!canInteract) return;
+
+      if (!rightId) {
+        setConnections(prev => prev.filter(connection => connection.leftId !== leftId));
+        setIsChecked(false);
+        setIsCorrect(null);
+        return;
+      }
+
+      setConnections(prev => {
+        const filtered = prev.filter(connection => connection.leftId !== leftId && connection.rightId !== rightId);
+        return [...filtered, { leftId, rightId }];
+      });
+      setIsChecked(false);
+      setIsCorrect(null);
+    },
+    [canInteract]
+  );
+
+  useEffect(() => {
+    if (!activeConnection) return;
+
+    const handlePointerMove = (event: PointerEvent) => {
+      if (!containerRef.current) return;
+      const rect = containerRef.current.getBoundingClientRect();
+      setActiveConnection(prev =>
+        prev
+          ? {
+              ...prev,
+              pointer: {
+                x: event.clientX - rect.left,
+                y: event.clientY - rect.top
+              }
+            }
+          : null
+      );
+    };
+
+    const handlePointerUp = () => {
+      finalizeConnection(activeConnection.leftId, hoveredRightRef.current);
+    };
+
+    window.addEventListener('pointermove', handlePointerMove);
+    window.addEventListener('pointerup', handlePointerUp, { once: true });
+
+    return () => {
+      window.removeEventListener('pointermove', handlePointerMove);
+      window.removeEventListener('pointerup', handlePointerUp);
+    };
+  }, [activeConnection, finalizeConnection]);
+
+  const handleStartConnection = (leftId: string, event: React.PointerEvent<HTMLDivElement>) => {
+    if (!canInteract) return;
+    if (event.button !== 0) return;
+
+    event.preventDefault();
+    event.stopPropagation();
+
+    const container = containerRef.current;
+    const leftNode = leftItemRefs.current.get(leftId);
+    if (!container || !leftNode) return;
+
+    const containerRect = container.getBoundingClientRect();
+    const leftRect = leftNode.getBoundingClientRect();
+
+    setActiveConnection({
+      leftId,
+      start: {
+        x: leftRect.right - containerRect.left,
+        y: leftRect.top + leftRect.height / 2 - containerRect.top
+      },
+      pointer: {
+        x: event.clientX - containerRect.left,
+        y: event.clientY - containerRect.top
+      }
+    });
+    setHoveredRight(null);
+  };
+
+  const handleRightPointerEnter = (rightId: string) => {
+    if (!activeConnection) return;
+    setHoveredRight(rightId);
+  };
+
+  const handleRightPointerLeave = (rightId: string) => {
+    if (hoveredRight === rightId) {
+      setHoveredRight(null);
+    }
+  };
+
+  const handleRightDoubleClick = (rightId: string) => {
+    if (!canInteract) return;
+    setConnections(prev => prev.filter(connection => connection.rightId !== rightId));
+    setIsChecked(false);
+    setIsCorrect(null);
+  };
+
+  const resetConnections = () => {
+    const shuffled = buildInitialRight();
+    setRightItems(shuffled);
+    setConnections([]);
+    setActiveConnection(null);
+    setHoveredRight(null);
+    setIsChecked(false);
+    setIsCorrect(null);
+  };
+
+  const allConnected = connections.length === leftItems.length && leftItems.length > 0;
+
+  const checkConnections = () => {
+    if (!allConnected) return;
+
+    const solved = connections.every(connection => connection.leftId === connection.rightId);
+    setIsCorrect(solved);
+    setIsChecked(true);
+    setAttempts(prev => prev + 1);
+  };
+
+  const connectionAccuracy = useMemo(() => {
+    if (!isChecked) return new Map<string, 'correct' | 'incorrect'>();
+
+    const map = new Map<string, 'correct' | 'incorrect'>();
+    connections.forEach(connection => {
+      map.set(connection.leftId, connection.leftId === connection.rightId ? 'correct' : 'incorrect');
+    });
+    return map;
+  }, [connections, isChecked]);
+
+  const getConnectionForRight = (rightId: string) => connections.find(connection => connection.rightId === rightId);
+  const getConnectionForLeft = (leftId: string) => connections.find(connection => connection.leftId === leftId);
+
+  const showBorder = tile.content.showBorder !== false;
+  const isEmbedded = variant === 'embedded';
+
+  return (
+    <div
+      className={`relative flex h-full flex-col gap-6 rounded-3xl border ${
+        showBorder ? 'border-2' : 'border-transparent'
+      } p-6 shadow-xl transition-shadow duration-300 ${isPreview ? 'opacity-90' : ''}`}
+      style={{
+        backgroundColor: isEmbedded ? 'transparent' : accentColor,
+        backgroundImage: isEmbedded ? undefined : `linear-gradient(135deg, ${gradientStart}, ${gradientEnd})`,
+        color: textColor,
+        borderColor: !isEmbedded && showBorder ? frameBorderColor : undefined
+      }}
+    >
+      <TaskInstructionPanel
+        icon={<Sparkles className="w-4 h-4" />}
+        label="Zadanie"
+        className="border"
+        style={{ backgroundColor: panelBackground, borderColor: panelBorder, color: textColor }}
+        iconWrapperStyle={{ backgroundColor: iconBackground, color: textColor }}
+        labelStyle={{ color: mutedLabelColor }}
+        bodyClassName="px-5 pb-5"
+      >
+        {instructionContent ?? (
+          <div
+            className="text-base leading-relaxed"
+            style={{ fontFamily: tile.content.fontFamily, fontSize: `${tile.content.fontSize}px` }}
+            onDoubleClick={onRequestTextEditing}
+            role={onRequestTextEditing ? 'button' : undefined}
+            tabIndex={onRequestTextEditing ? 0 : undefined}
+            dangerouslySetInnerHTML={{ __html: tile.content.richQuestion || tile.content.question }}
+          />
+        )}
+      </TaskInstructionPanel>
+
+      {isTestingMode && (
+        <div className="text-[11px] uppercase tracking-[0.32em]" style={{ color: testingCaptionColor }}>
+          Tryb testowania
+        </div>
+      )}
+
+      {attempts > 0 && (
+        <div className="text-xs uppercase tracking-[0.32em]" style={{ color: testingCaptionColor }}>
+          Próba #{attempts}
+        </div>
+      )}
+
+      <div
+        ref={containerRef}
+        className="relative flex-1 rounded-3xl border p-5"
+        style={{ backgroundColor: columnBackground, borderColor: columnBorder }}
+      >
+        <svg className="pointer-events-none absolute inset-0 h-full w-full">
+          {connectionLines.map(line => {
+            const status = connectionAccuracy.get(line.leftId);
+            const strokeColor =
+              status === 'correct'
+                ? connectionSuccessColor
+                : status === 'incorrect'
+                ? connectionErrorColor
+                : connectionBaseColor;
+
+            return (
+              <line
+                key={`${line.leftId}-${line.rightId}`}
+                x1={line.x1}
+                y1={line.y1}
+                x2={line.x2}
+                y2={line.y2}
+                stroke={strokeColor}
+                strokeWidth={status ? 5 : 4}
+                strokeLinecap="round"
+                opacity={0.92}
+              />
+            );
+          })}
+
+          {activeConnection && (
+            <line
+              x1={activeConnection.start.x}
+              y1={activeConnection.start.y}
+              x2={activeConnection.pointer.x}
+              y2={activeConnection.pointer.y}
+              stroke={connectionActiveColor}
+              strokeWidth={4}
+              strokeLinecap="round"
+              opacity={0.88}
+            />
+          )}
+        </svg>
+
+        <div className="relative grid h-full grid-cols-1 gap-6 lg:grid-cols-2">
+          <div className="flex flex-col gap-3">
+            <div
+              className="flex items-center justify-between rounded-2xl border px-4 py-3"
+              style={{ borderColor: itemBorder, backgroundColor: columnHighlightBackground, color: subtleCaptionColor }}
+            >
+              <div className="flex items-center gap-2 text-sm font-semibold">
+                <Link2 className="w-4 h-4" />
+                <span>Lewa kolumna</span>
+              </div>
+              <span className="text-xs">{leftItems.length} elementów</span>
+            </div>
+
+            <div className="flex-1 space-y-3 overflow-auto pr-1">
+              {leftItems.map((item, index) => {
+                const connection = getConnectionForLeft(item.id);
+                const status = connectionAccuracy.get(item.id);
+                const isActive = activeConnection?.leftId === item.id;
+                const isConnected = Boolean(connection);
+
+                let background = itemBackground;
+                let borderColor = itemBorder;
+                let foreground = textColor;
+
+                if (status === 'correct') {
+                  background = '#dcfce7';
+                  borderColor = '#22c55e';
+                  foreground = '#166534';
+                } else if (status === 'incorrect') {
+                  background = '#fee2e2';
+                  borderColor = '#f97316';
+                  foreground = '#7f1d1d';
+                } else if (isActive) {
+                  background = itemActiveBackground;
+                  borderColor = itemActiveBorder;
+                } else if (isConnected) {
+                  background = itemConnectedBackground;
+                  borderColor = itemConnectedBorder;
+                }
+
+                return (
+                  <div
+                    key={item.id}
+                    ref={node => registerLeftRef(item.id, node)}
+                    className="flex cursor-pointer items-center gap-4 rounded-2xl border px-4 py-3 shadow-sm transition-transform duration-200 hover:-translate-y-0.5"
+                    style={{ backgroundColor: background, borderColor, color: foreground }}
+                    onPointerDown={event => handleStartConnection(item.id, event)}
+                    onPointerCancel={() => setActiveConnection(null)}
+                    onDoubleClick={() => {
+                      if (!canInteract) return;
+                      setConnections(prev => prev.filter(connection => connection.leftId !== item.id));
+                      setIsChecked(false);
+                      setIsCorrect(null);
+                    }}
+                    role="button"
+                    tabIndex={0}
+                  >
+                    <div
+                      className="flex h-9 w-9 items-center justify-center rounded-xl border text-sm font-semibold"
+                      style={{
+                        backgroundColor: surfaceColor(accentColor, textColor, 0.68, 0.36),
+                        borderColor: surfaceColor(accentColor, textColor, 0.58, 0.46),
+                        color: mutedLabelColor
+                      }}
+                    >
+                      {index + 1}
+                    </div>
+                    <div className="flex-1">
+                      <div className="text-sm font-semibold leading-snug" style={{ color: foreground }}>
+                        {item.text}
+                      </div>
+                      {connection && (
+                        <div className="text-xs" style={{ color: subtleCaptionColor }}>
+                          Połączono z: {rightItems.find(right => right.id === connection.rightId)?.text ?? '—'}
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-3">
+            <div
+              className="flex items-center justify-between rounded-2xl border px-4 py-3"
+              style={{ borderColor: itemBorder, backgroundColor: columnHighlightBackground, color: subtleCaptionColor }}
+            >
+              <div className="flex items-center gap-2 text-sm font-semibold">
+                <Shuffle className="w-4 h-4" />
+                <span>Prawa kolumna</span>
+              </div>
+              <span className="text-xs">{rightItems.length} elementów</span>
+            </div>
+
+            <div className="flex-1 space-y-3 overflow-auto pl-1">
+              {rightItems.map((item, index) => {
+                const connection = getConnectionForRight(item.id);
+                const leftIndex = leftItems.findIndex(left => left.id === connection?.leftId);
+                const status = connection ? connectionAccuracy.get(connection.leftId) : undefined;
+                const isHovered = hoveredRight === item.id && Boolean(activeConnection);
+                const isConnected = Boolean(connection);
+
+                let background = itemBackground;
+                let borderColor = itemBorder;
+                let foreground = textColor;
+
+                if (status === 'correct') {
+                  background = '#dcfce7';
+                  borderColor = '#22c55e';
+                  foreground = '#166534';
+                } else if (status === 'incorrect') {
+                  background = '#fee2e2';
+                  borderColor = '#f97316';
+                  foreground = '#7f1d1d';
+                } else if (isHovered) {
+                  background = itemActiveBackground;
+                  borderColor = itemActiveBorder;
+                } else if (isConnected) {
+                  background = itemConnectedBackground;
+                  borderColor = itemConnectedBorder;
+                }
+
+                return (
+                  <div
+                    key={item.id}
+                    ref={node => registerRightRef(item.id, node)}
+                    className="relative flex cursor-pointer items-center gap-4 rounded-2xl border px-4 py-3 shadow-sm transition-transform duration-200 hover:-translate-y-0.5"
+                    style={{ backgroundColor: background, borderColor, color: foreground }}
+                    onPointerEnter={() => handleRightPointerEnter(item.id)}
+                    onPointerLeave={() => handleRightPointerLeave(item.id)}
+                    onDoubleClick={() => handleRightDoubleClick(item.id)}
+                  >
+                    <div
+                      className="flex h-9 w-9 items-center justify-center rounded-xl border text-sm font-semibold"
+                      style={{
+                        backgroundColor: surfaceColor(accentColor, textColor, 0.68, 0.36),
+                        borderColor: surfaceColor(accentColor, textColor, 0.58, 0.46),
+                        color: mutedLabelColor
+                      }}
+                    >
+                      {String.fromCharCode(65 + index)}
+                    </div>
+                    <div className="flex-1">
+                      <div className="text-sm font-semibold leading-snug" style={{ color: foreground }}>
+                        {item.text}
+                      </div>
+                      {isConnected && (
+                        <div className="text-xs" style={{ color: subtleCaptionColor }}>
+                          Połączono z elementem #{leftIndex + 1}
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {isChecked && isCorrect !== null && (
+        <div
+          className="flex items-center justify-between gap-4 rounded-2xl border px-6 py-4"
+          style={{
+            backgroundColor: isCorrect ? successFeedbackBackground : failureFeedbackBackground,
+            borderColor: isCorrect ? successFeedbackBorder : failureFeedbackBorder,
+            color: isCorrect ? textColor : '#7f1d1d'
+          }}
+        >
+          <div className="flex items-center gap-3 text-sm font-medium">
+            {isCorrect ? (
+              <CheckCircle className="w-5 h-5" style={{ color: successIconColor }} />
+            ) : (
+              <XCircle className="w-5 h-5 text-rose-300" />
+            )}
+            <span>{isCorrect ? tile.content.correctFeedback : tile.content.incorrectFeedback}</span>
+          </div>
+
+          {!isCorrect && (
+            <div className="text-xs" style={{ color: '#7f1d1d' }}>
+              Spróbuj ponownie, zmieniając połączenia.
+            </div>
+          )}
+        </div>
+      )}
+
+      {!isPreview && (
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div className="flex items-center gap-3">
+            <button
+              onClick={checkConnections}
+              disabled={!allConnected || (isChecked && isCorrect)}
+              className="px-6 py-2 rounded-xl font-semibold shadow-lg transition-transform duration-200 disabled:opacity-40 disabled:cursor-not-allowed hover:-translate-y-0.5"
+              style={{
+                backgroundColor: primaryButtonBackground,
+                color: primaryButtonTextColor,
+                boxShadow: '0 16px 32px rgba(15, 23, 42, 0.22)'
+              }}
+            >
+              {isChecked && isCorrect ? 'Pary sprawdzone' : 'Sprawdź połączenia'}
+            </button>
+
+            {isChecked && !isCorrect && (
+              <button
+                onClick={resetConnections}
+                className="flex items-center gap-2 rounded-xl border px-4 py-2 text-sm font-medium transition-colors"
+                style={{
+                  backgroundColor: secondaryButtonBackground,
+                  borderColor: secondaryButtonBorder,
+                  color: textColor
+                }}
+              >
+                <RotateCcw className="w-4 h-4" />
+                <span>Rozpocznij od nowa</span>
+              </button>
+            )}
+          </div>
+
+          <div className="text-xs" style={{ color: subtleCaptionColor }}>
+            Wskazówka: przeciągnij z lewej na prawą, aby stworzyć połączenie. Dwuklik na elemencie usuwa parę.
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/admin/TileRenderer.tsx
+++ b/src/components/admin/TileRenderer.tsx
@@ -1,6 +1,14 @@
 import React, { useState, useEffect } from 'react';
 import { Move, Trash2, Play, Code2 } from 'lucide-react';
-import { LessonTile, TextTile, ImageTile, QuizTile, ProgrammingTile, SequencingTile } from '../../types/lessonEditor';
+import {
+  LessonTile,
+  TextTile,
+  ImageTile,
+  QuizTile,
+  ProgrammingTile,
+  SequencingTile,
+  MatchingTile
+} from '../../types/lessonEditor';
 import { GridUtils } from '../../utils/gridUtils';
 import { Editor, EditorContent, useEditor } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
@@ -14,6 +22,7 @@ import OrderedList from '@tiptap/extension-ordered-list';
 import ListItem from '@tiptap/extension-list-item';
 import TextAlign from '../../extensions/TextAlign';
 import { SequencingInteractive } from './SequencingInteractive';
+import { MatchingInteractive } from './MatchingInteractive';
 import { TaskInstructionPanel } from './common/TaskInstructionPanel';
 import { QuizInteractive } from './QuizInteractive';
 
@@ -690,6 +699,65 @@ export const TileRenderer: React.FC<TileRendererProps> = ({
         }
         break;
       }
+      case 'matching': {
+        const matchingTile = tile as MatchingTile;
+        const accentColor = matchingTile.content.backgroundColor || computedBackground;
+        const textColor = getReadableTextColor(accentColor);
+
+        const renderMatchingContent = (instructionContent?: React.ReactNode, isPreviewMode = false) => (
+          <MatchingInteractive
+            tile={matchingTile}
+            isTestingMode={isTestingMode}
+            instructionContent={instructionContent}
+            isPreview={isPreviewMode}
+            onRequestTextEditing={isPreviewMode ? undefined : onDoubleClick}
+          />
+        );
+
+        if (isEditingText && isSelected) {
+          const questionEditorTile = {
+            ...tile,
+            type: 'text',
+            content: {
+              text: matchingTile.content.question,
+              richText: matchingTile.content.richQuestion,
+              fontFamily: matchingTile.content.fontFamily,
+              fontSize: matchingTile.content.fontSize,
+              verticalAlign: matchingTile.content.verticalAlign,
+              backgroundColor: matchingTile.content.backgroundColor,
+              showBorder: matchingTile.content.showBorder
+            }
+          } as TextTile;
+
+          contentToRender = renderMatchingContent(
+            <RichTextEditor
+              textTile={questionEditorTile}
+              tileId={tile.id}
+              textColor={textColor}
+              onUpdateTile={(tileId, updates) => {
+                if (!updates.content) return;
+
+                onUpdateTile(tileId, {
+                  content: {
+                    ...matchingTile.content,
+                    question: updates.content.text ?? matchingTile.content.question,
+                    richQuestion: updates.content.richText ?? matchingTile.content.richQuestion,
+                    fontFamily: updates.content.fontFamily ?? matchingTile.content.fontFamily,
+                    fontSize: updates.content.fontSize ?? matchingTile.content.fontSize,
+                    verticalAlign: updates.content.verticalAlign ?? matchingTile.content.verticalAlign
+                  }
+                });
+              }}
+              onFinishTextEditing={onFinishTextEditing}
+              onEditorReady={onEditorReady}
+            />,
+            true
+          );
+        } else {
+          contentToRender = renderMatchingContent();
+        }
+        break;
+      }
       default:
         contentToRender = (
           <div className="w-full h-full flex items-center justify-center">
@@ -746,7 +814,7 @@ export const TileRenderer: React.FC<TileRendererProps> = ({
         height: tile.size.height
       }}
       onMouseDown={isDraggingImage || isTestingMode ? undefined : onMouseDown}
-      onDoubleClick={tile.type === 'sequencing' ? undefined : onDoubleClick}
+      onDoubleClick={tile.type === 'sequencing' || tile.type === 'matching' ? undefined : onDoubleClick}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
     >

--- a/src/components/admin/side editor/MatchingEditor.tsx
+++ b/src/components/admin/side editor/MatchingEditor.tsx
@@ -1,0 +1,240 @@
+import React, { useState } from 'react';
+import { Plus, Trash2, GripVertical, Sparkles, Square, Link2 } from 'lucide-react';
+import { MatchingTile } from '../../../types/lessonEditor.ts';
+
+interface MatchingEditorProps {
+  tile: MatchingTile;
+  onUpdateTile: (tileId: string, updates: Partial<MatchingTile>) => void;
+  isTesting?: boolean;
+  onToggleTesting?: (tileId: string) => void;
+}
+
+export const MatchingEditor: React.FC<MatchingEditorProps> = ({
+  tile,
+  onUpdateTile,
+  isTesting = false,
+  onToggleTesting
+}) => {
+  const [draggedPair, setDraggedPair] = useState<string | null>(null);
+
+  const handleContentUpdate = (field: string, value: any) => {
+    onUpdateTile(tile.id, {
+      content: {
+        ...tile.content,
+        [field]: value
+      },
+      updated_at: new Date().toISOString()
+    });
+  };
+
+  const handlePairsUpdate = (pairs: MatchingTile['content']['pairs']) => {
+    handleContentUpdate('pairs', pairs);
+  };
+
+  const handlePairUpdate = (pairId: string, field: 'left' | 'right', value: string) => {
+    const updatedPairs = tile.content.pairs.map(pair =>
+      pair.id === pairId ? { ...pair, [field]: value } : pair
+    );
+    handlePairsUpdate(updatedPairs);
+  };
+
+  const addNewPair = () => {
+    const nextIndex = tile.content.pairs.length + 1;
+    const newPair = {
+      id: `pair-${Date.now()}`,
+      left: `Element ${nextIndex}`,
+      right: `Dopasowanie ${nextIndex}`
+    };
+    handlePairsUpdate([...tile.content.pairs, newPair]);
+  };
+
+  const removePair = (pairId: string) => {
+    if (tile.content.pairs.length <= 2) return;
+    const updatedPairs = tile.content.pairs.filter(pair => pair.id !== pairId);
+    handlePairsUpdate(updatedPairs);
+  };
+
+  const handleDragStart = (e: React.DragEvent, pairId: string) => {
+    setDraggedPair(pairId);
+    e.dataTransfer.effectAllowed = 'move';
+  };
+
+  const handleDragOver = (e: React.DragEvent) => {
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'move';
+  };
+
+  const handleDrop = (e: React.DragEvent, targetPairId: string) => {
+    e.preventDefault();
+
+    if (!draggedPair || draggedPair === targetPairId) {
+      setDraggedPair(null);
+      return;
+    }
+
+    const pairs = [...tile.content.pairs];
+    const draggedIndex = pairs.findIndex(pair => pair.id === draggedPair);
+    const targetIndex = pairs.findIndex(pair => pair.id === targetPairId);
+
+    if (draggedIndex === -1 || targetIndex === -1) {
+      setDraggedPair(null);
+      return;
+    }
+
+    const [dragged] = pairs.splice(draggedIndex, 1);
+    pairs.splice(targetIndex, 0, dragged);
+
+    handlePairsUpdate(pairs);
+    setDraggedPair(null);
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="p-4 rounded-lg border border-gray-200 bg-white shadow-sm">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <h3 className="text-sm font-semibold text-gray-900">Tryb testowania</h3>
+            <p className="text-xs text-gray-600 mt-1">
+              {isTesting
+                ? 'Tryb ucznia jest aktywny. Kafelek na płótnie jest zablokowany przed przypadkową edycją.'
+                : 'Wyłącz interakcje edycyjne kafelka i sprawdź zadanie dokładnie tak, jak zobaczy je uczeń.'}
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => onToggleTesting?.(tile.id)}
+            disabled={!onToggleTesting}
+            className={`inline-flex items-center gap-2 px-3 py-2 text-xs font-medium rounded-lg transition-colors shadow-sm ${
+              isTesting
+                ? 'bg-slate-900 text-white hover:bg-slate-800'
+                : 'bg-blue-600 text-white hover:bg-blue-500'
+            } disabled:opacity-60 disabled:cursor-not-allowed`}
+          >
+            {isTesting ? <Square className="w-4 h-4" /> : <Sparkles className="w-4 h-4" />}
+            <span>{isTesting ? 'Zakończ testowanie' : 'Przetestuj zadanie'}</span>
+          </button>
+        </div>
+      </div>
+
+      <div>
+        <div className="flex items-center justify-between mb-3">
+          <label className="block text-sm font-medium text-gray-700">
+            Pary do dopasowania ({tile.content.pairs.length})
+          </label>
+          <button
+            onClick={addNewPair}
+            className="flex items-center space-x-1 px-3 py-1 bg-blue-600 text-white text-xs rounded hover:bg-blue-700 transition-colors"
+          >
+            <Plus className="w-3 h-3" />
+            <span>Dodaj</span>
+          </button>
+        </div>
+
+        <div className="space-y-2 max-h-64 overflow-y-auto">
+          {tile.content.pairs.map(pair => (
+            <div
+              key={pair.id}
+              draggable
+              onDragStart={e => handleDragStart(e, pair.id)}
+              onDragOver={handleDragOver}
+              onDrop={e => handleDrop(e, pair.id)}
+              className={`flex items-center gap-3 p-3 bg-white border rounded-lg transition-all ${
+                draggedPair === pair.id ? 'opacity-50 scale-95' : 'hover:shadow-sm'
+              }`}
+            >
+              <div className="flex items-center">
+                <GripVertical className="w-4 h-4 text-gray-400 cursor-grab" />
+              </div>
+              <div className="flex-1 grid grid-cols-1 md:grid-cols-2 gap-2">
+                <input
+                  type="text"
+                  value={pair.left}
+                  onChange={e => handlePairUpdate(pair.id, 'left', e.target.value)}
+                  className="px-2 py-1 text-sm border border-gray-200 rounded focus:ring-1 focus:ring-blue-500 focus:border-transparent"
+                  placeholder="Lewy element"
+                />
+                <input
+                  type="text"
+                  value={pair.right}
+                  onChange={e => handlePairUpdate(pair.id, 'right', e.target.value)}
+                  className="px-2 py-1 text-sm border border-gray-200 rounded focus:ring-1 focus:ring-blue-500 focus:border-transparent"
+                  placeholder="Prawy element"
+                />
+              </div>
+              <button
+                onClick={() => removePair(pair.id)}
+                disabled={tile.content.pairs.length <= 2}
+                className="p-1 text-red-400 hover:text-red-600 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                title="Usuń parę"
+              >
+                <Trash2 className="w-3 h-3" />
+              </button>
+            </div>
+          ))}
+        </div>
+
+        {tile.content.pairs.length < 2 && (
+          <div className="text-xs text-amber-600 bg-amber-50 p-2 rounded mt-2">
+            ⚠️ Dodaj co najmniej 2 pary, aby ćwiczenie było funkcjonalne
+          </div>
+        )}
+      </div>
+
+      <div className="space-y-4">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-2 flex items-center gap-2">
+            <Link2 className="w-4 h-4 text-gray-500" />
+            Informacja zwrotna
+          </label>
+          <div className="space-y-3">
+            <div>
+              <span className="text-xs uppercase text-gray-500">Sukces</span>
+              <textarea
+                value={tile.content.correctFeedback}
+                onChange={e => handleContentUpdate('correctFeedback', e.target.value)}
+                className="mt-1 w-full px-3 py-2 border border-gray-200 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm resize-vertical"
+                rows={2}
+                placeholder="Komunikat po poprawnym rozwiązaniu"
+              />
+            </div>
+            <div>
+              <span className="text-xs uppercase text-gray-500">Błąd</span>
+              <textarea
+                value={tile.content.incorrectFeedback}
+                onChange={e => handleContentUpdate('incorrectFeedback', e.target.value)}
+                className="mt-1 w-full px-3 py-2 border border-gray-200 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm resize-vertical"
+                rows={2}
+                placeholder="Komunikat po błędnym rozwiązaniu"
+              />
+            </div>
+          </div>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-3">Kolor tła kafelka</label>
+          <input
+            type="color"
+            value={tile.content.backgroundColor}
+            onChange={e => handleContentUpdate('backgroundColor', e.target.value)}
+            className="w-full h-12 border border-gray-300 rounded-lg cursor-pointer"
+          />
+        </div>
+
+        <label className="flex items-center space-x-3 p-4 bg-gray-50 rounded-lg">
+          <input
+            type="checkbox"
+            checked={tile.content.showBorder}
+            onChange={e => handleContentUpdate('showBorder', e.target.checked)}
+            className="w-5 h-5 text-blue-600"
+          />
+          <div>
+            <span className="text-sm font-medium text-gray-900">Pokaż obramowanie kafelka</span>
+            <p className="text-xs text-gray-600 mt-1">
+              Gdy wyłączone, treść kafelka będzie bez dodatkowej ramki
+            </p>
+          </div>
+        </label>
+      </div>
+    </div>
+  );
+};

--- a/src/components/admin/side editor/TilePalette.tsx
+++ b/src/components/admin/side editor/TilePalette.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Type, Image, Puzzle, Eye, HelpCircle, Plus, Code, ArrowUpDown } from 'lucide-react';
+import { Type, Image, Puzzle, Eye, HelpCircle, Plus, Code, ArrowUpDown, Link2 } from 'lucide-react';
 import { TilePaletteItem } from '../../../types/lessonEditor.ts';
 
 interface TilePaletteProps {
@@ -37,6 +37,11 @@ const TILE_TYPES: TilePaletteItem[] = [
     type: 'sequencing',
     title: 'Ćwiczenie sekwencyjne',
     icon: 'ArrowUpDown'
+  },
+  {
+    type: 'matching',
+    title: 'Dopasowywanie w pary',
+    icon: 'Link2'
   }
 ];
 
@@ -49,6 +54,7 @@ const getIcon = (iconName: string) => {
     case 'HelpCircle': return HelpCircle;
     case 'Code': return Code;
     case 'ArrowUpDown': return ArrowUpDown;
+    case 'Link2': return Link2;
     default: return Type;
   }
 };

--- a/src/components/admin/side editor/TileSideEditor.tsx
+++ b/src/components/admin/side editor/TileSideEditor.tsx
@@ -1,9 +1,18 @@
 import React from 'react';
 import { Plus, Trash2, Type, X } from 'lucide-react';
-import { TextTile, ImageTile, LessonTile, ProgrammingTile, SequencingTile, QuizTile } from '../../../types/lessonEditor.ts';
+import {
+  TextTile,
+  ImageTile,
+  LessonTile,
+  ProgrammingTile,
+  SequencingTile,
+  QuizTile,
+  MatchingTile
+} from '../../../types/lessonEditor.ts';
 import { ImageUploadComponent } from './ImageUploadComponent.tsx';
 import { ImagePositionControl } from './ImagePositionControl.tsx';
 import { SequencingEditor } from './SequencingEditor.tsx';
+import { MatchingEditor } from './MatchingEditor.tsx';
 
 interface TileSideEditorProps {
   tile: LessonTile | undefined;
@@ -263,6 +272,18 @@ export const TileSideEditor: React.FC<TileSideEditorProps> = ({
         return (
           <SequencingEditor
             tile={sequencingTile}
+            onUpdateTile={onUpdateTile}
+            isTesting={isTesting}
+            onToggleTesting={onToggleTesting}
+          />
+        );
+      }
+
+      case 'matching': {
+        const matchingTile = tile as MatchingTile;
+        return (
+          <MatchingEditor
+            tile={matchingTile}
             onUpdateTile={onUpdateTile}
             isTesting={isTesting}
             onToggleTesting={onToggleTesting}

--- a/src/components/admin/top editor/TopToolbar.tsx
+++ b/src/components/admin/top editor/TopToolbar.tsx
@@ -5,7 +5,7 @@ import { FontSizeSelector } from './FontSizeSelector.tsx';
 import { TextColorPicker } from './TextColorPicker.tsx';
 import { FontSelector } from './FontSelector.tsx';
 import { AlignmentControls } from './AlignmentControls.tsx';
-import { LessonTile, ProgrammingTile, TextTile, SequencingTile } from '../../../types/lessonEditor.ts';
+import { LessonTile, ProgrammingTile, TextTile, SequencingTile, MatchingTile } from '../../../types/lessonEditor.ts';
 
 
 interface TopToolbarProps {
@@ -16,7 +16,7 @@ interface TopToolbarProps {
   isTextEditing: boolean;
   onFinishTextEditing?: () => void;
   editor?: Editor | null;
-  selectedTile?: TextTile | ProgrammingTile | SequencingTile | null;
+  selectedTile?: TextTile | ProgrammingTile | SequencingTile | MatchingTile | null;
   onUpdateTile?: (tileId: string, updates: Partial<LessonTile>) => void;
   className?: string;
 }
@@ -65,7 +65,11 @@ export const TopToolbar: React.FC<TopToolbarProps> = ({
   }, [editor]);
 
   useEffect(() => {
-    if (selectedTile?.type === 'text' || selectedTile?.type === 'sequencing') {
+    if (
+      selectedTile?.type === 'text' ||
+      selectedTile?.type === 'sequencing' ||
+      selectedTile?.type === 'matching'
+    ) {
       setVerticalAlign(selectedTile.content.verticalAlign || 'top');
     }
   }, [selectedTile]);

--- a/src/hooks/useTileInteractions.ts
+++ b/src/hooks/useTileInteractions.ts
@@ -33,6 +33,7 @@ export const useTileInteractions = ({
       tile.type === 'text' ||
       tile.type === 'programming' ||
       tile.type === 'sequencing' ||
+      tile.type === 'matching' ||
       tile.type === 'quiz'
     ) {
       dispatch({ type: 'startTextEditing', tileId: tile.id });

--- a/src/services/lessonContentService.ts
+++ b/src/services/lessonContentService.ts
@@ -1,5 +1,11 @@
-import { LessonContent, LessonTile, TextTile } from '../types/lessonEditor';
-import { ProgrammingTile, SequencingTile } from '../types/lessonEditor';
+import {
+  LessonContent,
+  LessonTile,
+  TextTile,
+  ProgrammingTile,
+  SequencingTile,
+  MatchingTile
+} from '../types/lessonEditor';
 import { GridUtils } from '../utils/gridUtils';
 import { logger } from '../utils/logger';
 
@@ -397,6 +403,66 @@ export class LessonContentService {
         ],
         correctFeedback: 'Świetnie! Prawidłowa kolejność.',
         incorrectFeedback: 'Spróbuj ponownie. Sprawdź kolejność elementów.'
+      },
+      created_at: now,
+      updated_at: now,
+      z_index: 1
+    };
+  }
+
+  /**
+   * Create a new matching tile
+   */
+  static createMatchingTile(position: { x: number; y: number }, page = 1): MatchingTile {
+    const id = `tile-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+    const now = new Date().toISOString();
+
+    const gridPos = GridUtils.pixelToGrid(position, {
+      width: GridUtils.GRID_COLUMNS,
+      height: 6,
+      gridSize: GridUtils.GRID_CELL_SIZE,
+      snapToGrid: true
+    });
+
+    gridPos.colSpan = 4;
+    gridPos.rowSpan = 5;
+
+    const pixelPos = GridUtils.gridToPixel(gridPos, {
+      width: GridUtils.GRID_COLUMNS,
+      height: 6,
+      gridSize: GridUtils.GRID_CELL_SIZE,
+      snapToGrid: true
+    });
+
+    const pixelSize = GridUtils.gridSizeToPixel(gridPos, {
+      width: GridUtils.GRID_COLUMNS,
+      height: 6,
+      gridSize: GridUtils.GRID_CELL_SIZE,
+      snapToGrid: true
+    });
+
+    return {
+      id,
+      type: 'matching',
+      position: pixelPos,
+      size: pixelSize,
+      gridPosition: gridPos,
+      page,
+      content: {
+        question: 'Połącz elementy w pasujące pary',
+        richQuestion: '<p style="margin: 0;">Połącz elementy w pasujące pary</p>',
+        fontFamily: 'Inter, system-ui, sans-serif',
+        fontSize: 16,
+        verticalAlign: 'top',
+        backgroundColor: '#CBD5F5',
+        showBorder: true,
+        pairs: [
+          { id: 'pair-1', left: 'Element A', right: 'Dopasowanie 1' },
+          { id: 'pair-2', left: 'Element B', right: 'Dopasowanie 2' },
+          { id: 'pair-3', left: 'Element C', right: 'Dopasowanie 3' }
+        ],
+        correctFeedback: 'Świetnie! Wszystkie pary są poprawne.',
+        incorrectFeedback: 'Nie wszystkie połączenia są poprawne. Spróbuj ponownie.'
       },
       created_at: now,
       updated_at: now,

--- a/src/types/lessonEditor.ts
+++ b/src/types/lessonEditor.ts
@@ -17,7 +17,7 @@ export interface GridPosition {
 
 export interface LessonTile {
   id: string;
-  type: 'text' | 'image' | 'visualization' | 'quiz' | 'programming' | 'sequencing';
+  type: 'text' | 'image' | 'visualization' | 'quiz' | 'programming' | 'sequencing' | 'matching';
   position: Position;
   size: Size;
   gridPosition: GridPosition;
@@ -122,6 +122,26 @@ export interface SequencingTile extends LessonTile {
       id: string;
       text: string;
       correctPosition: number; // 0-based index for correct order
+    }>;
+    correctFeedback: string;
+    incorrectFeedback: string;
+  };
+}
+
+export interface MatchingTile extends LessonTile {
+  type: 'matching';
+  content: {
+    question: string;
+    richQuestion?: string;
+    fontFamily: string;
+    fontSize: number;
+    verticalAlign: 'top' | 'center' | 'bottom';
+    backgroundColor: string;
+    showBorder: boolean;
+    pairs: Array<{
+      id: string;
+      left: string;
+      right: string;
     }>;
     correctFeedback: string;
     incorrectFeedback: string;


### PR DESCRIPTION
## Summary
- add a new matching tile type, default factory, and editor/palette wiring so it can be created like other lesson tiles
- implement a MatchingInteractive component that mirrors the sequencing tile aesthetics while letting students drag connections between pairs and receive feedback
- provide a side panel editor for authoring pairs, feedback, styling, and ensure toolbars/tile interactions recognise the new tile

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dacef254f08321a4655b50ae96ea10