### PR TITLE
Add fill-in-the-blanks lesson tile

### DIFF
--- a/src/Pages/LessonEditor.tsx
+++ b/src/Pages/LessonEditor.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { ArrowLeft, Save, RotateCcw, Grid, Edit } from 'lucide-react';
 import { Lesson, Course } from '../types/course.ts';
-import { LessonContent, LessonTile, ProgrammingTile, TextTile } from '../types/lessonEditor.ts';
+import { LessonContent, LessonTile, ProgrammingTile, TextTile, FillBlanksTile } from '../types/lessonEditor.ts';
 import { SequencingTile } from '../types/lessonEditor.ts';
 import { useLessonEditor } from '../hooks/useLessonEditor.ts';
 import { LessonContentService } from '../services/lessonContentService.ts';
@@ -24,8 +24,13 @@ interface LessonEditorProps {
   onBack: () => void;
 }
 
-const isRichTextTile = (tile: LessonTile | null): tile is TextTile | ProgrammingTile | SequencingTile => {
-  return !!tile && (tile.type === 'text' || tile.type === 'programming' || tile.type === 'sequencing');
+const isRichTextTile = (tile: LessonTile | null): tile is TextTile | ProgrammingTile | SequencingTile | FillBlanksTile => {
+  return !!tile && (
+    tile.type === 'text' ||
+    tile.type === 'programming' ||
+    tile.type === 'sequencing' ||
+    tile.type === 'fillBlanks'
+  );
 };
 
 export const LessonEditor: React.FC<LessonEditorProps> = ({ lesson, course, onBack }) => {
@@ -253,6 +258,9 @@ export const LessonEditor: React.FC<LessonEditorProps> = ({ lesson, course, onBa
       case 'sequencing':
         newTile = LessonContentService.createSequencingTile(position, currentPage);
         break;
+      case 'fillBlanks':
+        newTile = LessonContentService.createFillBlanksTile(position, currentPage);
+        break;
       default:
         logger.warn(`Tile type ${tileType} not implemented yet`);
         warning('Funkcja niedostępna', `Typ kafelka "${tileType}" nie jest jeszcze dostępny`);
@@ -313,7 +321,14 @@ export const LessonEditor: React.FC<LessonEditorProps> = ({ lesson, course, onBa
         };
 
         // Special handling for text-based tiles to ensure content properties are merged
-        if ((tile.type === 'text' || tile.type === 'programming' || tile.type === 'sequencing') && updates.content) {
+        if (
+          (
+            tile.type === 'text' ||
+            tile.type === 'programming' ||
+            tile.type === 'sequencing' ||
+            tile.type === 'fillBlanks'
+          ) && updates.content
+        ) {
           updatedTile.content = {
             ...tile.content,
             ...updates.content

--- a/src/components/admin/FillBlanksInteractive.tsx
+++ b/src/components/admin/FillBlanksInteractive.tsx
@@ -1,0 +1,468 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { BookOpenCheck, CheckCircle2, RotateCcw, XCircle } from 'lucide-react';
+import { FillBlanksSlot, FillBlanksTile, FillBlanksWord } from '../../types/lessonEditor';
+import { TaskInstructionPanel } from './common/TaskInstructionPanel';
+
+interface FillBlanksInteractiveProps {
+  tile: FillBlanksTile;
+  isPreview?: boolean;
+  isTestingMode?: boolean;
+  onRequestTextEditing?: () => void;
+  instructionContent?: React.ReactNode;
+}
+
+type DragSource =
+  | { type: 'bank'; wordId: string }
+  | { type: 'slot'; wordId: string; slotId: string };
+
+type EvaluationState = 'idle' | 'correct' | 'incorrect';
+
+const hexToRgb = (hex: string): { r: number; g: number; b: number } | null => {
+  if (!hex) return null;
+
+  let normalized = hex.replace('#', '').trim();
+  if (normalized.length === 3) {
+    normalized = normalized
+      .split('')
+      .map(char => `${char}${char}`)
+      .join('');
+  }
+
+  if (normalized.length !== 6) return null;
+
+  const intValue = Number.parseInt(normalized, 16);
+  if (Number.isNaN(intValue)) return null;
+
+  return {
+    r: (intValue >> 16) & 255,
+    g: (intValue >> 8) & 255,
+    b: intValue & 255
+  };
+};
+
+const channelToLinear = (value: number): number => {
+  const scaled = value / 255;
+  return scaled <= 0.03928 ? scaled / 12.92 : Math.pow((scaled + 0.055) / 1.055, 2.4);
+};
+
+const getReadableTextColor = (hex: string): string => {
+  const rgb = hexToRgb(hex);
+  if (!rgb) return '#0f172a';
+
+  const luminance =
+    0.2126 * channelToLinear(rgb.r) +
+    0.7152 * channelToLinear(rgb.g) +
+    0.0722 * channelToLinear(rgb.b);
+
+  return luminance > 0.6 ? '#0f172a' : '#f8fafc';
+};
+
+const lightenColor = (hex: string, amount: number): string => {
+  const rgb = hexToRgb(hex);
+  if (!rgb) return hex;
+
+  const lightenChannel = (channel: number) => Math.round(channel + (255 - channel) * amount);
+  return `rgb(${lightenChannel(rgb.r)}, ${lightenChannel(rgb.g)}, ${lightenChannel(rgb.b)})`;
+};
+
+const darkenColor = (hex: string, amount: number): string => {
+  const rgb = hexToRgb(hex);
+  if (!rgb) return hex;
+
+  const darkenChannel = (channel: number) => Math.round(channel * (1 - amount));
+  return `rgb(${darkenChannel(rgb.r)}, ${darkenChannel(rgb.g)}, ${darkenChannel(rgb.b)})`;
+};
+
+const surfaceColor = (accent: string, textColor: string, lightenAmount: number, darkenAmount: number): string =>
+  textColor === '#0f172a' ? lightenColor(accent, lightenAmount) : darkenColor(accent, darkenAmount);
+
+interface PlacementState {
+  [slotId: string]: string | null;
+}
+
+export const FillBlanksInteractive: React.FC<FillBlanksInteractiveProps> = ({
+  tile,
+  isPreview = false,
+  isTestingMode = false,
+  onRequestTextEditing,
+  instructionContent
+}) => {
+  const [placements, setPlacements] = useState<PlacementState>({});
+  const [evaluationState, setEvaluationState] = useState<EvaluationState>('idle');
+  const [dragOverSlotId, setDragOverSlotId] = useState<string | null>(null);
+
+  const accentColor = tile.content.backgroundColor || '#2563eb';
+  const textColor = useMemo(() => getReadableTextColor(accentColor), [accentColor]);
+  const mutedLabelColor = textColor === '#0f172a' ? '#475569' : '#dbeafe';
+  const subtleCaptionColor = textColor === '#0f172a' ? '#64748b' : '#e2e8f0';
+
+  const panelBackground = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.66, 0.4),
+    [accentColor, textColor]
+  );
+  const panelBorder = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.52, 0.58),
+    [accentColor, textColor]
+  );
+  const iconBackground = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.56, 0.52),
+    [accentColor, textColor]
+  );
+  const wordBackground = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.7, 0.38),
+    [accentColor, textColor]
+  );
+  const wordBorder = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.56, 0.48),
+    [accentColor, textColor]
+  );
+  const slotBackground = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.64, 0.42),
+    [accentColor, textColor]
+  );
+  const slotBorder = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.52, 0.54),
+    [accentColor, textColor]
+  );
+  const slotHoverBackground = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.74, 0.34),
+    [accentColor, textColor]
+  );
+
+  const availableWords = useMemo(() => {
+    const usedWordIds = new Set(Object.values(placements).filter((value): value is string => Boolean(value)));
+    return tile.content.wordBank.filter(word => !usedWordIds.has(word.id));
+  }, [placements, tile.content.wordBank]);
+
+  useEffect(() => {
+    const initialPlacements = tile.content.slots.reduce<PlacementState>((acc, slot) => {
+      acc[slot.id] = null;
+      return acc;
+    }, {} as PlacementState);
+    setPlacements(initialPlacements);
+    setEvaluationState('idle');
+    setDragOverSlotId(null);
+  }, [tile.content.slots, tile.id]);
+
+  const getWordById = useCallback(
+    (wordId: string | null) => tile.content.wordBank.find(word => word.id === wordId) ?? null,
+    [tile.content.wordBank]
+  );
+
+  const parseTemplate = useMemo(() => {
+    const parts = tile.content.textTemplate.split('___');
+    const segments: Array<{ type: 'text'; value: string } | { type: 'blank'; slot: FillBlanksSlot | null }> = [];
+
+    parts.forEach((part, index) => {
+      if (part) {
+        segments.push({ type: 'text', value: part });
+      }
+      if (index < tile.content.slots.length) {
+        segments.push({ type: 'blank', slot: tile.content.slots[index] ?? null });
+      }
+    });
+
+    return segments;
+  }, [tile.content.slots, tile.content.textTemplate]);
+
+  const isInteractionEnabled = isTestingMode && !isPreview;
+  const allSlotsFilled = useMemo(
+    () => tile.content.slots.every(slot => placements[slot.id]),
+    [placements, tile.content.slots]
+  );
+
+  const handleReset = () => {
+    setPlacements(prev => {
+      const resetState: PlacementState = {};
+      Object.keys(prev).forEach(slotId => {
+        resetState[slotId] = null;
+      });
+      return resetState;
+    });
+    setEvaluationState('idle');
+    setDragOverSlotId(null);
+  };
+
+  const handleEvaluate = () => {
+    if (!allSlotsFilled) return;
+
+    const isCorrect = tile.content.slots.every(slot => {
+      const placedWordId = placements[slot.id];
+      return placedWordId !== null && placedWordId === slot.correctWordId;
+    });
+
+    setEvaluationState(isCorrect ? 'correct' : 'incorrect');
+  };
+
+  const handleDragStart = (event: React.DragEvent, payload: DragSource) => {
+    event.dataTransfer.setData('application/json', JSON.stringify(payload));
+    event.dataTransfer.effectAllowed = 'move';
+  };
+
+  const handleDropOnBank = (event: React.DragEvent) => {
+    event.preventDefault();
+    try {
+      const payload = JSON.parse(event.dataTransfer.getData('application/json')) as DragSource;
+      if (payload.type === 'slot') {
+        setPlacements(prev => ({
+          ...prev,
+          [payload.slotId]: null
+        }));
+        setEvaluationState('idle');
+        setDragOverSlotId(null);
+      }
+    } catch (error) {
+      console.error('Failed to parse drag payload', error);
+    }
+  };
+
+  const handleDropOnSlot = (event: React.DragEvent, slot: FillBlanksSlot | null) => {
+    event.preventDefault();
+    if (!slot || !isInteractionEnabled) return;
+
+    try {
+      const payload = JSON.parse(event.dataTransfer.getData('application/json')) as DragSource;
+      if (payload.type === 'bank') {
+        setPlacements(prev => ({
+          ...prev,
+          [slot.id]: payload.wordId
+        }));
+        setEvaluationState('idle');
+      }
+      if (payload.type === 'slot') {
+        setPlacements(prev => {
+          const updated: PlacementState = { ...prev };
+          updated[payload.slotId] = prev[slot.id];
+          updated[slot.id] = payload.wordId;
+          return updated;
+        });
+        setEvaluationState('idle');
+      }
+      setDragOverSlotId(null);
+    } catch (error) {
+      console.error('Failed to parse drag payload', error);
+    }
+  };
+
+  const handleDragOverSlot = (event: React.DragEvent, slotId: string) => {
+    event.preventDefault();
+    event.dataTransfer.dropEffect = 'move';
+    setDragOverSlotId(slotId);
+  };
+
+  const handleDragLeaveSlot = (slotId: string) => {
+    setDragOverSlotId(prev => (prev === slotId ? null : prev));
+  };
+
+  const handleDragOverBank = (event: React.DragEvent) => {
+    event.preventDefault();
+    event.dataTransfer.dropEffect = 'move';
+  };
+
+  const handleTileDoubleClick = () => {
+    if (onRequestTextEditing) {
+      onRequestTextEditing();
+    }
+  };
+
+  const renderSlot = (slot: FillBlanksSlot | null, index: number) => {
+    if (!slot) {
+      return (
+        <span key={`placeholder-${index}`} className="inline-flex min-w-[56px] h-9 rounded-xl bg-slate-200/60"></span>
+      );
+    }
+
+    const assignedWordId = placements[slot.id];
+    const assignedWord = assignedWordId ? getWordById(assignedWordId) : null;
+    const isEvaluated = evaluationState !== 'idle';
+    const isCorrectPlacement = assignedWordId && assignedWordId === slot.correctWordId;
+    const slotStateStyles = isEvaluated
+      ? isCorrectPlacement
+        ? 'ring-2 ring-emerald-400'
+        : 'ring-2 ring-rose-400'
+      : '';
+
+    return (
+      <div
+        key={slot.id}
+        className={`inline-flex items-center justify-center px-3 h-10 rounded-xl border text-sm font-semibold transition-all duration-150 ${slotStateStyles}`}
+        style={{
+          backgroundColor:
+            assignedWord
+              ? wordBackground
+              : dragOverSlotId === slot.id && isInteractionEnabled
+                ? slotHoverBackground
+                : slotBackground,
+          borderColor: slotBorder,
+          color: textColor,
+          minWidth: '120px'
+        }}
+        onDragOver={(event) => handleDragOverSlot(event, slot.id)}
+        onDragLeave={() => handleDragLeaveSlot(slot.id)}
+        onDrop={(event) => handleDropOnSlot(event, slot)}
+      >
+        {assignedWord ? (
+          <div
+            className="flex items-center gap-2 cursor-move"
+            draggable={isInteractionEnabled}
+            onDragStart={(event) => handleDragStart(event, { type: 'slot', wordId: assignedWord.id, slotId: slot.id })}
+          >
+            <span>{assignedWord.text}</span>
+          </div>
+        ) : (
+          <span className="opacity-70" style={{ color: subtleCaptionColor }}>
+            Przeciągnij słowo
+          </span>
+        )}
+      </div>
+    );
+  };
+
+  const renderWordBankItem = (word: FillBlanksWord) => (
+    <div
+      key={word.id}
+      className="px-3 py-2 rounded-xl border text-sm font-semibold shadow-sm cursor-move"
+      style={{
+        backgroundColor: wordBackground,
+        borderColor: wordBorder,
+        color: textColor
+      }}
+      draggable={isInteractionEnabled}
+      onDragStart={(event) => handleDragStart(event, { type: 'bank', wordId: word.id })}
+    >
+      {word.text}
+    </div>
+  );
+
+  const renderEvaluationMessage = () => {
+    if (evaluationState === 'idle') return null;
+
+    const isCorrect = evaluationState === 'correct';
+    return (
+      <div
+        className={`flex items-center gap-2 rounded-xl px-4 py-3 text-sm font-medium ${
+          isCorrect ? 'bg-emerald-100 text-emerald-800' : 'bg-rose-100 text-rose-700'
+        }`}
+      >
+        {isCorrect ? <CheckCircle2 className="w-5 h-5" /> : <XCircle className="w-5 h-5" />}
+        {isCorrect
+          ? 'Świetnie! Wszystkie odpowiedzi są poprawne.'
+          : 'Spróbuj ponownie. Niektóre odpowiedzi są niepoprawne.'}
+      </div>
+    );
+  };
+
+  return (
+    <div className="relative w-full h-full" onDoubleClick={handleTileDoubleClick}>
+      <div className="w-full h-full flex flex-col gap-5 p-6">
+        <TaskInstructionPanel
+          icon={<BookOpenCheck className="w-4 h-4" />}
+          label="Instrukcja"
+          className="border"
+          style={{
+            backgroundColor: panelBackground,
+            borderColor: panelBorder,
+            color: textColor
+          }}
+          iconWrapperClassName="w-9 h-9 rounded-xl flex items-center justify-center shadow-sm"
+          iconWrapperStyle={{
+            backgroundColor: iconBackground,
+            color: textColor
+          }}
+          labelStyle={{ color: mutedLabelColor }}
+        >
+          {instructionContent ?? (
+            <div
+              className="text-sm leading-relaxed"
+              style={{
+                fontFamily: tile.content.fontFamily,
+                fontSize: `${tile.content.fontSize}px`,
+                color: textColor
+              }}
+              dangerouslySetInnerHTML={{ __html: tile.content.richInstruction || tile.content.instruction }}
+            />
+          )}
+        </TaskInstructionPanel>
+
+        <div
+          className="flex-1 rounded-2xl border p-5 space-y-6"
+          style={{
+            backgroundColor: surfaceColor(accentColor, textColor, 0.76, 0.32),
+            borderColor: surfaceColor(accentColor, textColor, 0.58, 0.5),
+            color: textColor
+          }}
+        >
+          <div className="flex flex-wrap items-center gap-3 text-base leading-relaxed" style={{ color: textColor }}>
+            {parseTemplate.map((segment, index) =>
+              segment.type === 'text' ? (
+                <span key={`text-${index}`} className="whitespace-pre-wrap">
+                  {segment.value}
+                </span>
+              ) : (
+                renderSlot(segment.slot, index)
+              )
+            )}
+          </div>
+
+          <div
+            className="rounded-2xl border p-4 space-y-4 transition-colors"
+            style={{
+              backgroundColor: surfaceColor(accentColor, textColor, 0.82, 0.26),
+              borderColor: surfaceColor(accentColor, textColor, 0.64, 0.42),
+              color: textColor
+            }}
+            onDragOver={handleDragOverBank}
+            onDrop={handleDropOnBank}
+          >
+            <div className="flex items-center justify-between">
+              <span className="text-sm font-semibold tracking-wide uppercase" style={{ color: mutedLabelColor }}>
+                Bank słów
+              </span>
+              {!isInteractionEnabled && (
+                <span className="text-xs" style={{ color: subtleCaptionColor }}>
+                  Podgląd bez możliwości interakcji
+                </span>
+              )}
+            </div>
+
+            <div className="flex flex-wrap gap-3">
+              {availableWords.length > 0 ? (
+                availableWords.map(renderWordBankItem)
+              ) : (
+                <span className="text-sm" style={{ color: subtleCaptionColor }}>
+                  Wszystkie słowa zostały wykorzystane.
+                </span>
+              )}
+            </div>
+          </div>
+
+          {isInteractionEnabled && (
+            <div className="flex items-center gap-3 pt-1">
+              <button
+                type="button"
+                onClick={handleEvaluate}
+                className="px-4 py-2 rounded-lg text-sm font-semibold shadow-sm transition-colors duration-200 bg-white/90 hover:bg-white disabled:opacity-60 disabled:cursor-not-allowed"
+                style={{ color: accentColor }}
+                disabled={!allSlotsFilled}
+              >
+                Sprawdź odpowiedzi
+              </button>
+              <button
+                type="button"
+                onClick={handleReset}
+                className="px-3 py-2 rounded-lg text-sm font-medium flex items-center gap-2 text-slate-600 hover:text-slate-800"
+              >
+                <RotateCcw className="w-4 h-4" />
+                Wyczyść
+              </button>
+            </div>
+          )}
+
+          {renderEvaluationMessage()}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default FillBlanksInteractive;

--- a/src/components/admin/TileRenderer.tsx
+++ b/src/components/admin/TileRenderer.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Move, Trash2, Play, Code2 } from 'lucide-react';
-import { LessonTile, TextTile, ImageTile, QuizTile, ProgrammingTile, SequencingTile } from '../../types/lessonEditor';
+import { LessonTile, TextTile, ImageTile, QuizTile, ProgrammingTile, SequencingTile, FillBlanksTile } from '../../types/lessonEditor';
 import { GridUtils } from '../../utils/gridUtils';
 import { Editor, EditorContent, useEditor } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
@@ -16,6 +16,7 @@ import TextAlign from '../../extensions/TextAlign';
 import { SequencingInteractive } from './SequencingInteractive';
 import { TaskInstructionPanel } from './common/TaskInstructionPanel';
 import { QuizInteractive } from './QuizInteractive';
+import { FillBlanksInteractive } from './FillBlanksInteractive';
 
 const hexToRgb = (hex: string): { r: number; g: number; b: number } | null => {
   if (!hex) return null;
@@ -688,6 +689,67 @@ export const TileRenderer: React.FC<TileRendererProps> = ({
         } else {
           contentToRender = renderSequencingContent();
         }
+        break;
+      }
+
+      case 'fillBlanks': {
+        const fillTile = tile as FillBlanksTile;
+        const accentColor = fillTile.content.backgroundColor || computedBackground;
+        const textColor = getReadableTextColor(accentColor);
+
+        if (isEditingText && isSelected) {
+          const instructionEditorTile: TextTile = {
+            ...tile,
+            type: 'text',
+            content: {
+              text: fillTile.content.instruction,
+              richText: fillTile.content.richInstruction,
+              fontFamily: fillTile.content.fontFamily,
+              fontSize: fillTile.content.fontSize,
+              verticalAlign: 'top',
+              backgroundColor: accentColor,
+              showBorder: fillTile.content.showBorder
+            }
+          };
+
+          contentToRender = (
+            <FillBlanksInteractive
+              tile={fillTile}
+              isPreview
+              instructionContent={
+                <RichTextEditor
+                  textTile={instructionEditorTile}
+                  tileId={tile.id}
+                  onUpdateTile={(tileId, updates) => {
+                    if (!updates.content) return;
+
+                    onUpdateTile(tileId, {
+                      content: {
+                        ...fillTile.content,
+                        instruction: updates.content.text ?? fillTile.content.instruction,
+                        richInstruction: updates.content.richText ?? fillTile.content.richInstruction,
+                        fontFamily: updates.content.fontFamily ?? fillTile.content.fontFamily,
+                        fontSize: updates.content.fontSize ?? fillTile.content.fontSize
+                      }
+                    });
+                  }}
+                  onFinishTextEditing={onFinishTextEditing}
+                  onEditorReady={onEditorReady}
+                  textColor={textColor}
+                />
+              }
+            />
+          );
+        } else {
+          contentToRender = (
+            <FillBlanksInteractive
+              tile={fillTile}
+              isTestingMode={isTestingMode}
+              onRequestTextEditing={onDoubleClick}
+            />
+          );
+        }
+
         break;
       }
       default:

--- a/src/components/admin/side editor/FillBlanksEditor.tsx
+++ b/src/components/admin/side editor/FillBlanksEditor.tsx
@@ -1,0 +1,217 @@
+import React, { useMemo } from 'react';
+import { FillBlanksSlot, FillBlanksTile, FillBlanksWord, LessonTile } from '../../../types/lessonEditor';
+import { Plus, Trash2 } from 'lucide-react';
+
+interface FillBlanksEditorProps {
+  tile: FillBlanksTile;
+  onUpdateTile: (tileId: string, updates: Partial<LessonTile>) => void;
+}
+
+const FONT_OPTIONS = [
+  { label: 'Inter', value: 'Inter, system-ui, sans-serif' },
+  { label: 'Roboto', value: 'Roboto, sans-serif' },
+  { label: 'Lora', value: 'Lora, serif' },
+  { label: 'Poppins', value: 'Poppins, sans-serif' }
+];
+
+const generateSlotId = (index: number) => `fill-slot-${index}-${Math.random().toString(36).slice(2, 7)}`;
+
+export const FillBlanksEditor: React.FC<FillBlanksEditorProps> = ({ tile, onUpdateTile }) => {
+  const placeholderCount = useMemo(() => (tile.content.textTemplate.match(/___/g) || []).length, [tile.content.textTemplate]);
+
+  const ensureSlotsMatchTemplate = (textTemplate: string, currentSlots: FillBlanksSlot[]): FillBlanksSlot[] => {
+    const matches = textTemplate.match(/___/g) || [];
+    return matches.map((_, index) => currentSlots[index] ?? { id: generateSlotId(index), correctWordId: null });
+  };
+
+  const handleContentUpdate = (updates: Partial<FillBlanksTile['content']>) => {
+    onUpdateTile(tile.id, {
+      content: {
+        ...tile.content,
+        ...updates
+      },
+      updated_at: new Date().toISOString()
+    });
+  };
+
+  const handleTemplateChange = (value: string) => {
+    const updatedSlots = ensureSlotsMatchTemplate(value, tile.content.slots);
+    handleContentUpdate({
+      textTemplate: value,
+      slots: updatedSlots
+    });
+  };
+
+  const handleWordUpdate = (wordId: string, value: string) => {
+    const updatedWordBank = tile.content.wordBank.map(word =>
+      word.id === wordId ? { ...word, text: value } : word
+    );
+    handleContentUpdate({ wordBank: updatedWordBank });
+  };
+
+  const handleAddWord = () => {
+    const newWord: FillBlanksWord = {
+      id: `word-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+      text: `Nowe słowo ${tile.content.wordBank.length + 1}`
+    };
+    handleContentUpdate({ wordBank: [...tile.content.wordBank, newWord] });
+  };
+
+  const handleRemoveWord = (wordId: string) => {
+    const updatedWordBank = tile.content.wordBank.filter(word => word.id !== wordId);
+    const updatedSlots = tile.content.slots.map(slot =>
+      slot.correctWordId === wordId ? { ...slot, correctWordId: null } : slot
+    );
+    handleContentUpdate({
+      wordBank: updatedWordBank,
+      slots: updatedSlots
+    });
+  };
+
+  const handleCorrectWordChange = (slotId: string, wordId: string | null) => {
+    const updatedSlots = tile.content.slots.map(slot =>
+      slot.id === slotId ? { ...slot, correctWordId: wordId } : slot
+    );
+    handleContentUpdate({ slots: updatedSlots });
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-2">Kolor akcentu</label>
+        <input
+          type="color"
+          value={tile.content.backgroundColor}
+          onChange={(event) => handleContentUpdate({ backgroundColor: event.target.value })}
+          className="w-full h-12 border border-gray-300 rounded-lg cursor-pointer"
+        />
+      </div>
+
+      <div>
+        <label className="flex items-center space-x-3 p-4 bg-gray-50 rounded-lg">
+          <input
+            type="checkbox"
+            checked={tile.content.showBorder}
+            onChange={(event) => handleContentUpdate({ showBorder: event.target.checked })}
+            className="w-5 h-5 text-blue-600"
+          />
+          <div>
+            <span className="text-sm font-medium text-gray-900">Pokaż obramowanie kafelka</span>
+            <p className="text-xs text-gray-600 mt-1">
+              Obwódka pomaga wyróżnić kafelek na tle innych elementów.
+            </p>
+          </div>
+        </label>
+      </div>
+
+      <div className="space-y-2">
+        <label className="block text-sm font-medium text-gray-700">Treść zadania</label>
+        <p className="text-xs text-gray-500">
+          Użyj sekwencji <span className="font-semibold">___</span> w miejscach, które mają zostać uzupełnione.
+        </p>
+        <textarea
+          value={tile.content.textTemplate}
+          onChange={(event) => handleTemplateChange(event.target.value)}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm resize-vertical"
+          rows={5}
+        />
+        <p className="text-xs text-gray-500">Liczba luk w tekście: {placeholderCount}</p>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-2">Rodzina czcionki</label>
+          <select
+            value={tile.content.fontFamily}
+            onChange={(event) => handleContentUpdate({ fontFamily: event.target.value })}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm"
+          >
+            {FONT_OPTIONS.map(option => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-2">Rozmiar tekstu</label>
+          <input
+            type="number"
+            min={12}
+            max={36}
+            value={tile.content.fontSize}
+            onChange={(event) => handleContentUpdate({ fontSize: Number(event.target.value) })}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm"
+          />
+        </div>
+      </div>
+
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <h4 className="text-sm font-semibold text-gray-800">Bank słów</h4>
+          <button
+            type="button"
+            onClick={handleAddWord}
+            className="inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-blue-50 text-blue-600 text-sm font-medium hover:bg-blue-100 transition"
+          >
+            <Plus className="w-4 h-4" />
+            Dodaj słowo
+          </button>
+        </div>
+
+        <div className="space-y-3">
+          {tile.content.wordBank.map(word => (
+            <div key={word.id} className="border border-gray-200 rounded-xl p-4 bg-gray-50 space-y-3">
+              <div className="flex items-center justify-between">
+                <span className="text-sm font-medium text-gray-700">Słowo</span>
+                <button
+                  type="button"
+                  onClick={() => handleRemoveWord(word.id)}
+                  className="inline-flex items-center gap-1 text-xs font-medium px-2 py-1 rounded-lg text-rose-600 hover:bg-rose-50 transition"
+                >
+                  <Trash2 className="w-4 h-4" />
+                  Usuń
+                </button>
+              </div>
+              <input
+                type="text"
+                value={word.text}
+                onChange={(event) => handleWordUpdate(word.id, event.target.value)}
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm"
+              />
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="space-y-3">
+        <h4 className="text-sm font-semibold text-gray-800">Poprawne odpowiedzi</h4>
+        {tile.content.slots.length === 0 ? (
+          <p className="text-sm text-gray-600">
+            Dodaj w treści zadania sekwencję <span className="font-semibold">___</span>, aby utworzyć lukę do uzupełnienia.
+          </p>
+        ) : (
+          <div className="space-y-3">
+            {tile.content.slots.map((slot, index) => (
+              <div key={slot.id} className="border border-gray-200 rounded-xl p-4 bg-white flex flex-col gap-2">
+                <span className="text-sm font-medium text-gray-700">Luka {index + 1}</span>
+                <select
+                  value={slot.correctWordId ?? ''}
+                  onChange={(event) => handleCorrectWordChange(slot.id, event.target.value || null)}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm"
+                >
+                  <option value="">Wybierz poprawne słowo</option>
+                  {tile.content.wordBank.map(word => (
+                    <option key={word.id} value={word.id}>
+                      {word.text}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/components/admin/side editor/TilePalette.tsx
+++ b/src/components/admin/side editor/TilePalette.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Type, Image, Puzzle, Eye, HelpCircle, Plus, Code, ArrowUpDown } from 'lucide-react';
+import { Type, Image, Puzzle, Eye, HelpCircle, Plus, Code, ArrowUpDown, ListChecks } from 'lucide-react';
 import { TilePaletteItem } from '../../../types/lessonEditor.ts';
 
 interface TilePaletteProps {
@@ -37,6 +37,11 @@ const TILE_TYPES: TilePaletteItem[] = [
     type: 'sequencing',
     title: 'Ćwiczenie sekwencyjne',
     icon: 'ArrowUpDown'
+  },
+  {
+    type: 'fillBlanks',
+    title: 'Uzupełnij luki',
+    icon: 'ListChecks'
   }
 ];
 
@@ -49,6 +54,7 @@ const getIcon = (iconName: string) => {
     case 'HelpCircle': return HelpCircle;
     case 'Code': return Code;
     case 'ArrowUpDown': return ArrowUpDown;
+    case 'ListChecks': return ListChecks;
     default: return Type;
   }
 };

--- a/src/components/admin/side editor/TileSideEditor.tsx
+++ b/src/components/admin/side editor/TileSideEditor.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { Plus, Trash2, Type, X } from 'lucide-react';
-import { TextTile, ImageTile, LessonTile, ProgrammingTile, SequencingTile, QuizTile } from '../../../types/lessonEditor.ts';
+import { TextTile, ImageTile, LessonTile, ProgrammingTile, SequencingTile, QuizTile, FillBlanksTile } from '../../../types/lessonEditor.ts';
 import { ImageUploadComponent } from './ImageUploadComponent.tsx';
 import { ImagePositionControl } from './ImagePositionControl.tsx';
 import { SequencingEditor } from './SequencingEditor.tsx';
+import { FillBlanksEditor } from './FillBlanksEditor.tsx';
 
 interface TileSideEditorProps {
   tile: LessonTile | undefined;
@@ -97,6 +98,7 @@ export const TileSideEditor: React.FC<TileSideEditorProps> = ({
       case 'image': return 'Edytor Obrazu';
       case 'visualization': return 'Edytor Wizualizacji';
       case 'quiz': return 'Edytor Quiz';
+      case 'fillBlanks': return 'Edytor uzupełniania luk';
       default: return 'Edytor Kafelka';
     }
   };
@@ -266,6 +268,16 @@ export const TileSideEditor: React.FC<TileSideEditorProps> = ({
             onUpdateTile={onUpdateTile}
             isTesting={isTesting}
             onToggleTesting={onToggleTesting}
+          />
+        );
+      }
+
+      case 'fillBlanks': {
+        const fillTile = tile as FillBlanksTile;
+        return (
+          <FillBlanksEditor
+            tile={fillTile}
+            onUpdateTile={onUpdateTile}
           />
         );
       }

--- a/src/components/admin/top editor/TopToolbar.tsx
+++ b/src/components/admin/top editor/TopToolbar.tsx
@@ -5,7 +5,7 @@ import { FontSizeSelector } from './FontSizeSelector.tsx';
 import { TextColorPicker } from './TextColorPicker.tsx';
 import { FontSelector } from './FontSelector.tsx';
 import { AlignmentControls } from './AlignmentControls.tsx';
-import { LessonTile, ProgrammingTile, TextTile, SequencingTile } from '../../../types/lessonEditor.ts';
+import { LessonTile, ProgrammingTile, TextTile, SequencingTile, FillBlanksTile } from '../../../types/lessonEditor.ts';
 
 
 interface TopToolbarProps {
@@ -16,7 +16,7 @@ interface TopToolbarProps {
   isTextEditing: boolean;
   onFinishTextEditing?: () => void;
   editor?: Editor | null;
-  selectedTile?: TextTile | ProgrammingTile | SequencingTile | null;
+  selectedTile?: TextTile | ProgrammingTile | SequencingTile | FillBlanksTile | null;
   onUpdateTile?: (tileId: string, updates: Partial<LessonTile>) => void;
   className?: string;
 }
@@ -67,6 +67,8 @@ export const TopToolbar: React.FC<TopToolbarProps> = ({
   useEffect(() => {
     if (selectedTile?.type === 'text' || selectedTile?.type === 'sequencing') {
       setVerticalAlign(selectedTile.content.verticalAlign || 'top');
+    } else {
+      setVerticalAlign('top');
     }
   }, [selectedTile]);
 
@@ -165,7 +167,11 @@ export const TopToolbar: React.FC<TopToolbarProps> = ({
             selectedHorizontal={horizontalAlign}
             selectedVertical={verticalAlign}
             onHorizontalChange={handleHorizontalChange}
-            onVerticalChange={selectedTile?.type === 'programming' ? undefined : handleVerticalChange}
+            onVerticalChange={
+              selectedTile?.type === 'programming' || selectedTile?.type === 'fillBlanks'
+                ? undefined
+                : handleVerticalChange
+            }
           />
           
           <div className="w-px h-6 bg-gray-300"></div>

--- a/src/hooks/useTileInteractions.ts
+++ b/src/hooks/useTileInteractions.ts
@@ -33,7 +33,8 @@ export const useTileInteractions = ({
       tile.type === 'text' ||
       tile.type === 'programming' ||
       tile.type === 'sequencing' ||
-      tile.type === 'quiz'
+      tile.type === 'quiz' ||
+      tile.type === 'fillBlanks'
     ) {
       dispatch({ type: 'startTextEditing', tileId: tile.id });
     } else if (tile.type === 'image') {

--- a/src/services/lessonContentService.ts
+++ b/src/services/lessonContentService.ts
@@ -1,5 +1,5 @@
 import { LessonContent, LessonTile, TextTile } from '../types/lessonEditor';
-import { ProgrammingTile, SequencingTile } from '../types/lessonEditor';
+import { ProgrammingTile, SequencingTile, FillBlanksTile } from '../types/lessonEditor';
 import { GridUtils } from '../utils/gridUtils';
 import { logger } from '../utils/logger';
 
@@ -397,6 +397,71 @@ export class LessonContentService {
         ],
         correctFeedback: 'Świetnie! Prawidłowa kolejność.',
         incorrectFeedback: 'Spróbuj ponownie. Sprawdź kolejność elementów.'
+      },
+      created_at: now,
+      updated_at: now,
+      z_index: 1
+    };
+  }
+
+  /**
+   * Create a new fill-in-the-blanks tile
+   */
+  static createFillBlanksTile(position: { x: number; y: number }, page = 1): FillBlanksTile {
+    const id = `tile-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+    const now = new Date().toISOString();
+
+    const gridPos = GridUtils.pixelToGrid(position, {
+      width: GridUtils.GRID_COLUMNS,
+      height: 6,
+      gridSize: GridUtils.GRID_CELL_SIZE,
+      snapToGrid: true
+    });
+
+    gridPos.colSpan = 4;
+    gridPos.rowSpan = 4;
+
+    const pixelPos = GridUtils.gridToPixel(gridPos, {
+      width: GridUtils.GRID_COLUMNS,
+      height: 6,
+      gridSize: GridUtils.GRID_CELL_SIZE,
+      snapToGrid: true
+    });
+
+    const pixelSize = GridUtils.gridSizeToPixel(gridPos, {
+      width: GridUtils.GRID_COLUMNS,
+      height: 6,
+      gridSize: GridUtils.GRID_CELL_SIZE,
+      snapToGrid: true
+    });
+
+    const defaultWordBank = [
+      { id: 'word-1', text: 'programowania' },
+      { id: 'word-2', text: 'algorytmów' },
+      { id: 'word-3', text: 'rozwiązań' }
+    ];
+
+    return {
+      id,
+      type: 'fillBlanks',
+      position: pixelPos,
+      size: pixelSize,
+      gridPosition: gridPos,
+      page,
+      content: {
+        instruction: '<p style="margin: 0;">Przeciągnij wyrazy do odpowiednich luk w tekście.</p>',
+        richInstruction: '<p style="margin: 0;">Przeciągnij wyrazy do odpowiednich luk w tekście.</p>',
+        fontFamily: 'Inter, system-ui, sans-serif',
+        fontSize: 16,
+        backgroundColor: '#2563eb',
+        showBorder: true,
+        textTemplate: 'Nauka ___ pomaga w zrozumieniu ___ i tworzeniu własnych ___.',
+        slots: [
+          { id: 'slot-1', correctWordId: 'word-1' },
+          { id: 'slot-2', correctWordId: 'word-2' },
+          { id: 'slot-3', correctWordId: 'word-3' }
+        ],
+        wordBank: defaultWordBank
       },
       created_at: now,
       updated_at: now,

--- a/src/types/lessonEditor.ts
+++ b/src/types/lessonEditor.ts
@@ -17,7 +17,7 @@ export interface GridPosition {
 
 export interface LessonTile {
   id: string;
-  type: 'text' | 'image' | 'visualization' | 'quiz' | 'programming' | 'sequencing';
+  type: 'text' | 'image' | 'visualization' | 'quiz' | 'programming' | 'sequencing' | 'fillBlanks';
   position: Position;
   size: Size;
   gridPosition: GridPosition;
@@ -125,6 +125,31 @@ export interface SequencingTile extends LessonTile {
     }>;
     correctFeedback: string;
     incorrectFeedback: string;
+  };
+}
+
+export interface FillBlanksWord {
+  id: string;
+  text: string;
+}
+
+export interface FillBlanksSlot {
+  id: string;
+  correctWordId: string | null;
+}
+
+export interface FillBlanksTile extends LessonTile {
+  type: 'fillBlanks';
+  content: {
+    instruction: string;
+    richInstruction?: string;
+    fontFamily: string;
+    fontSize: number;
+    backgroundColor: string;
+    showBorder: boolean;
+    textTemplate: string;
+    slots: FillBlanksSlot[];
+    wordBank: FillBlanksWord[];
   };
 }
 


### PR DESCRIPTION
## Summary
- add a fill-in-the-blanks interactive tile with drag and drop word bank, answer checking, and TaskInstructionPanel integration
- provide a dedicated side editor for configuring the prompt template, word bank entries, and correct answers
- wire the new tile type into creation, palette selection, rendering, and editing flows across the lesson editor

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dad1b3a10483218d8e9d66ff00ad8d