### PR TITLE
Add fill-in-the-blanks tile

### DIFF
--- a/src/Pages/LessonEditor.tsx
+++ b/src/Pages/LessonEditor.tsx
@@ -1,8 +1,14 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { ArrowLeft, Save, RotateCcw, Grid, Edit } from 'lucide-react';
 import { Lesson, Course } from '../types/course.ts';
-import { LessonContent, LessonTile, ProgrammingTile, TextTile } from '../types/lessonEditor.ts';
-import { SequencingTile } from '../types/lessonEditor.ts';
+import {
+  LessonContent,
+  LessonTile,
+  ProgrammingTile,
+  TextTile,
+  SequencingTile,
+  FillBlanksTile
+} from '../types/lessonEditor.ts';
 import { useLessonEditor } from '../hooks/useLessonEditor.ts';
 import { LessonContentService } from '../services/lessonContentService.ts';
 import { TilePalette } from '../components/admin/side editor/TilePalette.tsx';
@@ -24,8 +30,15 @@ interface LessonEditorProps {
   onBack: () => void;
 }
 
-const isRichTextTile = (tile: LessonTile | null): tile is TextTile | ProgrammingTile | SequencingTile => {
-  return !!tile && (tile.type === 'text' || tile.type === 'programming' || tile.type === 'sequencing');
+const isRichTextTile = (
+  tile: LessonTile | null
+): tile is TextTile | ProgrammingTile | SequencingTile | FillBlanksTile => {
+  return !!tile && (
+    tile.type === 'text' ||
+    tile.type === 'programming' ||
+    tile.type === 'sequencing' ||
+    tile.type === 'fillBlanks'
+  );
 };
 
 export const LessonEditor: React.FC<LessonEditorProps> = ({ lesson, course, onBack }) => {
@@ -253,6 +266,9 @@ export const LessonEditor: React.FC<LessonEditorProps> = ({ lesson, course, onBa
       case 'sequencing':
         newTile = LessonContentService.createSequencingTile(position, currentPage);
         break;
+      case 'fillBlanks':
+        newTile = LessonContentService.createFillBlanksTile(position, currentPage);
+        break;
       default:
         logger.warn(`Tile type ${tileType} not implemented yet`);
         warning('Funkcja niedostępna', `Typ kafelka "${tileType}" nie jest jeszcze dostępny`);
@@ -313,7 +329,15 @@ export const LessonEditor: React.FC<LessonEditorProps> = ({ lesson, course, onBa
         };
 
         // Special handling for text-based tiles to ensure content properties are merged
-        if ((tile.type === 'text' || tile.type === 'programming' || tile.type === 'sequencing') && updates.content) {
+        if (
+          (
+            tile.type === 'text' ||
+            tile.type === 'programming' ||
+            tile.type === 'sequencing' ||
+            tile.type === 'fillBlanks'
+          ) &&
+          updates.content
+        ) {
           updatedTile.content = {
             ...tile.content,
             ...updates.content

--- a/src/components/admin/FillBlanksInteractive.tsx
+++ b/src/components/admin/FillBlanksInteractive.tsx
@@ -1,0 +1,530 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { BookOpenCheck, CheckCircle, RotateCcw, Sparkles, XCircle } from 'lucide-react';
+import { FillBlanksTile } from '../../types/lessonEditor';
+import { TaskInstructionPanel } from './common/TaskInstructionPanel';
+
+interface FillBlanksInteractiveProps {
+  tile: FillBlanksTile;
+  isPreview?: boolean;
+  isTestingMode?: boolean;
+  onRequestTextEditing?: () => void;
+  instructionContent?: React.ReactNode;
+}
+
+type EvaluationState = 'idle' | 'correct' | 'incorrect';
+
+interface WordEntry {
+  id: string;
+  text: string;
+}
+
+interface Segment {
+  type: 'text' | 'blank';
+  value: string;
+  index?: number;
+}
+
+const BLANK_REGEX = /_{3,}/g;
+
+const hexToRgb = (hex: string): { r: number; g: number; b: number } | null => {
+  if (!hex) return null;
+
+  let normalized = hex.replace('#', '').trim();
+  if (normalized.length === 3) {
+    normalized = normalized
+      .split('')
+      .map(char => `${char}${char}`)
+      .join('');
+  }
+
+  if (normalized.length !== 6) return null;
+
+  const intValue = Number.parseInt(normalized, 16);
+  if (Number.isNaN(intValue)) return null;
+
+  return {
+    r: (intValue >> 16) & 255,
+    g: (intValue >> 8) & 255,
+    b: intValue & 255
+  };
+};
+
+const channelToLinear = (value: number): number => {
+  const scaled = value / 255;
+  return scaled <= 0.03928 ? scaled / 12.92 : Math.pow((scaled + 0.055) / 1.055, 2.4);
+};
+
+const getReadableTextColor = (hex: string): string => {
+  const rgb = hexToRgb(hex);
+  if (!rgb) return '#0f172a';
+
+  const luminance =
+    0.2126 * channelToLinear(rgb.r) +
+    0.7152 * channelToLinear(rgb.g) +
+    0.0722 * channelToLinear(rgb.b);
+
+  return luminance > 0.6 ? '#0f172a' : '#f8fafc';
+};
+
+const lightenColor = (hex: string, amount: number): string => {
+  const rgb = hexToRgb(hex);
+  if (!rgb) return hex;
+
+  const lightenChannel = (channel: number) => Math.round(channel + (255 - channel) * amount);
+  return `rgb(${lightenChannel(rgb.r)}, ${lightenChannel(rgb.g)}, ${lightenChannel(rgb.b)})`;
+};
+
+const darkenColor = (hex: string, amount: number): string => {
+  const rgb = hexToRgb(hex);
+  if (!rgb) return hex;
+
+  const darkenChannel = (channel: number) => Math.round(channel * (1 - amount));
+  return `rgb(${darkenChannel(rgb.r)}, ${darkenChannel(rgb.g)}, ${darkenChannel(rgb.b)})`;
+};
+
+const surfaceColor = (accent: string, textColor: string, lightenAmount: number, darkenAmount: number): string =>
+  textColor === '#0f172a' ? lightenColor(accent, lightenAmount) : darkenColor(accent, darkenAmount);
+
+const createWordEntries = (tileId: string, wordBank: string[]): WordEntry[] =>
+  wordBank.map((word, index) => ({ id: `${tileId}-word-${index}`, text: word }));
+
+export const FillBlanksInteractive: React.FC<FillBlanksInteractiveProps> = ({
+  tile,
+  isPreview = false,
+  isTestingMode = false,
+  onRequestTextEditing,
+  instructionContent
+}) => {
+  const accentColor = tile.content.backgroundColor || '#2563eb';
+  const textColor = useMemo(() => getReadableTextColor(accentColor), [accentColor]);
+  const mutedTextColor = textColor === '#0f172a' ? '#475569' : '#e2e8f0';
+
+  const [placements, setPlacements] = useState<(string | null)[]>([]);
+  const [wordEntries, setWordEntries] = useState<WordEntry[]>(() =>
+    createWordEntries(tile.id, tile.content.wordBank)
+  );
+  const [, setDraggedWordId] = useState<string | null>(null);
+  const [dragOverBlank, setDragOverBlank] = useState<number | null>(null);
+  const [evaluationState, setEvaluationState] = useState<EvaluationState>('idle');
+
+  const isInteractionEnabled = !isPreview && isTestingMode;
+
+  useEffect(() => {
+    setWordEntries(createWordEntries(tile.id, tile.content.wordBank));
+  }, [tile.id, tile.content.wordBank]);
+
+  useEffect(() => {
+    setPlacements(Array.from({ length: tile.content.blanks.length }, () => null));
+    setEvaluationState('idle');
+  }, [tile.content.blanks.length, tile.content.text, tile.content.wordBank]);
+
+  const wordMap = useMemo(() => {
+    return wordEntries.reduce<Record<string, string>>((acc, entry) => {
+      acc[entry.id] = entry.text;
+      return acc;
+    }, {});
+  }, [wordEntries]);
+
+  const segments = useMemo(() => {
+    const text = tile.content.text || '';
+    const result: Segment[] = [];
+    let lastIndex = 0;
+    let match: RegExpExecArray | null;
+    let blankIndex = 0;
+
+    while ((match = BLANK_REGEX.exec(text)) !== null) {
+      if (match.index > lastIndex) {
+        result.push({ type: 'text', value: text.slice(lastIndex, match.index) });
+      }
+
+      result.push({ type: 'blank', value: match[0], index: blankIndex });
+      blankIndex += 1;
+      lastIndex = match.index + match[0].length;
+    }
+
+    if (lastIndex < text.length) {
+      result.push({ type: 'text', value: text.slice(lastIndex) });
+    }
+
+    return result;
+  }, [tile.content.text]);
+
+  const panelBackground = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.64, 0.42),
+    [accentColor, textColor]
+  );
+  const panelBorder = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.54, 0.5),
+    [accentColor, textColor]
+  );
+  const iconBackground = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.58, 0.46),
+    [accentColor, textColor]
+  );
+  const wordSurface = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.7, 0.38),
+    [accentColor, textColor]
+  );
+  const wordBorder = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.6, 0.46),
+    [accentColor, textColor]
+  );
+  const blankSurface = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.74, 0.36),
+    [accentColor, textColor]
+  );
+  const blankBorder = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.62, 0.48),
+    [accentColor, textColor]
+  );
+  const blankHover = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.54, 0.52),
+    [accentColor, textColor]
+  );
+  const feedbackBackground = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.48, 0.54),
+    [accentColor, textColor]
+  );
+
+  const assignWordToBlank = useCallback((blankIndex: number, wordId: string | null) => {
+    setPlacements(prev => {
+      const next = [...prev];
+
+      if (wordId) {
+        const existingIndex = next.findIndex(value => value === wordId);
+        if (existingIndex !== -1) {
+          next[existingIndex] = null;
+        }
+        next[blankIndex] = wordId;
+      } else {
+        next[blankIndex] = null;
+      }
+
+      return next;
+    });
+    setEvaluationState('idle');
+  }, []);
+
+  const handleDragStart = (event: React.DragEvent<HTMLButtonElement>, wordId: string) => {
+    if (!isInteractionEnabled) return;
+    setDraggedWordId(wordId);
+    event.dataTransfer.setData('text/plain', wordId);
+    event.dataTransfer.effectAllowed = 'move';
+  };
+
+  const handleDragEnd = () => {
+    setDraggedWordId(null);
+    setDragOverBlank(null);
+  };
+
+  const handleDragOver = (event: React.DragEvent<HTMLDivElement>, index: number) => {
+    if (!isInteractionEnabled) return;
+    event.preventDefault();
+    event.dataTransfer.dropEffect = 'move';
+    setDragOverBlank(index);
+  };
+
+  const handleDragLeave = (index: number) => {
+    if (dragOverBlank === index) {
+      setDragOverBlank(null);
+    }
+  };
+
+  const handleDrop = (event: React.DragEvent<HTMLDivElement>, index: number) => {
+    if (!isInteractionEnabled) return;
+    event.preventDefault();
+    const wordId = event.dataTransfer.getData('text/plain');
+    if (!wordId) return;
+
+    assignWordToBlank(index, wordId);
+    setDraggedWordId(null);
+    setDragOverBlank(null);
+  };
+
+  const handleClearBlank = (index: number) => {
+    assignWordToBlank(index, null);
+  };
+
+  const handleReset = () => {
+    if (!isInteractionEnabled) return;
+    setPlacements(Array.from({ length: tile.content.blanks.length }, () => null));
+    setEvaluationState('idle');
+  };
+
+  const handleEvaluate = () => {
+    if (!isInteractionEnabled) return;
+
+    const allFilled = placements.every(value => value !== null);
+    if (!allFilled) {
+      setEvaluationState('incorrect');
+      return;
+    }
+
+    const isCorrect = placements.every((wordId, index) => {
+      if (!wordId) return false;
+      const filled = (wordMap[wordId] || '').trim();
+      const expected = (tile.content.blanks[index]?.correctAnswer || '').trim();
+      return filled.localeCompare(expected, undefined, { sensitivity: 'base' }) === 0;
+    });
+
+    setEvaluationState(isCorrect ? 'correct' : 'incorrect');
+  };
+
+  const handleInstructionDoubleClick = useCallback(
+    (event: React.MouseEvent) => {
+      if (isPreview || isTestingMode) return;
+      if (!onRequestTextEditing) return;
+
+      event.preventDefault();
+      event.stopPropagation();
+      onRequestTextEditing();
+    },
+    [isPreview, isTestingMode, onRequestTextEditing]
+  );
+
+  const renderInstructionContent = () => {
+    if (instructionContent) {
+      return instructionContent;
+    }
+
+    return (
+      <div
+        className="text-sm leading-relaxed cursor-text"
+        style={{ fontFamily: tile.content.fontFamily, fontSize: `${tile.content.fontSize}px` }}
+        onDoubleClick={handleInstructionDoubleClick}
+        dangerouslySetInnerHTML={{
+          __html:
+            tile.content.richInstruction ||
+            `<p style="margin: 0;">${tile.content.instruction || 'Dodaj instrukcję zadania'}</p>`
+        }}
+      />
+    );
+  };
+
+  const wordInUse = (wordId: string) => placements.includes(wordId);
+
+  return (
+    <div className="relative w-full h-full flex flex-col"
+      style={{
+        backgroundColor: tile.content.showBorder ? 'transparent' : accentColor,
+        borderRadius: tile.content.showBorder ? undefined : '1rem'
+      }}
+    >
+      <TaskInstructionPanel
+        icon={<BookOpenCheck className="w-5 h-5" style={{ color: textColor }} />}
+        label="Instrukcja zadania"
+        className={`border ${tile.content.showBorder ? 'border-transparent' : ''}`}
+        style={{
+          background: tile.content.showBorder ? 'transparent' : panelBackground,
+          borderColor: tile.content.showBorder ? 'transparent' : panelBorder,
+          color: textColor
+        }}
+        headerClassName="px-5 pt-5 pb-3 flex items-center gap-3"
+        iconWrapperClassName="w-10 h-10 rounded-xl flex items-center justify-center shadow-sm"
+        iconWrapperStyle={{ background: iconBackground }}
+        labelClassName="text-sm uppercase tracking-[0.24em] font-semibold"
+        labelStyle={{ color: textColor }}
+        bodyClassName="px-5 pb-5"
+      >
+        {renderInstructionContent()}
+      </TaskInstructionPanel>
+
+      <div className="flex-1 overflow-hidden px-5 pb-5">
+        <div
+          className={`w-full h-full rounded-2xl ${
+            tile.content.showBorder ? 'border' : ''
+          } flex flex-col gap-6 p-5`}
+          style={{
+            background: tile.content.showBorder ? blankSurface : surfaceColor(accentColor, textColor, 0.8, 0.34),
+            borderColor: tile.content.showBorder ? blankBorder : 'transparent',
+            color: textColor
+          }}
+        >
+          <div className="space-y-4">
+            <div className="flex items-center justify-between">
+              <h4 className="text-sm font-semibold tracking-wide" style={{ color: textColor }}>
+                Tekst z lukami
+              </h4>
+              {!isInteractionEnabled && (
+                <div className="flex items-center gap-2 text-xs" style={{ color: mutedTextColor }}>
+                  <Sparkles className="w-4 h-4" />
+                  <span>Włącz testowanie, aby przetestować zadanie</span>
+                </div>
+              )}
+            </div>
+
+            <div className="rounded-xl border border-dashed" style={{ borderColor: blankBorder, background: blankSurface }}>
+              <p className="p-4 text-base leading-relaxed text-left">
+                {segments.map((segment, index) => {
+                  if (segment.type === 'text') {
+                    return (
+                      <span key={`text-${index}`} className="whitespace-pre-wrap">
+                        {segment.value}
+                      </span>
+                    );
+                  }
+
+                  const blankIndex = segment.index ?? 0;
+                  const assignedWordId = placements[blankIndex];
+                  const assignedWord = assignedWordId ? wordMap[assignedWordId] : null;
+                  const isHovered = dragOverBlank === blankIndex;
+
+                  return (
+                    <span key={`blank-${blankIndex}`} className="inline-flex mx-1 my-0.5">
+                      <div
+                        className={`inline-flex items-center gap-2 px-3 py-2 rounded-lg border transition-all ${
+                          isInteractionEnabled
+                            ? 'cursor-pointer'
+                            : 'cursor-default'
+                        } ${
+                          isHovered ? 'shadow-md scale-105' : 'shadow-sm'
+                        }`}
+                        style={{
+                          background: assignedWord ? blankHover : blankSurface,
+                          borderColor: isHovered ? blankHover : blankBorder,
+                          color: textColor
+                        }}
+                        onDragOver={(event) => handleDragOver(event, blankIndex)}
+                        onDragLeave={() => handleDragLeave(blankIndex)}
+                        onDrop={(event) => handleDrop(event, blankIndex)}
+                        onDoubleClick={() => (isInteractionEnabled ? handleClearBlank(blankIndex) : undefined)}
+                      >
+                        {assignedWord ? (
+                          <>
+                            <span className="font-medium">{assignedWord}</span>
+                            {isInteractionEnabled && (
+                              <button
+                                type="button"
+                                onClick={(event) => {
+                                  event.stopPropagation();
+                                  handleClearBlank(blankIndex);
+                                }}
+                                className="text-xs rounded-full px-2 py-0.5"
+                                style={{
+                                  background: surfaceColor(accentColor, textColor, 0.48, 0.54),
+                                  color: textColor
+                                }}
+                              >
+                                ×
+                              </button>
+                            )}
+                          </>
+                        ) : (
+                          <span className="text-sm" style={{ color: mutedTextColor }}>
+                            {isInteractionEnabled ? 'Przeciągnij słowo' : 'Luka'}
+                          </span>
+                        )}
+                      </div>
+                    </span>
+                  );
+                })}
+              </p>
+            </div>
+          </div>
+
+          <div className="space-y-4">
+            <div className="flex items-center justify-between">
+              <h4 className="text-sm font-semibold tracking-wide" style={{ color: textColor }}>
+                Bank słów ({wordEntries.length})
+              </h4>
+              {isInteractionEnabled && (
+                <div className="flex items-center gap-2 text-xs" style={{ color: mutedTextColor }}>
+                  <span>Przeciągnij słowo do odpowiedniej luki</span>
+                </div>
+              )}
+            </div>
+
+            <div className="flex flex-wrap gap-2">
+              {wordEntries.map(entry => {
+                const inUse = wordInUse(entry.id);
+                return (
+                  <button
+                    key={entry.id}
+                    type="button"
+                    draggable={isInteractionEnabled && !inUse}
+                    onDragStart={(event) => handleDragStart(event, entry.id)}
+                    onDragEnd={handleDragEnd}
+                    onClick={() => {
+                      if (!isInteractionEnabled || inUse) return;
+                      const firstEmpty = placements.findIndex(value => value === null);
+                      if (firstEmpty !== -1) {
+                        assignWordToBlank(firstEmpty, entry.id);
+                      }
+                    }}
+                    className={`px-3 py-2 rounded-lg border text-sm font-medium transition-all ${
+                      inUse ? 'opacity-50 cursor-not-allowed' : 'hover:shadow-md'
+                    }`}
+                    style={{
+                      background: wordSurface,
+                      borderColor: wordBorder,
+                      color: textColor
+                    }}
+                  >
+                    {entry.text}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          {isInteractionEnabled && (
+            <div className="flex items-center justify-between pt-2">
+              <div className="flex items-center gap-2 text-sm" style={{ color: mutedTextColor }}>
+                <span>Dwuklik na słowie w luce, aby je usunąć</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={handleReset}
+                  className="inline-flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium transition-colors"
+                  style={{
+                    background: surfaceColor(accentColor, textColor, 0.64, 0.38),
+                    color: textColor
+                  }}
+                >
+                  <RotateCcw className="w-4 h-4" />
+                  Resetuj
+                </button>
+                <button
+                  type="button"
+                  onClick={handleEvaluate}
+                  className="inline-flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-semibold shadow-sm transition-colors"
+                  style={{
+                    background: surfaceColor(accentColor, textColor, 0.42, 0.54),
+                    color: textColor
+                  }}
+                >
+                  Sprawdź
+                </button>
+              </div>
+            </div>
+          )}
+
+          {evaluationState !== 'idle' && (
+            <div
+              className={`rounded-xl border px-4 py-3 flex items-center gap-3 shadow-sm ${
+                evaluationState === 'correct' ? 'backdrop-blur-sm' : ''
+              }`}
+              style={{
+                background: feedbackBackground,
+                borderColor: surfaceColor(accentColor, textColor, 0.46, 0.52),
+                color: textColor
+              }}
+            >
+              {evaluationState === 'correct' ? (
+                <CheckCircle className="w-5 h-5" />
+              ) : (
+                <XCircle className="w-5 h-5" />
+              )}
+              <div className="text-sm font-medium">
+                {evaluationState === 'correct'
+                  ? 'Świetnie! Wszystkie luki zostały uzupełnione poprawnie.'
+                  : 'Sprawdź odpowiedzi i spróbuj ponownie.'}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/admin/TileRenderer.tsx
+++ b/src/components/admin/TileRenderer.tsx
@@ -1,6 +1,14 @@
 import React, { useState, useEffect } from 'react';
 import { Move, Trash2, Play, Code2 } from 'lucide-react';
-import { LessonTile, TextTile, ImageTile, QuizTile, ProgrammingTile, SequencingTile } from '../../types/lessonEditor';
+import {
+  LessonTile,
+  TextTile,
+  ImageTile,
+  QuizTile,
+  ProgrammingTile,
+  SequencingTile,
+  FillBlanksTile
+} from '../../types/lessonEditor';
 import { GridUtils } from '../../utils/gridUtils';
 import { Editor, EditorContent, useEditor } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
@@ -16,6 +24,7 @@ import TextAlign from '../../extensions/TextAlign';
 import { SequencingInteractive } from './SequencingInteractive';
 import { TaskInstructionPanel } from './common/TaskInstructionPanel';
 import { QuizInteractive } from './QuizInteractive';
+import { FillBlanksInteractive } from './FillBlanksInteractive';
 
 const hexToRgb = (hex: string): { r: number; g: number; b: number } | null => {
   if (!hex) return null;
@@ -627,6 +636,72 @@ export const TileRenderer: React.FC<TileRendererProps> = ({
               onRequestTextEditing={onDoubleClick}
             />
           );
+        }
+        break;
+      }
+
+      case 'fillBlanks': {
+        const fillTile = tile as FillBlanksTile;
+        const accentColor = fillTile.content.backgroundColor || computedBackground;
+        const textColor = getReadableTextColor(accentColor);
+
+        const renderFillBlanksContent = (
+          instructionContent?: React.ReactNode,
+          isPreviewMode = false
+        ) => (
+          <FillBlanksInteractive
+            tile={fillTile}
+            isTestingMode={isTestingMode}
+            isPreview={isPreviewMode}
+            instructionContent={instructionContent}
+            onRequestTextEditing={isPreviewMode ? undefined : onDoubleClick}
+          />
+        );
+
+        if (isEditingText && isSelected) {
+          const instructionEditorTile: TextTile = {
+            ...tile,
+            type: 'text',
+            content: {
+              text: fillTile.content.instruction,
+              richText: fillTile.content.richInstruction,
+              fontFamily: fillTile.content.fontFamily,
+              fontSize: fillTile.content.fontSize,
+              verticalAlign: 'top',
+              backgroundColor: fillTile.content.backgroundColor,
+              showBorder: fillTile.content.showBorder
+            }
+          };
+
+          contentToRender = renderFillBlanksContent(
+            <RichTextEditor
+              textTile={instructionEditorTile}
+              tileId={tile.id}
+              textColor={textColor}
+              onUpdateTile={(tileId, updates) => {
+                if (!updates.content) return;
+
+                onUpdateTile(tileId, {
+                  content: {
+                    ...fillTile.content,
+                    instruction:
+                      updates.content.text ?? fillTile.content.instruction,
+                    richInstruction:
+                      updates.content.richText ?? fillTile.content.richInstruction,
+                    fontFamily:
+                      updates.content.fontFamily ?? fillTile.content.fontFamily,
+                    fontSize:
+                      updates.content.fontSize ?? fillTile.content.fontSize
+                  }
+                });
+              }}
+              onFinishTextEditing={onFinishTextEditing}
+              onEditorReady={onEditorReady}
+            />,
+            true
+          );
+        } else {
+          contentToRender = renderFillBlanksContent();
         }
         break;
       }

--- a/src/components/admin/side editor/FillBlanksEditor.tsx
+++ b/src/components/admin/side editor/FillBlanksEditor.tsx
@@ -1,0 +1,246 @@
+import React, { useMemo } from 'react';
+import { Plus, Trash2, Sparkles, Square, Info } from 'lucide-react';
+import { FillBlanksTile } from '../../../types/lessonEditor.ts';
+
+interface FillBlanksEditorProps {
+  tile: FillBlanksTile;
+  onUpdateTile: (tileId: string, updates: Partial<FillBlanksTile>) => void;
+  isTesting?: boolean;
+  onToggleTesting?: (tileId: string) => void;
+}
+
+const BLANK_REGEX = /_{3,}/g;
+
+export const FillBlanksEditor: React.FC<FillBlanksEditorProps> = ({
+  tile,
+  onUpdateTile,
+  isTesting = false,
+  onToggleTesting
+}) => {
+  const blankCount = useMemo(
+    () => (tile.content.text.match(BLANK_REGEX) || []).length,
+    [tile.content.text]
+  );
+
+  const updateContent = (updates: Partial<FillBlanksTile['content']>) => {
+    onUpdateTile(tile.id, {
+      content: {
+        ...tile.content,
+        ...updates
+      },
+      updated_at: new Date().toISOString()
+    });
+  };
+
+  const syncBlanksWithText = (text: string) => {
+    const matches = text.match(BLANK_REGEX) || [];
+    let blanks = [...tile.content.blanks];
+
+    if (matches.length > blanks.length) {
+      const additions = Array.from({ length: matches.length - blanks.length }, (_, index) => ({
+        id: `${tile.id}-blank-${Date.now()}-${index}`,
+        correctAnswer: tile.content.wordBank[0] || ''
+      }));
+      blanks = [...blanks, ...additions];
+    } else if (matches.length < blanks.length) {
+      blanks = blanks.slice(0, matches.length);
+    }
+
+    return blanks;
+  };
+
+  const handleTextChange = (value: string) => {
+    const blanks = syncBlanksWithText(value);
+    updateContent({ text: value, blanks });
+  };
+
+  const handleWordBankChange = (index: number, value: string) => {
+    const wordBank = tile.content.wordBank.map((word, idx) => (idx === index ? value : word));
+    const blanks = tile.content.blanks.map(blank =>
+      wordBank.includes(blank.correctAnswer) ? blank : { ...blank, correctAnswer: '' }
+    );
+    updateContent({ wordBank, blanks });
+  };
+
+  const handleAddWord = () => {
+    updateContent({ wordBank: [...tile.content.wordBank, `Nowe słowo ${tile.content.wordBank.length + 1}`] });
+  };
+
+  const handleRemoveWord = (index: number) => {
+    const wordBank = tile.content.wordBank.filter((_, idx) => idx !== index);
+    const blanks = tile.content.blanks.map(blank =>
+      wordBank.includes(blank.correctAnswer) ? blank : { ...blank, correctAnswer: '' }
+    );
+    updateContent({ wordBank, blanks });
+  };
+
+  const handleCorrectAnswerChange = (blankIndex: number, value: string) => {
+    const blanks = tile.content.blanks.map((blank, idx) =>
+      idx === blankIndex ? { ...blank, correctAnswer: value } : blank
+    );
+    updateContent({ blanks });
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="p-4 rounded-lg border border-gray-200 bg-white shadow-sm">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <h3 className="text-sm font-semibold text-gray-900">Tryb testowania</h3>
+            <p className="text-xs text-gray-600 mt-1">
+              {isTesting
+                ? 'Tryb ucznia jest aktywny. Kafelek na płótnie jest zablokowany przed przypadkową edycją.'
+                : 'Wyłącz interakcje edycyjne kafelka i sprawdź zadanie dokładnie tak, jak zobaczy je uczeń.'}
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => onToggleTesting?.(tile.id)}
+            disabled={!onToggleTesting}
+            className={`inline-flex items-center gap-2 px-3 py-2 text-xs font-medium rounded-lg transition-colors shadow-sm ${
+              isTesting
+                ? 'bg-slate-900 text-white hover:bg-slate-800'
+                : 'bg-blue-600 text-white hover:bg-blue-500'
+            } disabled:opacity-60 disabled:cursor-not-allowed`}
+          >
+            {isTesting ? <Square className="w-4 h-4" /> : <Sparkles className="w-4 h-4" />}
+            <span>{isTesting ? 'Zakończ testowanie' : 'Przetestuj zadanie'}</span>
+          </button>
+        </div>
+      </div>
+
+      <div className="space-y-3">
+        <label className="block text-sm font-medium text-gray-700">
+          Tekst zadania ({blankCount} {blankCount === 1 ? 'luka' : 'luki'})
+        </label>
+        <textarea
+          value={tile.content.text}
+          onChange={(event) => handleTextChange(event.target.value)}
+          className="w-full min-h-[120px] px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm"
+          placeholder="Użyj ___ aby zaznaczyć miejsce na lukę"
+        />
+        <p className="text-xs text-gray-500 flex items-center gap-1">
+          <Info className="w-4 h-4" />
+          Każde wystąpienie symbolu ___ zostanie zamienione na miejsce do przeciągnięcia słowa.
+        </p>
+      </div>
+
+      <div className="space-y-4">
+        <div className="flex items-center justify-between">
+          <h3 className="text-sm font-medium text-gray-700">Bank słów</h3>
+          <button
+            type="button"
+            onClick={handleAddWord}
+            className="inline-flex items-center gap-2 px-3 py-2 bg-blue-50 text-blue-600 text-sm font-medium rounded-lg hover:bg-blue-100 transition"
+          >
+            <Plus className="w-4 h-4" />
+            Dodaj słowo
+          </button>
+        </div>
+
+        <div className="space-y-3">
+          {tile.content.wordBank.length === 0 && (
+            <div className="text-xs text-amber-600 bg-amber-50 px-3 py-2 rounded-lg">
+              Dodaj co najmniej jedno słowo, aby przygotować bank wyrazów.
+            </div>
+          )}
+
+          {tile.content.wordBank.map((word, index) => (
+            <div key={`${tile.id}-word-${index}`} className="flex items-center gap-3">
+              <input
+                type="text"
+                value={word}
+                onChange={(event) => handleWordBankChange(index, event.target.value)}
+                className="flex-1 px-3 py-2 border border-gray-300 rounded-lg focus:ring-1 focus:ring-blue-500 focus:border-transparent text-sm"
+                placeholder={`Słowo ${index + 1}`}
+              />
+              <button
+                type="button"
+                onClick={() => handleRemoveWord(index)}
+                className="p-2 text-rose-500 hover:text-rose-600 hover:bg-rose-50 rounded-lg transition"
+                title="Usuń słowo"
+              >
+                <Trash2 className="w-4 h-4" />
+              </button>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="space-y-3">
+        <h3 className="text-sm font-medium text-gray-700">Poprawne odpowiedzi</h3>
+        {blankCount === 0 ? (
+          <div className="text-xs text-gray-500 bg-gray-100 px-3 py-2 rounded-lg">
+            Dodaj co najmniej jedną lukę w tekście, aby przypisać poprawne odpowiedzi.
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {tile.content.blanks.map((blank, index) => (
+              <div key={blank.id} className="flex items-center gap-3">
+                <div className="w-12 h-12 rounded-lg bg-blue-50 text-blue-700 flex items-center justify-center font-semibold">
+                  {index + 1}
+                </div>
+                <div className="flex-1">
+                  <label className="block text-xs font-medium text-gray-600 mb-1">
+                    Wybierz poprawne słowo dla luki {index + 1}
+                  </label>
+                  <select
+                    value={blank.correctAnswer}
+                    onChange={(event) => handleCorrectAnswerChange(index, event.target.value)}
+                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-1 focus:ring-blue-500 focus:border-transparent text-sm"
+                  >
+                    <option value="">— Wybierz słowo —</option>
+                    {tile.content.wordBank.map((word) => (
+                      <option key={`${blank.id}-${word}`} value={word}>
+                        {word}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-2">Kolor akcentu</label>
+          <input
+            type="color"
+            value={tile.content.backgroundColor}
+            onChange={(event) => updateContent({ backgroundColor: event.target.value })}
+            className="w-full h-12 border border-gray-300 rounded-lg cursor-pointer"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-2">Widoczna ramka</label>
+          <div className="flex items-center gap-3">
+            <button
+              type="button"
+              onClick={() => updateContent({ showBorder: true })}
+              className={`flex-1 px-3 py-2 text-sm font-medium rounded-lg border transition ${
+                tile.content.showBorder
+                  ? 'border-blue-500 bg-blue-50 text-blue-600'
+                  : 'border-gray-200 text-gray-600 hover:border-blue-200'
+              }`}
+            >
+              Włączona
+            </button>
+            <button
+              type="button"
+              onClick={() => updateContent({ showBorder: false })}
+              className={`flex-1 px-3 py-2 text-sm font-medium rounded-lg border transition ${
+                !tile.content.showBorder
+                  ? 'border-blue-500 bg-blue-50 text-blue-600'
+                  : 'border-gray-200 text-gray-600 hover:border-blue-200'
+              }`}
+            >
+              Wyłączona
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/admin/side editor/TilePalette.tsx
+++ b/src/components/admin/side editor/TilePalette.tsx
@@ -29,6 +29,11 @@ const TILE_TYPES: TilePaletteItem[] = [
     icon: 'HelpCircle'
   },
   {
+    type: 'fillBlanks',
+    title: 'Uzupełnij luki',
+    icon: 'Puzzle'
+  },
+  {
     type: 'programming',
     title: 'Zadanie programistyczne',
     icon: 'Code'

--- a/src/components/admin/side editor/TileSideEditor.tsx
+++ b/src/components/admin/side editor/TileSideEditor.tsx
@@ -1,9 +1,18 @@
 import React from 'react';
 import { Plus, Trash2, Type, X } from 'lucide-react';
-import { TextTile, ImageTile, LessonTile, ProgrammingTile, SequencingTile, QuizTile } from '../../../types/lessonEditor.ts';
+import {
+  TextTile,
+  ImageTile,
+  LessonTile,
+  ProgrammingTile,
+  SequencingTile,
+  QuizTile,
+  FillBlanksTile
+} from '../../../types/lessonEditor.ts';
 import { ImageUploadComponent } from './ImageUploadComponent.tsx';
 import { ImagePositionControl } from './ImagePositionControl.tsx';
 import { SequencingEditor } from './SequencingEditor.tsx';
+import { FillBlanksEditor } from './FillBlanksEditor.tsx';
 
 interface TileSideEditorProps {
   tile: LessonTile | undefined;
@@ -85,9 +94,20 @@ export const TileSideEditor: React.FC<TileSideEditorProps> = ({
 
   const getTileIcon = () => {
     switch (tile.type) {
-      case 'text': return Type;
-      case 'image': return Type; // You can import Image icon
-      default: return Type;
+      case 'text':
+        return Type;
+      case 'image':
+        return Type;
+      case 'quiz':
+        return Type;
+      case 'programming':
+        return Type;
+      case 'sequencing':
+        return Type;
+      case 'fillBlanks':
+        return Type;
+      default:
+        return Type;
     }
   };
 
@@ -97,6 +117,7 @@ export const TileSideEditor: React.FC<TileSideEditorProps> = ({
       case 'image': return 'Edytor Obrazu';
       case 'visualization': return 'Edytor Wizualizacji';
       case 'quiz': return 'Edytor Quiz';
+      case 'fillBlanks': return 'Uzupełnianie luk';
       default: return 'Edytor Kafelka';
     }
   };
@@ -264,6 +285,18 @@ export const TileSideEditor: React.FC<TileSideEditorProps> = ({
           <SequencingEditor
             tile={sequencingTile}
             onUpdateTile={onUpdateTile}
+            isTesting={isTesting}
+            onToggleTesting={onToggleTesting}
+          />
+        );
+      }
+
+      case 'fillBlanks': {
+        const fillTile = tile as FillBlanksTile;
+        return (
+          <FillBlanksEditor
+            tile={fillTile}
+            onUpdateTile={onUpdateTile as (tileId: string, updates: Partial<FillBlanksTile>) => void}
             isTesting={isTesting}
             onToggleTesting={onToggleTesting}
           />

--- a/src/components/admin/top editor/TopToolbar.tsx
+++ b/src/components/admin/top editor/TopToolbar.tsx
@@ -5,7 +5,13 @@ import { FontSizeSelector } from './FontSizeSelector.tsx';
 import { TextColorPicker } from './TextColorPicker.tsx';
 import { FontSelector } from './FontSelector.tsx';
 import { AlignmentControls } from './AlignmentControls.tsx';
-import { LessonTile, ProgrammingTile, TextTile, SequencingTile } from '../../../types/lessonEditor.ts';
+import {
+  LessonTile,
+  ProgrammingTile,
+  TextTile,
+  SequencingTile,
+  FillBlanksTile
+} from '../../../types/lessonEditor.ts';
 
 
 interface TopToolbarProps {
@@ -16,7 +22,7 @@ interface TopToolbarProps {
   isTextEditing: boolean;
   onFinishTextEditing?: () => void;
   editor?: Editor | null;
-  selectedTile?: TextTile | ProgrammingTile | SequencingTile | null;
+  selectedTile?: TextTile | ProgrammingTile | SequencingTile | FillBlanksTile | null;
   onUpdateTile?: (tileId: string, updates: Partial<LessonTile>) => void;
   className?: string;
 }
@@ -77,6 +83,10 @@ export const TopToolbar: React.FC<TopToolbarProps> = ({
 
   const handleVerticalChange = (alignment: 'top' | 'center' | 'bottom') => {
     setVerticalAlign(alignment);
+    if (selectedTile?.type === 'fillBlanks') {
+      return;
+    }
+
     if (selectedTile && onUpdateTile) {
       onUpdateTile(selectedTile.id, {
         content: {
@@ -165,7 +175,11 @@ export const TopToolbar: React.FC<TopToolbarProps> = ({
             selectedHorizontal={horizontalAlign}
             selectedVertical={verticalAlign}
             onHorizontalChange={handleHorizontalChange}
-            onVerticalChange={selectedTile?.type === 'programming' ? undefined : handleVerticalChange}
+            onVerticalChange={
+              selectedTile?.type === 'programming' || selectedTile?.type === 'fillBlanks'
+                ? undefined
+                : handleVerticalChange
+            }
           />
           
           <div className="w-px h-6 bg-gray-300"></div>

--- a/src/hooks/useTileInteractions.ts
+++ b/src/hooks/useTileInteractions.ts
@@ -33,7 +33,8 @@ export const useTileInteractions = ({
       tile.type === 'text' ||
       tile.type === 'programming' ||
       tile.type === 'sequencing' ||
-      tile.type === 'quiz'
+      tile.type === 'quiz' ||
+      tile.type === 'fillBlanks'
     ) {
       dispatch({ type: 'startTextEditing', tileId: tile.id });
     } else if (tile.type === 'image') {

--- a/src/services/lessonContentService.ts
+++ b/src/services/lessonContentService.ts
@@ -1,5 +1,5 @@
 import { LessonContent, LessonTile, TextTile } from '../types/lessonEditor';
-import { ProgrammingTile, SequencingTile } from '../types/lessonEditor';
+import { ProgrammingTile, SequencingTile, FillBlanksTile } from '../types/lessonEditor';
 import { GridUtils } from '../utils/gridUtils';
 import { logger } from '../utils/logger';
 
@@ -397,6 +397,68 @@ export class LessonContentService {
         ],
         correctFeedback: 'Świetnie! Prawidłowa kolejność.',
         incorrectFeedback: 'Spróbuj ponownie. Sprawdź kolejność elementów.'
+      },
+      created_at: now,
+      updated_at: now,
+      z_index: 1
+    };
+  }
+
+  /**
+   * Create a new fill-in-the-blanks tile
+   */
+  static createFillBlanksTile(position: { x: number; y: number }, page = 1): FillBlanksTile {
+    const id = `tile-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+    const now = new Date().toISOString();
+
+    const gridPos = GridUtils.pixelToGrid(position, {
+      width: GridUtils.GRID_COLUMNS,
+      height: 6,
+      gridSize: GridUtils.GRID_CELL_SIZE,
+      snapToGrid: true
+    });
+
+    gridPos.colSpan = 4;
+    gridPos.rowSpan = 4;
+
+    const pixelPos = GridUtils.gridToPixel(gridPos, {
+      width: GridUtils.GRID_COLUMNS,
+      height: 6,
+      gridSize: GridUtils.GRID_CELL_SIZE,
+      snapToGrid: true
+    });
+
+    const pixelSize = GridUtils.gridSizeToPixel(gridPos, {
+      width: GridUtils.GRID_COLUMNS,
+      height: 6,
+      gridSize: GridUtils.GRID_CELL_SIZE,
+      snapToGrid: true
+    });
+
+    const defaultWordBank = ['kot', 'płot', 'pies', 'kotek'];
+
+    return {
+      id,
+      type: 'fillBlanks',
+      position: pixelPos,
+      size: pixelSize,
+      gridPosition: gridPos,
+      page,
+      content: {
+        instruction: 'Przeciągnij wyrazy z banku, aby uzupełnić zdania.',
+        richInstruction:
+          '<p style="margin: 0;">Przeciągnij wyrazy z banku, aby uzupełnić zdania.</p>',
+        fontFamily: 'Inter, system-ui, sans-serif',
+        fontSize: 16,
+        backgroundColor: '#2563eb',
+        showBorder: true,
+        text: '___ wskoczył na wysoki ___ i zawołał swojego przyjaciela ___',
+        blanks: [
+          { id: `${id}-blank-1`, correctAnswer: 'kot' },
+          { id: `${id}-blank-2`, correctAnswer: 'płot' },
+          { id: `${id}-blank-3`, correctAnswer: 'pies' }
+        ],
+        wordBank: defaultWordBank
       },
       created_at: now,
       updated_at: now,

--- a/src/types/lessonEditor.ts
+++ b/src/types/lessonEditor.ts
@@ -17,7 +17,7 @@ export interface GridPosition {
 
 export interface LessonTile {
   id: string;
-  type: 'text' | 'image' | 'visualization' | 'quiz' | 'programming' | 'sequencing';
+  type: 'text' | 'image' | 'visualization' | 'quiz' | 'programming' | 'sequencing' | 'fillBlanks';
   position: Position;
   size: Size;
   gridPosition: GridPosition;
@@ -125,6 +125,24 @@ export interface SequencingTile extends LessonTile {
     }>;
     correctFeedback: string;
     incorrectFeedback: string;
+  };
+}
+
+export interface FillBlanksTile extends LessonTile {
+  type: 'fillBlanks';
+  content: {
+    instruction: string;
+    richInstruction?: string;
+    fontFamily: string;
+    fontSize: number;
+    backgroundColor: string;
+    showBorder: boolean;
+    text: string;
+    blanks: Array<{
+      id: string;
+      correctAnswer: string;
+    }>;
+    wordBank: string[];
   };
 }
 


### PR DESCRIPTION
## Summary
- define the fill-in-the-blanks lesson tile type and default factory
- implement student-facing interaction plus side editor tooling for configuring blanks and word bank
- wire the new tile through the palette, renderer, editor interactions, and toolbar handling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dad1b3a10483218d8e9d66ff00ad8d