### PR TITLE
Add fill-in-the-blank matching tile

### DIFF
--- a/src/Pages/LessonEditor.tsx
+++ b/src/Pages/LessonEditor.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { ArrowLeft, Save, RotateCcw, Grid, Edit } from 'lucide-react';
 import { Lesson, Course } from '../types/course.ts';
-import { LessonContent, LessonTile, ProgrammingTile, TextTile } from '../types/lessonEditor.ts';
+import { LessonContent, LessonTile, ProgrammingTile, TextTile, MatchingTile } from '../types/lessonEditor.ts';
 import { SequencingTile } from '../types/lessonEditor.ts';
 import { useLessonEditor } from '../hooks/useLessonEditor.ts';
 import { LessonContentService } from '../services/lessonContentService.ts';
@@ -24,8 +24,8 @@ interface LessonEditorProps {
   onBack: () => void;
 }
 
-const isRichTextTile = (tile: LessonTile | null): tile is TextTile | ProgrammingTile | SequencingTile => {
-  return !!tile && (tile.type === 'text' || tile.type === 'programming' || tile.type === 'sequencing');
+const isRichTextTile = (tile: LessonTile | null): tile is TextTile | ProgrammingTile | SequencingTile | MatchingTile => {
+  return !!tile && (tile.type === 'text' || tile.type === 'programming' || tile.type === 'sequencing' || tile.type === 'matching');
 };
 
 export const LessonEditor: React.FC<LessonEditorProps> = ({ lesson, course, onBack }) => {
@@ -253,6 +253,9 @@ export const LessonEditor: React.FC<LessonEditorProps> = ({ lesson, course, onBa
       case 'sequencing':
         newTile = LessonContentService.createSequencingTile(position, currentPage);
         break;
+      case 'matching':
+        newTile = LessonContentService.createMatchingTile(position, currentPage);
+        break;
       default:
         logger.warn(`Tile type ${tileType} not implemented yet`);
         warning('Funkcja niedostępna', `Typ kafelka "${tileType}" nie jest jeszcze dostępny`);
@@ -313,7 +316,7 @@ export const LessonEditor: React.FC<LessonEditorProps> = ({ lesson, course, onBa
         };
 
         // Special handling for text-based tiles to ensure content properties are merged
-        if ((tile.type === 'text' || tile.type === 'programming' || tile.type === 'sequencing') && updates.content) {
+        if ((tile.type === 'text' || tile.type === 'programming' || tile.type === 'sequencing' || tile.type === 'matching') && updates.content) {
           updatedTile.content = {
             ...tile.content,
             ...updates.content

--- a/src/components/admin/MatchingInteractive.tsx
+++ b/src/components/admin/MatchingInteractive.tsx
@@ -1,0 +1,662 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { Sparkles, PenLine, RefreshCw, CheckCircle, XCircle, BookOpen, Hand } from 'lucide-react';
+import { MatchingTile, MatchingWord } from '../../types/lessonEditor';
+import { TaskInstructionPanel } from './common/TaskInstructionPanel';
+
+interface MatchingInteractiveProps {
+  tile: MatchingTile;
+  isPreview?: boolean;
+  isTestingMode?: boolean;
+  onRequestTextEditing?: () => void;
+  instructionContent?: React.ReactNode;
+}
+
+type DragSource = 'bank' | 'blank';
+
+interface DragState {
+  wordId: string;
+  source: DragSource;
+  blankId?: string;
+}
+
+interface Segment {
+  type: 'text' | 'blank';
+  value: string;
+}
+
+const PLACEHOLDER_REGEX = /\[\[([^\[\]]+)\]\]/g;
+
+const parseSegments = (text: string, blankIds: Set<string>): Segment[] => {
+  const segments: Segment[] = [];
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+  const source = text ?? '';
+
+  while ((match = PLACEHOLDER_REGEX.exec(source)) !== null) {
+    const [placeholder, id] = match;
+    if (match.index > lastIndex) {
+      segments.push({ type: 'text', value: source.slice(lastIndex, match.index) });
+    }
+
+    if (id && blankIds.has(id)) {
+      segments.push({ type: 'blank', value: id });
+    } else {
+      segments.push({ type: 'text', value: placeholder });
+    }
+
+    lastIndex = match.index + placeholder.length;
+  }
+
+  if (lastIndex < source.length) {
+    segments.push({ type: 'text', value: source.slice(lastIndex) });
+  }
+
+  if (segments.length === 0) {
+    segments.push({ type: 'text', value: source });
+  }
+
+  return segments;
+};
+
+const hexToRgb = (hex: string): { r: number; g: number; b: number } | null => {
+  if (!hex) return null;
+
+  let normalized = hex.replace('#', '').trim();
+  if (normalized.length === 3) {
+    normalized = normalized.split('').map(char => `${char}${char}`).join('');
+  }
+
+  if (normalized.length !== 6) return null;
+
+  const intValue = Number.parseInt(normalized, 16);
+  if (Number.isNaN(intValue)) return null;
+
+  return {
+    r: (intValue >> 16) & 255,
+    g: (intValue >> 8) & 255,
+    b: intValue & 255
+  };
+};
+
+const channelToLinear = (value: number): number => {
+  const scaled = value / 255;
+  return scaled <= 0.03928 ? scaled / 12.92 : Math.pow((scaled + 0.055) / 1.055, 2.4);
+};
+
+const getReadableTextColor = (hex: string): string => {
+  const rgb = hexToRgb(hex);
+  if (!rgb) return '#0f172a';
+
+  const luminance =
+    0.2126 * channelToLinear(rgb.r) +
+    0.7152 * channelToLinear(rgb.g) +
+    0.0722 * channelToLinear(rgb.b);
+
+  return luminance > 0.6 ? '#0f172a' : '#f8fafc';
+};
+
+const lightenColor = (hex: string, amount: number): string => {
+  const rgb = hexToRgb(hex);
+  if (!rgb) return hex;
+
+  const lightenChannel = (channel: number) => Math.round(channel + (255 - channel) * amount);
+  return `rgb(${lightenChannel(rgb.r)}, ${lightenChannel(rgb.g)}, ${lightenChannel(rgb.b)})`;
+};
+
+const darkenColor = (hex: string, amount: number): string => {
+  const rgb = hexToRgb(hex);
+  if (!rgb) return hex;
+
+  const darkenChannel = (channel: number) => Math.round(channel * (1 - amount));
+  return `rgb(${darkenChannel(rgb.r)}, ${darkenChannel(rgb.g)}, ${darkenChannel(rgb.b)})`;
+};
+
+const surfaceColor = (accent: string, textColor: string, lightenAmount: number, darkenAmount: number): string =>
+  textColor === '#0f172a' ? lightenColor(accent, lightenAmount) : darkenColor(accent, darkenAmount);
+
+export const MatchingInteractive: React.FC<MatchingInteractiveProps> = ({
+  tile,
+  isPreview = false,
+  isTestingMode = false,
+  onRequestTextEditing,
+  instructionContent
+}) => {
+  const [availableWords, setAvailableWords] = useState<MatchingWord[]>(() => [...tile.content.wordBank]);
+  const [placements, setPlacements] = useState<Record<string, MatchingWord | null>>(() => {
+    const initial: Record<string, MatchingWord | null> = {};
+    tile.content.blanks.forEach(blank => {
+      initial[blank.id] = null;
+    });
+    return initial;
+  });
+  const [dragState, setDragState] = useState<DragState | null>(null);
+  const [hoveredBlankId, setHoveredBlankId] = useState<string | null>(null);
+  const [isBankHighlighted, setIsBankHighlighted] = useState(false);
+  const [isChecked, setIsChecked] = useState(false);
+  const [isCorrect, setIsCorrect] = useState<boolean | null>(null);
+  const [attempts, setAttempts] = useState(0);
+  const [feedbackMessage, setFeedbackMessage] = useState('');
+
+  const blankIds = useMemo(() => new Set(tile.content.blanks.map(blank => blank.id)), [tile.content.blanks]);
+  const segments = useMemo(() => parseSegments(tile.content.storyText || '', blankIds), [tile.content.storyText, blankIds]);
+  const wordOrder = useMemo(() => tile.content.wordBank.map(word => word.id), [tile.content.wordBank]);
+  const canInteract = !isPreview;
+
+  const accentColor = tile.content.backgroundColor || '#0f172a';
+  const textColor = useMemo(() => getReadableTextColor(accentColor), [accentColor]);
+  const gradientStart = useMemo(() => lightenColor(accentColor, 0.08), [accentColor]);
+  const gradientEnd = useMemo(() => darkenColor(accentColor, 0.08), [accentColor]);
+  const frameBorderColor = useMemo(() => surfaceColor(accentColor, textColor, 0.52, 0.6), [accentColor, textColor]);
+  const panelBackground = useMemo(() => surfaceColor(accentColor, textColor, 0.64, 0.45), [accentColor, textColor]);
+  const panelBorder = useMemo(() => surfaceColor(accentColor, textColor, 0.5, 0.58), [accentColor, textColor]);
+  const iconBackground = useMemo(() => surfaceColor(accentColor, textColor, 0.56, 0.5), [accentColor, textColor]);
+  const mutedLabelColor = textColor === '#0f172a' ? '#475569' : '#dbeafe';
+  const subtleCaptionColor = textColor === '#0f172a' ? '#64748b' : '#e2e8f0';
+  const bankBackground = useMemo(() => surfaceColor(accentColor, textColor, 0.6, 0.42), [accentColor, textColor]);
+  const bankBorder = useMemo(() => surfaceColor(accentColor, textColor, 0.5, 0.56), [accentColor, textColor]);
+  const bankHighlightBackground = useMemo(() => surfaceColor(accentColor, textColor, 0.7, 0.34), [accentColor, textColor]);
+  const bankHighlightBorder = useMemo(() => surfaceColor(accentColor, textColor, 0.62, 0.46), [accentColor, textColor]);
+  const wordBackground = useMemo(() => surfaceColor(accentColor, textColor, 0.56, 0.48), [accentColor, textColor]);
+  const wordBorder = useMemo(() => surfaceColor(accentColor, textColor, 0.48, 0.58), [accentColor, textColor]);
+  const wordHoverBackground = useMemo(() => surfaceColor(accentColor, textColor, 0.62, 0.42), [accentColor, textColor]);
+  const wordHoverBorder = useMemo(() => surfaceColor(accentColor, textColor, 0.54, 0.54), [accentColor, textColor]);
+  const blankEmptyBackground = useMemo(() => surfaceColor(accentColor, textColor, 0.6, 0.4), [accentColor, textColor]);
+  const blankEmptyBorder = useMemo(() => surfaceColor(accentColor, textColor, 0.5, 0.56), [accentColor, textColor]);
+  const blankFilledBackground = useMemo(() => surfaceColor(accentColor, textColor, 0.54, 0.46), [accentColor, textColor]);
+  const blankFilledBorder = useMemo(() => surfaceColor(accentColor, textColor, 0.44, 0.6), [accentColor, textColor]);
+  const blankHoverBackground = useMemo(() => surfaceColor(accentColor, textColor, 0.68, 0.32), [accentColor, textColor]);
+  const blankHoverBorder = useMemo(() => surfaceColor(accentColor, textColor, 0.58, 0.5), [accentColor, textColor]);
+  const blankCorrectBackground = useMemo(() => surfaceColor(accentColor, textColor, 0.7, 0.22), [accentColor, textColor]);
+  const blankCorrectBorder = useMemo(() => surfaceColor(accentColor, textColor, 0.62, 0.34), [accentColor, textColor]);
+  const attemptCaptionColor = useMemo(() => surfaceColor(accentColor, textColor, 0.42, 0.4), [accentColor, textColor]);
+
+  const resetState = useCallback(() => {
+    const initial: Record<string, MatchingWord | null> = {};
+    tile.content.blanks.forEach(blank => {
+      initial[blank.id] = null;
+    });
+
+    setPlacements(initial);
+    setAvailableWords([...tile.content.wordBank]);
+    setDragState(null);
+    setHoveredBlankId(null);
+    setIsBankHighlighted(false);
+    setIsChecked(false);
+    setIsCorrect(null);
+    setFeedbackMessage('');
+    setAttempts(0);
+  }, [tile.content.blanks, tile.content.wordBank]);
+
+  useEffect(() => {
+    resetState();
+  }, [resetState, tile.content.storyText]);
+
+  const sortWords = useCallback((words: MatchingWord[]) => {
+    const order = new Map(wordOrder.map((id, index) => [id, index]));
+    return [...words].sort((a, b) => {
+      const indexA = order.has(a.id) ? order.get(a.id)! : Number.POSITIVE_INFINITY;
+      const indexB = order.has(b.id) ? order.get(b.id)! : Number.POSITIVE_INFINITY;
+      return indexA - indexB;
+    });
+  }, [wordOrder]);
+
+  const handleDragStart = (word: MatchingWord, source: DragSource, blankId?: string) => (event: React.DragEvent) => {
+    if (!canInteract) return;
+
+    setDragState({ wordId: word.id, source, blankId });
+    event.dataTransfer.setData('application/json', JSON.stringify({ type: 'matching-word', wordId: word.id, source, blankId }));
+    event.dataTransfer.effectAllowed = 'move';
+  };
+
+  const handleDragEnd = () => {
+    setDragState(null);
+    setHoveredBlankId(null);
+    setIsBankHighlighted(false);
+  };
+
+  const handleBlankDragOver = (blankId: string) => (event: React.DragEvent) => {
+    if (!canInteract) return;
+    event.preventDefault();
+    event.dataTransfer.dropEffect = 'move';
+    setHoveredBlankId(blankId);
+  };
+
+  const handleBlankDragLeave = (blankId: string) => (event: React.DragEvent) => {
+    if (!canInteract) return;
+    if (!event.currentTarget.contains(event.relatedTarget as Node)) {
+      if (hoveredBlankId === blankId) {
+        setHoveredBlankId(null);
+      }
+    }
+  };
+
+  const handleDropOnBlank = (blankId: string) => (event: React.DragEvent) => {
+    if (!canInteract) return;
+    event.preventDefault();
+
+    const dataString = event.dataTransfer.getData('application/json');
+    if (!dataString) return;
+
+    try {
+      const data = JSON.parse(dataString) as DragState & { type: string };
+      if (data.type !== 'matching-word') return;
+
+      setHoveredBlankId(null);
+
+      if (data.source === 'bank') {
+        const word = availableWords.find(item => item.id === data.wordId);
+        if (!word) return;
+
+        setPlacements(prev => {
+          const next = { ...prev };
+          const displaced = next[blankId];
+          next[blankId] = word;
+
+          setAvailableWords(prevWords => {
+            const filtered = prevWords.filter(item => item.id !== word.id);
+            return displaced ? sortWords([...filtered, displaced]) : filtered;
+          });
+
+          setIsChecked(false);
+          setIsCorrect(null);
+          setFeedbackMessage('');
+          return next;
+        });
+      } else if (data.source === 'blank') {
+        const fromBlankId = data.blankId;
+        if (!fromBlankId || fromBlankId === blankId) return;
+
+        setPlacements(prev => {
+          const next = { ...prev };
+          const movingWord = next[fromBlankId];
+          if (!movingWord) return prev;
+
+          const displaced = next[blankId];
+          next[fromBlankId] = null;
+          next[blankId] = movingWord;
+
+          if (displaced) {
+            setAvailableWords(prevWords => sortWords([...prevWords, displaced]));
+          }
+
+          setIsChecked(false);
+          setIsCorrect(null);
+          setFeedbackMessage('');
+          return next;
+        });
+      }
+    } catch (error) {
+      console.error('Failed to process drop:', error);
+    }
+  };
+
+  const handleBankDragOver = (event: React.DragEvent) => {
+    if (!canInteract) return;
+    event.preventDefault();
+    event.dataTransfer.dropEffect = 'move';
+    setIsBankHighlighted(true);
+  };
+
+  const handleBankDragLeave = (event: React.DragEvent) => {
+    if (!canInteract) return;
+    if (!event.currentTarget.contains(event.relatedTarget as Node)) {
+      setIsBankHighlighted(false);
+    }
+  };
+
+  const handleDropToBank = (event: React.DragEvent) => {
+    if (!canInteract) return;
+    event.preventDefault();
+
+    const dataString = event.dataTransfer.getData('application/json');
+    if (!dataString) return;
+
+    try {
+      const data = JSON.parse(dataString) as DragState & { type: string };
+      if (data.type !== 'matching-word' || data.source !== 'blank' || !data.blankId) return;
+
+      setPlacements(prev => {
+        const next = { ...prev };
+        const placedWord = next[data.blankId!];
+        if (!placedWord) return prev;
+
+        next[data.blankId!] = null;
+        setAvailableWords(prevWords => sortWords([...prevWords, placedWord]));
+        setIsChecked(false);
+        setIsCorrect(null);
+        setFeedbackMessage('');
+        return next;
+      });
+    } catch (error) {
+      console.error('Failed to process drop:', error);
+    } finally {
+      setIsBankHighlighted(false);
+    }
+  };
+
+  const allBlanksFilled = useMemo(() => tile.content.blanks.every(blank => placements[blank.id]), [tile.content.blanks, placements]);
+
+  const handleCheckAnswers = () => {
+    if (!canInteract) return;
+
+    const nextAttempts = attempts + 1;
+    setAttempts(nextAttempts);
+
+    if (!allBlanksFilled) {
+      setIsChecked(true);
+      setIsCorrect(false);
+      setFeedbackMessage('Uzupełnij wszystkie luki, aby sprawdzić odpowiedzi.');
+      return;
+    }
+
+    const isAllCorrect = tile.content.blanks.every(blank => {
+      const placed = placements[blank.id];
+      if (!placed || !blank.correctWordId) return false;
+      return placed.id === blank.correctWordId;
+    });
+
+    setIsChecked(true);
+    setIsCorrect(isAllCorrect);
+    setFeedbackMessage(isAllCorrect ? tile.content.successFeedback : tile.content.failureFeedback);
+  };
+
+  const handleReset = () => {
+    resetState();
+  };
+
+  const getBlankStyle = (blankId: string): React.CSSProperties => {
+    const placedWord = placements[blankId];
+
+    if (isChecked && isCorrect !== null) {
+      const blankDefinition = tile.content.blanks.find(blank => blank.id === blankId);
+      const isBlankCorrect = blankDefinition && placedWord && blankDefinition.correctWordId === placedWord.id;
+
+      if (isBlankCorrect) {
+        return {
+          backgroundColor: blankCorrectBackground,
+          borderColor: blankCorrectBorder,
+          color: textColor
+        };
+      }
+
+      if (placedWord) {
+        return {
+          backgroundColor: '#fee2e2',
+          borderColor: '#f87171',
+          color: '#b91c1c'
+        };
+      }
+    }
+
+    if (hoveredBlankId === blankId) {
+      return {
+        backgroundColor: blankHoverBackground,
+        borderColor: blankHoverBorder,
+        color: textColor
+      };
+    }
+
+    if (placedWord) {
+      return {
+        backgroundColor: blankFilledBackground,
+        borderColor: blankFilledBorder,
+        color: textColor
+      };
+    }
+
+    return {
+      backgroundColor: blankEmptyBackground,
+      borderColor: blankEmptyBorder,
+      color: mutedLabelColor
+    };
+  };
+
+  const getWordClassNames = (wordId: string): string => {
+    const isDragging = dragState?.wordId === wordId;
+    return `inline-flex items-center gap-2 px-4 py-2 rounded-xl border transition-all duration-200 select-none ${
+      isDragging ? 'opacity-70 scale-95 shadow-sm' : 'hover:shadow-md'
+    }`;
+  };
+
+  const handleTileDoubleClick = (event: React.MouseEvent) => {
+    if (isPreview || isTestingMode) return;
+
+    event.preventDefault();
+    event.stopPropagation();
+    onRequestTextEditing?.();
+  };
+
+  return (
+    <div className="relative w-full h-full" onDoubleClick={handleTileDoubleClick}>
+      <div
+        className={`w-full h-full flex flex-col gap-6 transition-all duration-300 ${
+          isPreview
+            ? 'p-6'
+            : `rounded-3xl ${tile.content.showBorder ? 'border' : ''} shadow-2xl shadow-slate-950/40 p-6 overflow-hidden`
+        }`}
+        style={{
+          backgroundColor: isPreview ? 'transparent' : accentColor,
+          backgroundImage: isPreview ? undefined : `linear-gradient(135deg, ${gradientStart}, ${gradientEnd})`,
+          color: textColor,
+          borderColor: !isPreview && tile.content.showBorder ? frameBorderColor : undefined
+        }}
+      >
+        <TaskInstructionPanel
+          icon={<Sparkles className="w-4 h-4" />}
+          label="Zadanie"
+          className="border"
+          style={{
+            backgroundColor: panelBackground,
+            borderColor: panelBorder,
+            color: textColor
+          }}
+          iconWrapperClassName="w-9 h-9 rounded-xl flex items-center justify-center shadow-sm"
+          iconWrapperStyle={{
+            backgroundColor: iconBackground,
+            color: textColor
+          }}
+          labelStyle={{ color: mutedLabelColor }}
+          bodyClassName="px-5 pb-5"
+        >
+          {instructionContent ?? (
+            <div
+              className="text-base leading-relaxed"
+              style={{
+                fontFamily: tile.content.fontFamily,
+                fontSize: `${tile.content.fontSize}px`
+              }}
+              dangerouslySetInnerHTML={{
+                __html: tile.content.richInstructions || tile.content.instructions
+              }}
+            />
+          )}
+        </TaskInstructionPanel>
+
+        {isTestingMode && (
+          <div className="text-[11px] uppercase tracking-[0.32em]" style={{ color: attemptCaptionColor }}>
+            Tryb testowania
+          </div>
+        )}
+
+        {attempts > 0 && (
+          <div className="text-xs uppercase tracking-[0.32em]" style={{ color: attemptCaptionColor }}>
+            Próba #{attempts}
+          </div>
+        )}
+
+        <div className="grid grid-cols-1 lg:grid-cols-[1.7fr_1fr] gap-6 flex-1 min-h-0">
+          <div className="flex flex-col rounded-2xl border bg-white/10 backdrop-blur-sm" style={{ borderColor: panelBorder }}>
+            <div className="px-6 py-4 border-b flex items-center gap-2" style={{ borderColor: panelBorder, color: subtleCaptionColor }}>
+              <BookOpen className="w-4 h-4" />
+              <span className="text-sm font-semibold tracking-wide uppercase">Treść ćwiczenia</span>
+            </div>
+            <div className="flex-1 px-6 py-5 overflow-auto">
+              <div
+                className="flex flex-wrap items-center gap-x-3 gap-y-4 text-base leading-relaxed"
+                style={{ fontFamily: tile.content.fontFamily, fontSize: `${tile.content.fontSize}px` }}
+              >
+                {segments.map((segment, index) => {
+                  if (segment.type === 'text') {
+                    return (
+                      <span key={`text-${index}`} className="whitespace-pre-wrap text-left" style={{ color: textColor }}>
+                        {segment.value}
+                      </span>
+                    );
+                  }
+
+                  const blankId = segment.value;
+                  const blankDefinition = tile.content.blanks.find(blank => blank.id === blankId);
+                  const placedWord = placements[blankId];
+                  const blankStyle = getBlankStyle(blankId);
+
+                  return (
+                    <div
+                      key={`blank-${blankId}-${index}`}
+                      className={`inline-flex min-w-[140px] items-center justify-between gap-3 rounded-xl border px-4 py-2 transition-all duration-200 ${
+                        canInteract ? 'cursor-pointer' : 'cursor-default'
+                      }`}
+                      style={blankStyle}
+                      onDragOver={handleBlankDragOver(blankId)}
+                      onDragLeave={handleBlankDragLeave(blankId)}
+                      onDrop={handleDropOnBlank(blankId)}
+                    >
+                      <div className="flex flex-col">
+                        <span className="text-[11px] uppercase tracking-[0.24em]" style={{ color: mutedLabelColor }}>
+                          {blankDefinition?.label || 'Luka'}
+                        </span>
+                        <span className="text-sm font-semibold" style={{ color: blankStyle.color }}>
+                          {placedWord ? placedWord.text : 'Przeciągnij słowo'}
+                        </span>
+                      </div>
+                      {placedWord && canInteract && (
+                        <span
+                          draggable
+                          onDragStart={handleDragStart(placedWord, 'blank', blankId)}
+                          onDragEnd={handleDragEnd}
+                          className="text-xs uppercase tracking-[0.28em] text-white/70 px-2 py-1 rounded-md bg-white/10"
+                          style={{ color: blankStyle.color }}
+                        >
+                          Przenieś
+                        </span>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+
+          <div
+            className="flex flex-col rounded-2xl border transition-all duration-200"
+            style={{
+              backgroundColor: isBankHighlighted ? bankHighlightBackground : bankBackground,
+              borderColor: isBankHighlighted ? bankHighlightBorder : bankBorder,
+              boxShadow: isBankHighlighted ? '0 22px 44px rgba(15, 23, 42, 0.22)' : undefined
+            }}
+            onDragOver={handleBankDragOver}
+            onDragLeave={handleBankDragLeave}
+            onDrop={handleDropToBank}
+          >
+            <div className="px-5 py-4 border-b flex items-center justify-between" style={{ borderColor: bankBorder, color: subtleCaptionColor }}>
+              <div className="flex items-center gap-2 text-sm font-semibold">
+                <Hand className="w-4 h-4" />
+                <span>Pula słów</span>
+              </div>
+              <span className="text-xs" style={{ color: mutedLabelColor }}>
+                {availableWords.length} słów
+              </span>
+            </div>
+
+            <div className="flex-1 px-5 py-4 overflow-auto">
+              {availableWords.length === 0 ? (
+                <div className="flex flex-col items-center justify-center gap-2 text-center text-sm py-10" style={{ color: subtleCaptionColor }}>
+                  <PenLine className="w-5 h-5" />
+                  <span>Wszystkie słowa są już wykorzystane</span>
+                </div>
+              ) : (
+                <div className="flex flex-wrap gap-2">
+                  {availableWords.map(word => (
+                    <div
+                      key={word.id}
+                      draggable={canInteract}
+                      onDragStart={handleDragStart(word, 'bank')}
+                      onDragEnd={handleDragEnd}
+                      className={getWordClassNames(word.id)}
+                      style={{
+                        backgroundColor: wordBackground,
+                        borderColor: wordBorder,
+                        color: textColor
+                      }}
+                      onMouseEnter={(e) => {
+                        if (!canInteract) return;
+                        (e.currentTarget as HTMLElement).style.backgroundColor = wordHoverBackground;
+                        (e.currentTarget as HTMLElement).style.borderColor = wordHoverBorder;
+                      }}
+                      onMouseLeave={(e) => {
+                        (e.currentTarget as HTMLElement).style.backgroundColor = wordBackground;
+                        (e.currentTarget as HTMLElement).style.borderColor = wordBorder;
+                      }}
+                    >
+                      <span className="text-sm font-semibold" style={{ color: textColor }}>
+                        {word.text}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+
+        <div className="flex flex-col lg:flex-row items-start lg:items-center gap-3 justify-between">
+          <div className="flex items-center gap-3">
+            <button
+              type="button"
+              onClick={handleCheckAnswers}
+              disabled={!canInteract}
+              className={`inline-flex items-center gap-2 rounded-xl px-5 py-2 text-sm font-semibold transition-colors ${
+                canInteract
+                  ? 'bg-white/90 text-slate-900 hover:bg-white'
+                  : 'bg-white/60 text-slate-400 cursor-not-allowed'
+              }`}
+            >
+              <CheckCircle className="w-4 h-4" />
+              Sprawdź odpowiedzi
+            </button>
+            <button
+              type="button"
+              onClick={handleReset}
+              disabled={!canInteract}
+              className={`inline-flex items-center gap-2 rounded-xl px-4 py-2 text-sm font-medium transition-colors ${
+                canInteract
+                  ? 'bg-transparent border border-white/40 text-white hover:bg-white/10'
+                  : 'bg-transparent border border-white/20 text-white/50 cursor-not-allowed'
+              }`}
+            >
+              <RefreshCw className="w-4 h-4" />
+              Resetuj
+            </button>
+          </div>
+
+          {isChecked && (
+            <div
+              className={`inline-flex items-center gap-2 rounded-xl px-4 py-2 text-sm font-semibold transition-all ${
+                isCorrect ? 'bg-emerald-500/90 text-white' : 'bg-rose-500/90 text-white'
+              }`}
+            >
+              {isCorrect ? <CheckCircle className="w-4 h-4" /> : <XCircle className="w-4 h-4" />}
+              <span>{isCorrect ? 'Świetnie!' : 'Spróbuj ponownie'}</span>
+            </div>
+          )}
+        </div>
+
+        {feedbackMessage && (
+          <div className={`rounded-2xl border px-5 py-4 text-sm leading-relaxed ${isCorrect ? 'bg-emerald-500/10 border-emerald-400/60 text-emerald-900' : 'bg-rose-500/10 border-rose-400/60 text-rose-900'}`}>
+            {feedbackMessage}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+

--- a/src/components/admin/side editor/MatchingEditor.tsx
+++ b/src/components/admin/side editor/MatchingEditor.tsx
@@ -1,0 +1,328 @@
+import React, { useMemo, useRef } from 'react';
+import { Plus, Trash2, Type, Info, Hash } from 'lucide-react';
+import { MatchingTile, MatchingBlank, MatchingWord } from '../../../types/lessonEditor.ts';
+
+interface MatchingEditorProps {
+  tile: MatchingTile;
+  onUpdateTile: (tileId: string, updates: Partial<MatchingTile>) => void;
+}
+
+const PLACEHOLDER_REGEX = /\[\[([^\[\]]+)\]\]/g;
+
+const extractPlaceholderIds = (text: string): string[] => {
+  const ids: string[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = PLACEHOLDER_REGEX.exec(text)) !== null) {
+    if (match[1]) {
+      ids.push(match[1]);
+    }
+  }
+  return ids;
+};
+
+export const MatchingEditor: React.FC<MatchingEditorProps> = ({ tile, onUpdateTile }) => {
+  const textAreaRef = useRef<HTMLTextAreaElement>(null);
+
+  const updateContent = (contentUpdates: Partial<MatchingTile['content']>) => {
+    onUpdateTile(tile.id, {
+      content: {
+        ...tile.content,
+        ...contentUpdates
+      },
+      updated_at: new Date().toISOString()
+    });
+  };
+
+  const handleStoryTextChange = (value: string) => {
+    const placeholderIds = extractPlaceholderIds(value);
+    const existingBlanks = new Map(tile.content.blanks.map(blank => [blank.id, blank]));
+
+    const normalizedBlanks: MatchingBlank[] = placeholderIds.map((id, index) => {
+      const existing = existingBlanks.get(id);
+      return {
+        id,
+        label: existing?.label ?? `Luka ${index + 1}`,
+        correctWordId: existing?.correctWordId ?? null
+      };
+    });
+
+    updateContent({
+      storyText: value,
+      blanks: normalizedBlanks
+    });
+  };
+
+  const handleInsertBlank = () => {
+    const textarea = textAreaRef.current;
+    const currentText = tile.content.storyText ?? '';
+    const newBlankId = `blank-${Date.now().toString(36)}`;
+    const placeholder = `[[${newBlankId}]]`;
+
+    if (!textarea) {
+      handleStoryTextChange(`${currentText}${currentText.endsWith(' ') || !currentText ? '' : ' '}${placeholder}`);
+      return;
+    }
+
+    const { selectionStart, selectionEnd } = textarea;
+    const before = currentText.slice(0, selectionStart);
+    const after = currentText.slice(selectionEnd);
+    const updatedText = `${before}${placeholder}${after}`;
+
+    handleStoryTextChange(updatedText);
+
+    requestAnimationFrame(() => {
+      const cursor = selectionStart + placeholder.length;
+      textarea.focus();
+      textarea.setSelectionRange(cursor, cursor);
+    });
+  };
+
+  const handleBlankLabelChange = (blankId: string, value: string) => {
+    const updatedBlanks = tile.content.blanks.map(blank =>
+      blank.id === blankId ? { ...blank, label: value } : blank
+    );
+    updateContent({ blanks: updatedBlanks });
+  };
+
+  const handleBlankCorrectWordChange = (blankId: string, wordId: string) => {
+    const normalizedId = wordId === '' ? null : wordId;
+    const updatedBlanks = tile.content.blanks.map(blank =>
+      blank.id === blankId ? { ...blank, correctWordId: normalizedId } : blank
+    );
+    updateContent({ blanks: updatedBlanks });
+  };
+
+  const handleWordTextChange = (wordId: string, value: string) => {
+    const updatedWords = tile.content.wordBank.map(word =>
+      word.id === wordId ? { ...word, text: value } : word
+    );
+    updateContent({ wordBank: updatedWords });
+  };
+
+  const handleAddWord = () => {
+    const newWord: MatchingWord = {
+      id: `word-${Date.now().toString(36)}`,
+      text: `Nowe słowo ${tile.content.wordBank.length + 1}`
+    };
+    updateContent({ wordBank: [...tile.content.wordBank, newWord] });
+  };
+
+  const handleRemoveWord = (wordId: string) => {
+    const updatedWords = tile.content.wordBank.filter(word => word.id !== wordId);
+    const updatedBlanks = tile.content.blanks.map(blank =>
+      blank.correctWordId === wordId ? { ...blank, correctWordId: null } : blank
+    );
+
+    updateContent({
+      wordBank: updatedWords,
+      blanks: updatedBlanks
+    });
+  };
+
+  const placeholders = useMemo(() => extractPlaceholderIds(tile.content.storyText || ''), [tile.content.storyText]);
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-4">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-2">
+            Kolor wiodący kafelka
+          </label>
+          <input
+            type="color"
+            value={tile.content.backgroundColor}
+            onChange={(e) => updateContent({ backgroundColor: e.target.value })}
+            className="w-full h-12 border border-gray-300 rounded-lg cursor-pointer"
+          />
+        </div>
+
+        <label className="flex items-center space-x-3 p-4 bg-gray-50 rounded-lg">
+          <input
+            type="checkbox"
+            checked={tile.content.showBorder}
+            onChange={(e) => updateContent({ showBorder: e.target.checked })}
+            className="w-5 h-5 text-blue-600"
+          />
+          <div>
+            <span className="text-sm font-medium text-gray-900">Pokaż dekoracyjną ramkę</span>
+            <p className="text-xs text-gray-600 mt-1">
+              Obramowanie dodaje subtelny akcent i pomaga oddzielić ćwiczenie od tła
+            </p>
+          </div>
+        </label>
+      </div>
+
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <label className="block text-sm font-medium text-gray-700">
+            Tekst zadania z lukami
+          </label>
+          <button
+            type="button"
+            onClick={handleInsertBlank}
+            className="inline-flex items-center gap-2 px-3 py-1.5 text-xs font-medium text-blue-600 border border-blue-200 rounded-lg hover:bg-blue-50 transition-colors"
+          >
+            <Plus className="w-3.5 h-3.5" />
+            Wstaw lukę
+          </button>
+        </div>
+
+        <textarea
+          ref={textAreaRef}
+          value={tile.content.storyText}
+          onChange={(e) => handleStoryTextChange(e.target.value)}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm leading-relaxed resize-vertical min-h-[140px]"
+          placeholder="np. Fotony są nośnikami [[blank-1]] i przemieszczają się w [[blank-2]]."
+        />
+
+        <div className="flex items-start gap-2 text-xs text-gray-600 bg-blue-50 border border-blue-100 rounded-lg p-3">
+          <Info className="w-4 h-4 text-blue-500 mt-0.5" />
+          <div className="space-y-1">
+            <p>
+              Używaj nawiasów podwójnych, aby oznaczyć luki, np. <code className="font-mono text-blue-600">[[blank-1]]</code>.
+              Każdy identyfikator musi być unikalny.
+            </p>
+            <p>
+              Przycisk <strong>Wstaw lukę</strong> automatycznie doda nowy identyfikator w bieżącej pozycji kursora.
+            </p>
+          </div>
+        </div>
+
+        {placeholders.length === 0 && (
+          <div className="flex items-center gap-2 text-xs text-amber-600 bg-amber-50 border border-amber-100 rounded-lg p-3">
+            <Type className="w-4 h-4" />
+            <span>Dodaj przynajmniej jedną lukę, aby zadanie było interaktywne.</span>
+          </div>
+        )}
+      </div>
+
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <h3 className="text-sm font-medium text-gray-800">Luki ({tile.content.blanks.length})</h3>
+        </div>
+
+        {tile.content.blanks.length === 0 ? (
+          <div className="text-xs text-gray-500 bg-gray-50 border border-dashed border-gray-200 rounded-lg p-4 text-center">
+            Dodaj luki w tekście, aby zarządzać ich poprawnymi odpowiedziami.
+          </div>
+        ) : (
+          <div className="space-y-3 max-h-56 overflow-y-auto pr-1">
+            {tile.content.blanks.map((blank, index) => (
+              <div key={blank.id} className="p-3 bg-white border border-gray-200 rounded-lg space-y-2">
+                <div className="flex items-center justify-between text-xs text-gray-500">
+                  <span className="inline-flex items-center gap-1">
+                    <Hash className="w-3.5 h-3.5" />
+                    {blank.id}
+                  </span>
+                  <span className="text-gray-400">Luka {index + 1}</span>
+                </div>
+
+                <div className="space-y-2">
+                  <div>
+                    <label className="block text-xs font-medium text-gray-700 mb-1">
+                      Etykieta pomocnicza
+                    </label>
+                    <input
+                      type="text"
+                      value={blank.label}
+                      onChange={(e) => handleBlankLabelChange(blank.id, e.target.value)}
+                      className="w-full px-2 py-1.5 border border-gray-300 rounded focus:ring-1 focus:ring-blue-500 focus:border-transparent text-sm"
+                      placeholder={`Opis luki ${index + 1}`}
+                    />
+                  </div>
+
+                  <div>
+                    <label className="block text-xs font-medium text-gray-700 mb-1">
+                      Poprawna odpowiedź
+                    </label>
+                    <select
+                      value={blank.correctWordId ?? ''}
+                      onChange={(e) => handleBlankCorrectWordChange(blank.id, e.target.value)}
+                      className="w-full px-2 py-1.5 border border-gray-300 rounded focus:ring-1 focus:ring-blue-500 focus:border-transparent text-sm bg-white"
+                    >
+                      <option value="">Wybierz z puli słów</option>
+                      {tile.content.wordBank.map(word => (
+                        <option key={word.id} value={word.id}>
+                          {word.text}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <h3 className="text-sm font-medium text-gray-800">Pula słów ({tile.content.wordBank.length})</h3>
+          <button
+            type="button"
+            onClick={handleAddWord}
+            className="inline-flex items-center gap-2 px-3 py-1.5 text-xs font-medium bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+          >
+            <Plus className="w-3.5 h-3.5" />
+            Dodaj słowo
+          </button>
+        </div>
+
+        <div className="space-y-2 max-h-56 overflow-y-auto pr-1">
+          {tile.content.wordBank.map((word) => (
+            <div key={word.id} className="flex items-center gap-2 p-3 bg-white border border-gray-200 rounded-lg">
+              <input
+                type="text"
+                value={word.text}
+                onChange={(e) => handleWordTextChange(word.id, e.target.value)}
+                className="flex-1 px-2 py-1.5 border border-gray-300 rounded focus:ring-1 focus:ring-blue-500 focus:border-transparent text-sm"
+                placeholder="Treść słowa"
+              />
+              <button
+                type="button"
+                onClick={() => handleRemoveWord(word.id)}
+                className="p-2 text-red-500 hover:text-red-600 hover:bg-red-50 rounded-lg transition-colors"
+                title="Usuń słowo"
+              >
+                <Trash2 className="w-4 h-4" />
+              </button>
+            </div>
+          ))}
+
+          {tile.content.wordBank.length === 0 && (
+            <div className="text-xs text-gray-500 bg-gray-50 border border-dashed border-gray-200 rounded-lg p-4 text-center">
+              Dodaj słowa, aby uczniowie mogli przeciągać je do odpowiednich luk.
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Komunikat po poprawnym rozwiązaniu
+          </label>
+          <textarea
+            value={tile.content.successFeedback}
+            onChange={(e) => updateContent({ successFeedback: e.target.value })}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-transparent text-sm resize-vertical"
+            rows={3}
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Komunikat po błędnej próbie
+          </label>
+          <textarea
+            value={tile.content.failureFeedback}
+            onChange={(e) => updateContent({ failureFeedback: e.target.value })}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent text-sm resize-vertical"
+            rows={3}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+

--- a/src/components/admin/side editor/TilePalette.tsx
+++ b/src/components/admin/side editor/TilePalette.tsx
@@ -94,17 +94,17 @@ export const TilePalette: React.FC<TilePaletteProps> = ({
       </div>
 
       {/* Tile Types */}
-      <div className="flex-1 p-4 space-y-3 overflow-y-auto overscroll-contain">
+      <div className="flex-1 px-4 py-3 space-y-2 overflow-y-auto overscroll-contain">
         {TILE_TYPES.map((tileType) => {
           const IconComponent = getIcon(tileType.icon);
-          
+
           return (
             <div
               key={tileType.type}
               draggable
               onDragStart={(e) => handleDragStart(e, tileType.type)}
               onClick={() => handleClick(tileType.type)}
-              className="group p-4 bg-white border-2 border-gray-200 rounded-lg cursor-pointer hover:border-blue-300 hover:shadow-md transition-all duration-200 active:scale-95"
+              className="group p-3 bg-white border-2 border-gray-200 rounded-lg cursor-pointer hover:border-blue-300 hover:shadow-md transition-all duration-200 active:scale-95"
             >
               <div className="flex items-center space-x-3">
                 <div className="w-10 h-10 bg-blue-100 rounded-lg flex items-center justify-center group-hover:bg-blue-200 transition-colors">

--- a/src/components/admin/side editor/TilePalette.tsx
+++ b/src/components/admin/side editor/TilePalette.tsx
@@ -37,6 +37,11 @@ const TILE_TYPES: TilePaletteItem[] = [
     type: 'sequencing',
     title: 'Ćwiczenie sekwencyjne',
     icon: 'ArrowUpDown'
+  },
+  {
+    type: 'matching',
+    title: 'Uzupełnianie luk',
+    icon: 'Puzzle'
   }
 ];
 

--- a/src/components/admin/side editor/TileSideEditor.tsx
+++ b/src/components/admin/side editor/TileSideEditor.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { Plus, Trash2, Type, X } from 'lucide-react';
-import { TextTile, ImageTile, LessonTile, ProgrammingTile, SequencingTile, QuizTile } from '../../../types/lessonEditor.ts';
+import { TextTile, ImageTile, LessonTile, ProgrammingTile, SequencingTile, QuizTile, MatchingTile } from '../../../types/lessonEditor.ts';
 import { ImageUploadComponent } from './ImageUploadComponent.tsx';
 import { ImagePositionControl } from './ImagePositionControl.tsx';
 import { SequencingEditor } from './SequencingEditor.tsx';
+import { MatchingEditor } from './MatchingEditor.tsx';
 
 interface TileSideEditorProps {
   tile: LessonTile | undefined;
@@ -266,6 +267,24 @@ export const TileSideEditor: React.FC<TileSideEditorProps> = ({
             onUpdateTile={onUpdateTile}
             isTesting={isTesting}
             onToggleTesting={onToggleTesting}
+          />
+        );
+      }
+
+      case 'matching': {
+        const matchingTile = tile as MatchingTile;
+        return (
+          <MatchingEditor
+            tile={matchingTile}
+            onUpdateTile={(tileId, matchingUpdates) => {
+              onUpdateTile(tileId, {
+                content: {
+                  ...matchingTile.content,
+                  ...matchingUpdates.content
+                },
+                updated_at: new Date().toISOString()
+              });
+            }}
           />
         );
       }

--- a/src/components/admin/top editor/TopToolbar.tsx
+++ b/src/components/admin/top editor/TopToolbar.tsx
@@ -5,7 +5,7 @@ import { FontSizeSelector } from './FontSizeSelector.tsx';
 import { TextColorPicker } from './TextColorPicker.tsx';
 import { FontSelector } from './FontSelector.tsx';
 import { AlignmentControls } from './AlignmentControls.tsx';
-import { LessonTile, ProgrammingTile, TextTile, SequencingTile } from '../../../types/lessonEditor.ts';
+import { LessonTile, ProgrammingTile, TextTile, SequencingTile, MatchingTile } from '../../../types/lessonEditor.ts';
 
 
 interface TopToolbarProps {
@@ -16,7 +16,7 @@ interface TopToolbarProps {
   isTextEditing: boolean;
   onFinishTextEditing?: () => void;
   editor?: Editor | null;
-  selectedTile?: TextTile | ProgrammingTile | SequencingTile | null;
+  selectedTile?: TextTile | ProgrammingTile | SequencingTile | MatchingTile | null;
   onUpdateTile?: (tileId: string, updates: Partial<LessonTile>) => void;
   className?: string;
 }
@@ -65,7 +65,7 @@ export const TopToolbar: React.FC<TopToolbarProps> = ({
   }, [editor]);
 
   useEffect(() => {
-    if (selectedTile?.type === 'text' || selectedTile?.type === 'sequencing') {
+    if (selectedTile?.type === 'text' || selectedTile?.type === 'sequencing' || selectedTile?.type === 'matching') {
       setVerticalAlign(selectedTile.content.verticalAlign || 'top');
     }
   }, [selectedTile]);

--- a/src/hooks/useTileInteractions.ts
+++ b/src/hooks/useTileInteractions.ts
@@ -33,6 +33,7 @@ export const useTileInteractions = ({
       tile.type === 'text' ||
       tile.type === 'programming' ||
       tile.type === 'sequencing' ||
+      tile.type === 'matching' ||
       tile.type === 'quiz'
     ) {
       dispatch({ type: 'startTextEditing', tileId: tile.id });

--- a/src/services/lessonContentService.ts
+++ b/src/services/lessonContentService.ts
@@ -1,5 +1,5 @@
 import { LessonContent, LessonTile, TextTile } from '../types/lessonEditor';
-import { ProgrammingTile, SequencingTile } from '../types/lessonEditor';
+import { ProgrammingTile, SequencingTile, MatchingTile } from '../types/lessonEditor';
 import { GridUtils } from '../utils/gridUtils';
 import { logger } from '../utils/logger';
 
@@ -397,6 +397,75 @@ export class LessonContentService {
         ],
         correctFeedback: 'Świetnie! Prawidłowa kolejność.',
         incorrectFeedback: 'Spróbuj ponownie. Sprawdź kolejność elementów.'
+      },
+      created_at: now,
+      updated_at: now,
+      z_index: 1
+    };
+  }
+
+  /**
+   * Create a new matching tile
+   */
+  static createMatchingTile(position: { x: number; y: number }, page = 1): MatchingTile {
+    const id = `tile-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+    const now = new Date().toISOString();
+
+    const gridPos = GridUtils.pixelToGrid(position, {
+      width: GridUtils.GRID_COLUMNS,
+      height: 6,
+      gridSize: GridUtils.GRID_CELL_SIZE,
+      snapToGrid: true
+    });
+
+    gridPos.colSpan = 4;
+    gridPos.rowSpan = 5;
+
+    const pixelPos = GridUtils.gridToPixel(gridPos, {
+      width: GridUtils.GRID_COLUMNS,
+      height: 6,
+      gridSize: GridUtils.GRID_CELL_SIZE,
+      snapToGrid: true
+    });
+
+    const pixelSize = GridUtils.gridSizeToPixel(gridPos, {
+      width: GridUtils.GRID_COLUMNS,
+      height: 6,
+      gridSize: GridUtils.GRID_CELL_SIZE,
+      snapToGrid: true
+    });
+
+    const wordBank = [
+      { id: 'word-1', text: 'chloroplastach' },
+      { id: 'word-2', text: 'światła słonecznego' },
+      { id: 'word-3', text: 'dwutlenku węgla' }
+    ];
+
+    const blanks = [
+      { id: 'blank-1', label: 'Miejsce procesu', correctWordId: 'word-1' },
+      { id: 'blank-2', label: 'Energia', correctWordId: 'word-2' }
+    ];
+
+    return {
+      id,
+      type: 'matching',
+      position: pixelPos,
+      size: pixelSize,
+      gridPosition: gridPos,
+      page,
+      content: {
+        instructions: 'Przeciągnij poprawne pojęcia do odpowiednich luk, aby uzupełnić opis fotosyntezy.',
+        richInstructions: '<p style="margin: 0;">Przeciągnij poprawne pojęcia do odpowiednich luk, aby uzupełnić opis fotosyntezy.</p>',
+        fontFamily: 'Inter, system-ui, sans-serif',
+        fontSize: 16,
+        verticalAlign: 'top',
+        backgroundColor: '#4f46e5',
+        showBorder: true,
+        storyText: 'Fotosynteza zachodzi w [[blank-1]] i wymaga [[blank-2]] oraz wody.',
+        blanks,
+        wordBank,
+        successFeedback: 'Doskonale! Wszystkie pojęcia znajdują się na właściwych miejscach.',
+        failureFeedback: 'Niektóre luki są jeszcze błędne. Sprawdź opis i spróbuj ponownie.'
       },
       created_at: now,
       updated_at: now,

--- a/src/types/lessonEditor.ts
+++ b/src/types/lessonEditor.ts
@@ -17,7 +17,7 @@ export interface GridPosition {
 
 export interface LessonTile {
   id: string;
-  type: 'text' | 'image' | 'visualization' | 'quiz' | 'programming' | 'sequencing';
+  type: 'text' | 'image' | 'visualization' | 'quiz' | 'programming' | 'sequencing' | 'matching';
   position: Position;
   size: Size;
   gridPosition: GridPosition;
@@ -125,6 +125,35 @@ export interface SequencingTile extends LessonTile {
     }>;
     correctFeedback: string;
     incorrectFeedback: string;
+  };
+}
+
+export interface MatchingBlank {
+  id: string;
+  label: string;
+  correctWordId: string | null;
+}
+
+export interface MatchingWord {
+  id: string;
+  text: string;
+}
+
+export interface MatchingTile extends LessonTile {
+  type: 'matching';
+  content: {
+    instructions: string;
+    richInstructions?: string;
+    fontFamily: string;
+    fontSize: number;
+    verticalAlign: 'top' | 'center' | 'bottom';
+    backgroundColor: string;
+    showBorder: boolean;
+    storyText: string;
+    blanks: MatchingBlank[];
+    wordBank: MatchingWord[];
+    successFeedback: string;
+    failureFeedback: string;
   };
 }
 


### PR DESCRIPTION
## Summary
- add a matching tile definition, service factory, and palette entry for fill-in-the-blank tasks
- implement MatchingInteractive with drag-and-drop word bank and TaskInstructionPanel integration
- provide MatchingEditor side panel controls for text, blanks, word bank, and feedback settings

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dad1b3a10483218d8e9d66ff00ad8d