### PR TITLE
Add match pairs tile for fill-in-the-blank tasks

### DIFF
--- a/src/Pages/LessonEditor.tsx
+++ b/src/Pages/LessonEditor.tsx
@@ -253,6 +253,9 @@ export const LessonEditor: React.FC<LessonEditorProps> = ({ lesson, course, onBa
       case 'sequencing':
         newTile = LessonContentService.createSequencingTile(position, currentPage);
         break;
+      case 'matchPairs':
+        newTile = LessonContentService.createMatchPairsTile(position, currentPage);
+        break;
       default:
         logger.warn(`Tile type ${tileType} not implemented yet`);
         warning('Funkcja niedostępna', `Typ kafelka "${tileType}" nie jest jeszcze dostępny`);
@@ -313,7 +316,7 @@ export const LessonEditor: React.FC<LessonEditorProps> = ({ lesson, course, onBa
         };
 
         // Special handling for text-based tiles to ensure content properties are merged
-        if ((tile.type === 'text' || tile.type === 'programming' || tile.type === 'sequencing') && updates.content) {
+        if ((tile.type === 'text' || tile.type === 'programming' || tile.type === 'sequencing' || tile.type === 'matchPairs') && updates.content) {
           updatedTile.content = {
             ...tile.content,
             ...updates.content

--- a/src/components/admin/MatchPairsInteractive.tsx
+++ b/src/components/admin/MatchPairsInteractive.tsx
@@ -1,0 +1,523 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { Puzzle, CheckCircle2, XCircle, RotateCcw } from 'lucide-react';
+import { MatchPairsTile } from '../../types/lessonEditor';
+import { TaskInstructionPanel } from './common/TaskInstructionPanel';
+import { MATCH_PAIRS_PLACEHOLDER_REGEX } from '../../utils/matchPairs';
+
+interface MatchPairsInteractiveProps {
+  tile: MatchPairsTile;
+  isPreview?: boolean;
+  isTestingMode?: boolean;
+  onRequestTextEditing?: () => void;
+  instructionContent?: React.ReactNode;
+}
+
+type EvaluationState = 'idle' | 'correct' | 'incorrect';
+type BlankStatus = 'idle' | 'correct' | 'incorrect';
+
+type Segment =
+  | { type: 'text'; text: string }
+  | { type: 'blank'; blank: MatchPairsTile['content']['blanks'][number]; index: number };
+
+const hexToRgb = (hex: string): { r: number; g: number; b: number } | null => {
+  if (!hex) return null;
+
+  let normalized = hex.replace('#', '').trim();
+  if (normalized.length === 3) {
+    normalized = normalized
+      .split('')
+      .map(char => `${char}${char}`)
+      .join('');
+  }
+
+  if (normalized.length !== 6) return null;
+
+  const intValue = Number.parseInt(normalized, 16);
+  if (Number.isNaN(intValue)) return null;
+
+  return {
+    r: (intValue >> 16) & 255,
+    g: (intValue >> 8) & 255,
+    b: intValue & 255
+  };
+};
+
+const channelToLinear = (value: number): number => {
+  const scaled = value / 255;
+  return scaled <= 0.03928 ? scaled / 12.92 : Math.pow((scaled + 0.055) / 1.055, 2.4);
+};
+
+const getReadableTextColor = (hex: string): string => {
+  const rgb = hexToRgb(hex);
+  if (!rgb) return '#0f172a';
+
+  const luminance =
+    0.2126 * channelToLinear(rgb.r) +
+    0.7152 * channelToLinear(rgb.g) +
+    0.0722 * channelToLinear(rgb.b);
+
+  return luminance > 0.6 ? '#0f172a' : '#f8fafc';
+};
+
+const lightenColor = (hex: string, amount: number): string => {
+  const rgb = hexToRgb(hex);
+  if (!rgb) return hex;
+
+  const lightenChannel = (channel: number) => Math.round(channel + (255 - channel) * amount);
+  return `rgb(${lightenChannel(rgb.r)}, ${lightenChannel(rgb.g)}, ${lightenChannel(rgb.b)})`;
+};
+
+const darkenColor = (hex: string, amount: number): string => {
+  const rgb = hexToRgb(hex);
+  if (!rgb) return hex;
+
+  const darkenChannel = (channel: number) => Math.round(channel * (1 - amount));
+  return `rgb(${darkenChannel(rgb.r)}, ${darkenChannel(rgb.g)}, ${darkenChannel(rgb.b)})`;
+};
+
+const surfaceColor = (accent: string, textColor: string, lightenAmount: number, darkenAmount: number): string =>
+  textColor === '#0f172a' ? lightenColor(accent, lightenAmount) : darkenColor(accent, darkenAmount);
+
+const buildSegments = (tile: MatchPairsTile): Segment[] => {
+  const segments: Segment[] = [];
+  const text = tile.content.prompt || '';
+  const blanks = tile.content.blanks;
+
+  MATCH_PAIRS_PLACEHOLDER_REGEX.lastIndex = 0;
+  let lastIndex = 0;
+  let blankIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = MATCH_PAIRS_PLACEHOLDER_REGEX.exec(text)) !== null) {
+    if (match.index > lastIndex) {
+      segments.push({ type: 'text', text: text.slice(lastIndex, match.index) });
+    }
+
+    const blank = blanks[blankIndex];
+    if (blank) {
+      segments.push({ type: 'blank', blank, index: blankIndex });
+    }
+
+    lastIndex = match.index + match[0].length;
+    blankIndex += 1;
+  }
+
+  if (lastIndex < text.length) {
+    segments.push({ type: 'text', text: text.slice(lastIndex) });
+  }
+
+  for (; blankIndex < blanks.length; blankIndex += 1) {
+    segments.push({ type: 'blank', blank: blanks[blankIndex], index: blankIndex });
+  }
+
+  return segments;
+};
+
+export const MatchPairsInteractive: React.FC<MatchPairsInteractiveProps> = ({
+  tile,
+  isPreview = false,
+  isTestingMode = false,
+  onRequestTextEditing,
+  instructionContent
+}) => {
+  const [assignments, setAssignments] = useState<Record<string, string | null>>(() => {
+    const initial: Record<string, string | null> = {};
+    tile.content.blanks.forEach((blank) => {
+      initial[blank.id] = null;
+    });
+    return initial;
+  });
+  const [blankStatuses, setBlankStatuses] = useState<Record<string, BlankStatus>>(() => {
+    const initial: Record<string, BlankStatus> = {};
+    tile.content.blanks.forEach((blank) => {
+      initial[blank.id] = 'idle';
+    });
+    return initial;
+  });
+  const [draggedOptionId, setDraggedOptionId] = useState<string | null>(null);
+  const [hoveredBlankId, setHoveredBlankId] = useState<string | null>(null);
+  const [evaluationState, setEvaluationState] = useState<EvaluationState>('idle');
+
+  const isInteractionEnabled = !isPreview && isTestingMode;
+
+  useEffect(() => {
+    const initialAssignments: Record<string, string | null> = {};
+    const initialStatuses: Record<string, BlankStatus> = {};
+
+    tile.content.blanks.forEach((blank) => {
+      initialAssignments[blank.id] = null;
+      initialStatuses[blank.id] = 'idle';
+    });
+
+    setAssignments(initialAssignments);
+    setBlankStatuses(initialStatuses);
+    setEvaluationState('idle');
+  }, [tile.content.blanks, tile.content.options, tile.id]);
+
+  const accentColor = tile.content.backgroundColor || '#4c1d95';
+  const textColor = useMemo(() => getReadableTextColor(accentColor), [accentColor]);
+  const panelBackground = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.66, 0.42),
+    [accentColor, textColor]
+  );
+  const panelBorder = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.5, 0.56),
+    [accentColor, textColor]
+  );
+  const iconBackground = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.58, 0.48),
+    [accentColor, textColor]
+  );
+  const mutedLabelColor = textColor === '#0f172a' ? '#475569' : '#dbeafe';
+  const blankBackground = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.74, 0.38),
+    [accentColor, textColor]
+  );
+  const blankBorder = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.52, 0.54),
+    [accentColor, textColor]
+  );
+  const blankHoverBackground = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.82, 0.32),
+    [accentColor, textColor]
+  );
+  const blankHoverBorder = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.6, 0.46),
+    [accentColor, textColor]
+  );
+  const bankBackground = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.68, 0.4),
+    [accentColor, textColor]
+  );
+  const bankBorder = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.54, 0.52),
+    [accentColor, textColor]
+  );
+  const chipBackground = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.56, 0.48),
+    [accentColor, textColor]
+  );
+  const chipBorder = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.48, 0.56),
+    [accentColor, textColor]
+  );
+
+  const segments = useMemo(() => buildSegments(tile), [tile]);
+
+  const assignedOptionIds = useMemo(() => {
+    const used = new Set<string>();
+    Object.values(assignments).forEach((value) => {
+      if (value) {
+        used.add(value);
+      }
+    });
+    return used;
+  }, [assignments]);
+
+  const availableOptions = useMemo(
+    () => tile.content.options.filter((option) => !assignedOptionIds.has(option.id)),
+    [tile.content.options, assignedOptionIds]
+  );
+
+  const allBlanksFilled = tile.content.blanks.length > 0 && tile.content.blanks.every((blank) => assignments[blank.id]);
+
+  const handleTileDoubleClick = useCallback(
+    (event: React.MouseEvent) => {
+      if (isPreview || isTestingMode) return;
+
+      event.preventDefault();
+      event.stopPropagation();
+      onRequestTextEditing?.();
+    },
+    [isPreview, isTestingMode, onRequestTextEditing]
+  );
+
+  const assignOptionToBlank = (blankId: string, optionId: string | null) => {
+    setAssignments((prev) => {
+      const updated: Record<string, string | null> = { ...prev };
+
+      if (optionId) {
+        Object.keys(updated).forEach((key) => {
+          if (updated[key] === optionId) {
+            updated[key] = null;
+          }
+        });
+      }
+
+      updated[blankId] = optionId;
+      return updated;
+    });
+
+    setBlankStatuses((prev) => ({
+      ...prev,
+      [blankId]: 'idle'
+    }));
+    setEvaluationState('idle');
+  };
+
+  const handleOptionDragStart = (event: React.DragEvent, optionId: string) => {
+    if (!isInteractionEnabled) return;
+    setDraggedOptionId(optionId);
+    event.dataTransfer.setData('text/plain', optionId);
+    event.dataTransfer.effectAllowed = 'move';
+  };
+
+  const handleOptionDragEnd = () => {
+    setDraggedOptionId(null);
+  };
+
+  const handleBlankDragOver = (event: React.DragEvent) => {
+    if (!isInteractionEnabled) return;
+    event.preventDefault();
+    event.dataTransfer.dropEffect = 'move';
+  };
+
+  const handleBlankDrop = (event: React.DragEvent, blankId: string) => {
+    if (!isInteractionEnabled) return;
+    event.preventDefault();
+    const optionId = draggedOptionId || event.dataTransfer.getData('text/plain');
+    if (!optionId) return;
+
+    assignOptionToBlank(blankId, optionId);
+    setHoveredBlankId(null);
+    setDraggedOptionId(null);
+  };
+
+  const handleBlankDragEnter = (blankId: string) => {
+    if (!isInteractionEnabled) return;
+    setHoveredBlankId(blankId);
+  };
+
+  const handleBlankDragLeave = (blankId: string) => {
+    if (!isInteractionEnabled) return;
+    if (hoveredBlankId === blankId) {
+      setHoveredBlankId(null);
+    }
+  };
+
+  const handleClearBlank = (blankId: string) => {
+    if (!isInteractionEnabled) return;
+    assignOptionToBlank(blankId, null);
+  };
+
+  const handleReset = () => {
+    if (!isInteractionEnabled) return;
+    const resetAssignments: Record<string, string | null> = {};
+    const resetStatuses: Record<string, BlankStatus> = {};
+
+    tile.content.blanks.forEach((blank) => {
+      resetAssignments[blank.id] = null;
+      resetStatuses[blank.id] = 'idle';
+    });
+
+    setAssignments(resetAssignments);
+    setBlankStatuses(resetStatuses);
+    setEvaluationState('idle');
+  };
+
+  const handleEvaluate = () => {
+    if (!isInteractionEnabled) return;
+
+    const statusUpdates: Record<string, BlankStatus> = {};
+    let isCorrect = true;
+
+    tile.content.blanks.forEach((blank) => {
+      const assigned = assignments[blank.id];
+      const blankIsCorrect = Boolean(assigned) && assigned === blank.correctOptionId;
+      statusUpdates[blank.id] = blankIsCorrect ? 'correct' : 'incorrect';
+      if (!blankIsCorrect) {
+        isCorrect = false;
+      }
+    });
+
+    setBlankStatuses(statusUpdates);
+    setEvaluationState(isCorrect ? 'correct' : 'incorrect');
+  };
+
+  const renderEvaluationMessage = () => {
+    if (!isInteractionEnabled || evaluationState === 'idle') return null;
+
+    const isCorrect = evaluationState === 'correct';
+
+    return (
+      <div
+        className={`flex items-center gap-2 rounded-xl px-4 py-3 text-sm font-medium ${
+          isCorrect ? 'bg-emerald-100 text-emerald-800' : 'bg-rose-100 text-rose-700'
+        }`}
+      >
+        {isCorrect ? <CheckCircle2 className="w-5 h-5" /> : <XCircle className="w-5 h-5" />}
+        {isCorrect ? 'Świetnie! Wszystkie odpowiedzi są poprawne.' : 'Spróbuj ponownie. Przeciągnij słowa w inne miejsca.'}
+      </div>
+    );
+  };
+
+  const renderBlankSegment = (segment: Extract<Segment, { type: 'blank' }>) => {
+    const assignedOptionId = assignments[segment.blank.id];
+    const assignedOption = assignedOptionId
+      ? tile.content.options.find((option) => option.id === assignedOptionId)
+      : null;
+    const status = blankStatuses[segment.blank.id] ?? 'idle';
+    const isHovered = hoveredBlankId === segment.blank.id;
+
+    let background = blankBackground;
+    let border = blankBorder;
+    let text = textColor;
+
+    if (status === 'correct') {
+      background = '#dcfce7';
+      border = '#22c55e';
+      text = '#166534';
+    } else if (status === 'incorrect') {
+      background = '#fee2e2';
+      border = '#f87171';
+      text = '#b91c1c';
+    } else if (isHovered) {
+      background = blankHoverBackground;
+      border = blankHoverBorder;
+    }
+
+    return (
+      <span
+        key={segment.blank.id}
+        className={`inline-flex items-center gap-2 px-3 py-1.5 mx-1 rounded-lg border text-sm font-medium transition-all duration-200 ${
+          isInteractionEnabled ? 'cursor-pointer' : 'cursor-default'
+        }`}
+        style={{
+          backgroundColor: background,
+          borderColor: border,
+          color: text
+        }}
+        draggable={false}
+        onDragOver={handleBlankDragOver}
+        onDrop={(event) => handleBlankDrop(event, segment.blank.id)}
+        onDragEnter={() => handleBlankDragEnter(segment.blank.id)}
+        onDragLeave={() => handleBlankDragLeave(segment.blank.id)}
+      >
+        {assignedOption ? (
+          <>
+            <span>{assignedOption.text}</span>
+            {isInteractionEnabled && (
+              <button
+                type="button"
+                onClick={() => handleClearBlank(segment.blank.id)}
+                className="ml-1 inline-flex items-center justify-center w-5 h-5 rounded-full bg-white/60 text-xs text-slate-600 hover:bg-white/80"
+              >
+                ×
+              </button>
+            )}
+          </>
+        ) : (
+          <span className="opacity-70">Przeciągnij słowo</span>
+        )}
+      </span>
+    );
+  };
+
+  return (
+    <div className="relative w-full h-full" onDoubleClick={handleTileDoubleClick}>
+      <div className="w-full h-full flex flex-col gap-5 p-6">
+        <TaskInstructionPanel
+          icon={<Puzzle className="w-4 h-4" />}
+          label="Uzupełnij tekst"
+          className="border"
+          style={{
+            backgroundColor: panelBackground,
+            borderColor: panelBorder,
+            color: textColor
+          }}
+          iconWrapperClassName="w-9 h-9 rounded-xl flex items-center justify-center shadow-sm"
+          iconWrapperStyle={{
+            backgroundColor: iconBackground,
+            color: textColor
+          }}
+          labelStyle={{ color: mutedLabelColor }}
+          bodyClassName="px-5 pb-5"
+        >
+          {instructionContent ?? (
+            <div
+              className="flex flex-wrap items-center gap-y-2 text-base leading-relaxed"
+              style={{
+                fontFamily: tile.content.fontFamily,
+                fontSize: `${tile.content.fontSize}px`,
+                color: textColor,
+                whiteSpace: 'pre-wrap'
+              }}
+            >
+              {segments.map((segment, index) =>
+                segment.type === 'text' ? (
+                  <span key={`text-${index}`} className="whitespace-pre-wrap">
+                    {segment.text}
+                  </span>
+                ) : (
+                  renderBlankSegment(segment)
+                )
+              )}
+            </div>
+          )}
+        </TaskInstructionPanel>
+
+        <div
+          className="rounded-2xl border p-4 flex flex-col gap-3"
+          style={{
+            backgroundColor: bankBackground,
+            borderColor: bankBorder,
+            color: textColor
+          }}
+        >
+          <div className="text-xs uppercase tracking-[0.32em] font-semibold opacity-80">
+            Bank słów
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {availableOptions.length === 0 && (
+              <span className="text-sm opacity-70">Wszystkie słowa zostały użyte</span>
+            )}
+            {availableOptions.map((option) => (
+              <span
+                key={option.id}
+                className={`inline-flex items-center px-3 py-1.5 rounded-full border text-sm font-medium shadow-sm transition-transform ${
+                  isInteractionEnabled ? 'cursor-grab active:cursor-grabbing' : 'opacity-70 cursor-not-allowed'
+                }`}
+                style={{
+                  backgroundColor: chipBackground,
+                  borderColor: chipBorder,
+                  color: textColor
+                }}
+                draggable={isInteractionEnabled}
+                onDragStart={(event) => handleOptionDragStart(event, option.id)}
+                onDragEnd={handleOptionDragEnd}
+              >
+                {option.text}
+              </span>
+            ))}
+          </div>
+        </div>
+
+        {isInteractionEnabled && (
+          <div className="flex items-center gap-3 pt-1">
+            <button
+              type="button"
+              onClick={handleEvaluate}
+              className="px-4 py-2 rounded-lg text-sm font-semibold shadow-sm transition-colors duration-200 bg-white/90 hover:bg-white disabled:opacity-60 disabled:cursor-not-allowed"
+              style={{ color: accentColor }}
+              disabled={!allBlanksFilled}
+            >
+              Sprawdź odpowiedzi
+            </button>
+            <button
+              type="button"
+              onClick={handleReset}
+              className="px-3 py-2 rounded-lg text-sm font-medium flex items-center gap-2 text-slate-600 hover:text-slate-800"
+            >
+              <RotateCcw className="w-4 h-4" />
+              Wyczyść
+            </button>
+          </div>
+        )}
+
+        {renderEvaluationMessage()}
+      </div>
+    </div>
+  );
+};
+
+export default MatchPairsInteractive;

--- a/src/components/admin/side editor/MatchPairsEditor.tsx
+++ b/src/components/admin/side editor/MatchPairsEditor.tsx
@@ -1,0 +1,261 @@
+import React, { useMemo } from 'react';
+import { Plus, Trash2, Sparkles, Square, RotateCcw } from 'lucide-react';
+import { MatchPairsTile, LessonTile } from '../../../types/lessonEditor.ts';
+import {
+  ensureValidBlankAssignments,
+  promptToRichText,
+  synchronizeBlanksWithPrompt,
+  countBlanksInPrompt
+} from '../../../utils/matchPairs.ts';
+
+interface MatchPairsEditorProps {
+  tile: MatchPairsTile;
+  onUpdateTile: (tileId: string, updates: Partial<LessonTile>) => void;
+  isTesting?: boolean;
+  onToggleTesting?: (tileId: string) => void;
+}
+
+export const MatchPairsEditor: React.FC<MatchPairsEditorProps> = ({
+  tile,
+  onUpdateTile,
+  isTesting = false,
+  onToggleTesting
+}) => {
+  const blankCount = tile.content.blanks.length;
+  const optionCount = tile.content.options.length;
+
+  const placeholderCount = useMemo(
+    () => countBlanksInPrompt(tile.content.prompt),
+    [tile.content.prompt]
+  );
+
+  const updateContent = (contentUpdates: Partial<MatchPairsTile['content']>) => {
+    onUpdateTile(tile.id, {
+      content: {
+        ...tile.content,
+        ...contentUpdates
+      },
+      updated_at: new Date().toISOString()
+    });
+  };
+
+  const handlePromptChange = (value: string) => {
+    const synchronizedBlanks = synchronizeBlanksWithPrompt(value, tile.content.blanks);
+    updateContent({
+      prompt: value,
+      richPrompt: promptToRichText(value),
+      blanks: ensureValidBlankAssignments(synchronizedBlanks, tile.content.options)
+    });
+  };
+
+  const handleBackgroundChange = (value: string) => {
+    updateContent({ backgroundColor: value });
+  };
+
+  const handleToggleBorder = (checked: boolean) => {
+    updateContent({ showBorder: checked });
+  };
+
+  const handleAddOption = () => {
+    const newOption = {
+      id: `option-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+      text: `Nowe słowo ${tile.content.options.length + 1}`
+    } as MatchPairsTile['content']['options'][number];
+
+    const updatedOptions = [...tile.content.options, newOption];
+    const normalizedBlanks = ensureValidBlankAssignments(tile.content.blanks, updatedOptions);
+
+    updateContent({ options: updatedOptions, blanks: normalizedBlanks });
+  };
+
+  const handleOptionTextChange = (optionId: string, text: string) => {
+    const updatedOptions = tile.content.options.map((option) =>
+      option.id === optionId ? { ...option, text } : option
+    );
+
+    updateContent({ options: updatedOptions });
+  };
+
+  const handleRemoveOption = (optionId: string) => {
+    const updatedOptions = tile.content.options.filter((option) => option.id !== optionId);
+    const normalizedBlanks = ensureValidBlankAssignments(tile.content.blanks, updatedOptions);
+
+    updateContent({ options: updatedOptions, blanks: normalizedBlanks });
+  };
+
+  const handleBlankAnswerChange = (blankId: string, optionId: string | null) => {
+    const updatedBlanks = tile.content.blanks.map((blank) =>
+      blank.id === blankId ? { ...blank, correctOptionId: optionId } : blank
+    );
+
+    updateContent({ blanks: updatedBlanks });
+  };
+
+  const handleResetAssignments = () => {
+    const resetBlanks = tile.content.blanks.map((blank) => ({
+      ...blank,
+      correctOptionId: null
+    }));
+
+    updateContent({ blanks: resetBlanks });
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="p-4 rounded-lg border border-gray-200 bg-white shadow-sm">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <h3 className="text-sm font-semibold text-gray-900">Tryb testowania</h3>
+            <p className="text-xs text-gray-600 mt-1">
+              {isTesting
+                ? 'Tryb ucznia jest aktywny. Kafelek na płótnie jest zablokowany przed przypadkową edycją.'
+                : 'Wyłącz interakcje edycyjne kafelka i sprawdź zadanie dokładnie tak, jak zobaczy je uczeń.'}
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => onToggleTesting?.(tile.id)}
+            disabled={!onToggleTesting}
+            className={`inline-flex items-center gap-2 px-3 py-2 text-xs font-medium rounded-lg transition-colors shadow-sm ${
+              isTesting
+                ? 'bg-slate-900 text-white hover:bg-slate-800'
+                : 'bg-blue-600 text-white hover:bg-blue-500'
+            } disabled:opacity-60 disabled:cursor-not-allowed`}
+          >
+            {isTesting ? <Square className="w-4 h-4" /> : <Sparkles className="w-4 h-4" />}
+            <span>{isTesting ? 'Zakończ testowanie' : 'Przetestuj zadanie'}</span>
+          </button>
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <label className="block text-sm font-medium text-gray-700">Instrukcja z lukami</label>
+        <textarea
+          value={tile.content.prompt}
+          onChange={(e) => handlePromptChange(e.target.value)}
+          rows={4}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm"
+          placeholder="Wprowadź treść zadania i użyj dwóch podkreśleń __ w miejscach, które mają zostać uzupełnione"
+        />
+        <p className="text-xs text-gray-500">
+          Użyj dwóch znaków podkreślenia (<code>__</code>) dla każdej luki. Tekst zawiera {placeholderCount}{' '}
+          {placeholderCount === 1 ? 'lukę' : 'luki'}.
+        </p>
+        {placeholderCount !== blankCount && (
+          <p className="text-xs text-amber-600 bg-amber-50 border border-amber-100 rounded-lg px-3 py-2">
+            Liczba wykrytych luk różni się od zapisanych odpowiedzi ({blankCount}). Zmiany zostaną zsynchronizowane automatycznie.
+          </p>
+        )}
+      </div>
+
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <h3 className="text-sm font-semibold text-gray-800">Bank słów ({optionCount})</h3>
+          <button
+            type="button"
+            onClick={handleAddOption}
+            className="flex items-center gap-2 px-3 py-2 rounded-lg bg-blue-50 text-blue-600 text-xs font-medium hover:bg-blue-100 transition"
+          >
+            <Plus className="w-4 h-4" />
+            Dodaj słowo
+          </button>
+        </div>
+
+        <div className="space-y-3 max-h-64 overflow-y-auto pr-1">
+          {tile.content.options.map((option) => (
+            <div key={option.id} className="flex items-center gap-3 p-3 bg-gray-50 border border-gray-200 rounded-xl">
+              <input
+                type="text"
+                value={option.text}
+                onChange={(e) => handleOptionTextChange(option.id, e.target.value)}
+                className="flex-1 px-3 py-2 text-sm border border-gray-200 rounded-lg focus:ring-1 focus:ring-blue-500 focus:border-transparent"
+                placeholder="Wyraz lub fraza"
+              />
+              <button
+                type="button"
+                onClick={() => handleRemoveOption(option.id)}
+                className="p-2 text-red-500 hover:text-red-600 transition-colors"
+                title="Usuń słowo"
+              >
+                <Trash2 className="w-4 h-4" />
+              </button>
+            </div>
+          ))}
+
+          {tile.content.options.length === 0 && (
+            <div className="text-xs text-slate-500 bg-slate-50 border border-slate-100 rounded-lg px-3 py-2">
+              Dodaj co najmniej jedno słowo, aby uczniowie mieli elementy do przeciągnięcia.
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <h3 className="text-sm font-semibold text-gray-800">Poprawne odpowiedzi</h3>
+          <button
+            type="button"
+            onClick={handleResetAssignments}
+            className="flex items-center gap-2 px-2 py-1 text-xs text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded-lg transition"
+          >
+            <RotateCcw className="w-3 h-3" />
+            Wyczyść przypisania
+          </button>
+        </div>
+        <div className="space-y-2">
+          {tile.content.blanks.length === 0 && (
+            <p className="text-xs text-slate-500 bg-slate-50 border border-slate-100 rounded-lg px-3 py-2">
+              Dodaj luki w tekście przy pomocy podwójnego podkreślenia (<code>__</code>), aby można było ustawić poprawne odpowiedzi.
+            </p>
+          )}
+          {tile.content.blanks.map((blank, index) => (
+            <div key={blank.id} className="flex items-center gap-3 p-3 bg-white border border-gray-200 rounded-xl">
+              <div className="text-sm font-medium text-gray-700 min-w-[90px]">
+                Luka {index + 1}
+              </div>
+              <select
+                value={blank.correctOptionId ?? ''}
+                onChange={(e) => handleBlankAnswerChange(blank.id, e.target.value || null)}
+                className="flex-1 px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              >
+                <option value="">Wybierz poprawne słowo</option>
+                {tile.content.options.map((option) => (
+                  <option key={option.id} value={option.id}>
+                    {option.text}
+                  </option>
+                ))}
+              </select>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="space-y-4">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-3">Kolor tła kafelka</label>
+          <input
+            type="color"
+            value={tile.content.backgroundColor}
+            onChange={(e) => handleBackgroundChange(e.target.value)}
+            className="w-full h-12 border border-gray-300 rounded-lg cursor-pointer"
+          />
+        </div>
+
+        <label className="flex items-center gap-3 p-4 bg-gray-50 rounded-lg border border-gray-200">
+          <input
+            type="checkbox"
+            checked={tile.content.showBorder}
+            onChange={(e) => handleToggleBorder(e.target.checked)}
+            className="w-5 h-5 text-blue-600 focus:ring-blue-500"
+          />
+          <div>
+            <span className="text-sm font-medium text-gray-900">Pokaż obramowanie kafelka</span>
+            <p className="text-xs text-gray-600 mt-1">
+              Gdy wyłączone, kafelek łączy się z tłem i wygląda bardziej minimalistycznie.
+            </p>
+          </div>
+        </label>
+      </div>
+    </div>
+  );
+};

--- a/src/components/admin/side editor/TilePalette.tsx
+++ b/src/components/admin/side editor/TilePalette.tsx
@@ -37,6 +37,11 @@ const TILE_TYPES: TilePaletteItem[] = [
     type: 'sequencing',
     title: 'Ćwiczenie sekwencyjne',
     icon: 'ArrowUpDown'
+  },
+  {
+    type: 'matchPairs',
+    title: 'Dopasuj brakujące słowa',
+    icon: 'Puzzle'
   }
 ];
 

--- a/src/components/admin/side editor/TileSideEditor.tsx
+++ b/src/components/admin/side editor/TileSideEditor.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { Plus, Trash2, Type, X } from 'lucide-react';
-import { TextTile, ImageTile, LessonTile, ProgrammingTile, SequencingTile, QuizTile } from '../../../types/lessonEditor.ts';
+import { TextTile, ImageTile, LessonTile, ProgrammingTile, SequencingTile, QuizTile, MatchPairsTile } from '../../../types/lessonEditor.ts';
 import { ImageUploadComponent } from './ImageUploadComponent.tsx';
 import { ImagePositionControl } from './ImagePositionControl.tsx';
 import { SequencingEditor } from './SequencingEditor.tsx';
+import { MatchPairsEditor } from './MatchPairsEditor.tsx';
 
 interface TileSideEditorProps {
   tile: LessonTile | undefined;
@@ -97,6 +98,7 @@ export const TileSideEditor: React.FC<TileSideEditorProps> = ({
       case 'image': return 'Edytor Obrazu';
       case 'visualization': return 'Edytor Wizualizacji';
       case 'quiz': return 'Edytor Quiz';
+      case 'matchPairs': return 'Edytor luk w tekście';
       default: return 'Edytor Kafelka';
     }
   };
@@ -263,6 +265,18 @@ export const TileSideEditor: React.FC<TileSideEditorProps> = ({
         return (
           <SequencingEditor
             tile={sequencingTile}
+            onUpdateTile={onUpdateTile}
+            isTesting={isTesting}
+            onToggleTesting={onToggleTesting}
+          />
+        );
+      }
+
+      case 'matchPairs': {
+        const matchPairsTile = tile as MatchPairsTile;
+        return (
+          <MatchPairsEditor
+            tile={matchPairsTile}
             onUpdateTile={onUpdateTile}
             isTesting={isTesting}
             onToggleTesting={onToggleTesting}

--- a/src/hooks/useTileInteractions.ts
+++ b/src/hooks/useTileInteractions.ts
@@ -33,7 +33,8 @@ export const useTileInteractions = ({
       tile.type === 'text' ||
       tile.type === 'programming' ||
       tile.type === 'sequencing' ||
-      tile.type === 'quiz'
+      tile.type === 'quiz' ||
+      tile.type === 'matchPairs'
     ) {
       dispatch({ type: 'startTextEditing', tileId: tile.id });
     } else if (tile.type === 'image') {

--- a/src/services/lessonContentService.ts
+++ b/src/services/lessonContentService.ts
@@ -1,5 +1,11 @@
-import { LessonContent, LessonTile, TextTile } from '../types/lessonEditor';
-import { ProgrammingTile, SequencingTile } from '../types/lessonEditor';
+import {
+  LessonContent,
+  LessonTile,
+  TextTile,
+  ProgrammingTile,
+  SequencingTile,
+  MatchPairsTile
+} from '../types/lessonEditor';
 import { GridUtils } from '../utils/gridUtils';
 import { logger } from '../utils/logger';
 
@@ -336,6 +342,76 @@ export class LessonContentService {
         language: 'python',
         startingCode: '',
         endingCode: ''
+      },
+      created_at: now,
+      updated_at: now,
+      z_index: 1
+    };
+  }
+
+  /**
+   * Create a new match pairs tile
+   */
+  static createMatchPairsTile(position: { x: number; y: number }, page = 1): MatchPairsTile {
+    const id = `tile-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+    const now = new Date().toISOString();
+
+    const gridPos = GridUtils.pixelToGrid(position, {
+      width: GridUtils.GRID_COLUMNS,
+      height: 6,
+      gridSize: GridUtils.GRID_CELL_SIZE,
+      snapToGrid: true
+    });
+
+    gridPos.colSpan = 4;
+    gridPos.rowSpan = 4;
+
+    const pixelPos = GridUtils.gridToPixel(gridPos, {
+      width: GridUtils.GRID_COLUMNS,
+      height: 6,
+      gridSize: GridUtils.GRID_CELL_SIZE,
+      snapToGrid: true
+    });
+
+    const pixelSize = GridUtils.gridSizeToPixel(gridPos, {
+      width: GridUtils.GRID_COLUMNS,
+      height: 6,
+      gridSize: GridUtils.GRID_CELL_SIZE,
+      snapToGrid: true
+    });
+
+    const options: MatchPairsTile['content']['options'] = [
+      { id: `option-${Date.now()}-1`, text: 'czyta' },
+      { id: `option-${Date.now()}-2`, text: 'książkę' },
+      { id: `option-${Date.now()}-3`, text: 'wieczorem' },
+      { id: `option-${Date.now()}-4`, text: 'głośno' }
+    ];
+
+    const blanks: MatchPairsTile['content']['blanks'] = [
+      { id: `blank-${Date.now()}-1`, correctOptionId: options[0].id },
+      { id: `blank-${Date.now()}-2`, correctOptionId: options[1].id },
+      { id: `blank-${Date.now()}-3`, correctOptionId: options[2].id }
+    ];
+
+    const prompt = 'Basia __ swoją ulubioną __ __.';
+
+    return {
+      id,
+      type: 'matchPairs',
+      position: pixelPos,
+      size: pixelSize,
+      gridPosition: gridPos,
+      page,
+      content: {
+        prompt,
+        richPrompt: '<p style="margin: 0;">Basia __ swoją ulubioną __ __.</p>',
+        fontFamily: 'Inter, system-ui, sans-serif',
+        fontSize: 16,
+        verticalAlign: 'top',
+        backgroundColor: '#c4b5fd',
+        showBorder: true,
+        blanks,
+        options
       },
       created_at: now,
       updated_at: now,

--- a/src/types/lessonEditor.ts
+++ b/src/types/lessonEditor.ts
@@ -17,7 +17,7 @@ export interface GridPosition {
 
 export interface LessonTile {
   id: string;
-  type: 'text' | 'image' | 'visualization' | 'quiz' | 'programming' | 'sequencing';
+  type: 'text' | 'image' | 'visualization' | 'quiz' | 'programming' | 'sequencing' | 'matchPairs';
   position: Position;
   size: Size;
   gridPosition: GridPosition;
@@ -125,6 +125,27 @@ export interface SequencingTile extends LessonTile {
     }>;
     correctFeedback: string;
     incorrectFeedback: string;
+  };
+}
+
+export interface MatchPairsTile extends LessonTile {
+  type: 'matchPairs';
+  content: {
+    prompt: string; // Plain text version of the instruction with blanks marked as __
+    richPrompt?: string; // Formatted HTML version of the instruction
+    fontFamily: string;
+    fontSize: number;
+    verticalAlign: 'top' | 'center' | 'bottom';
+    backgroundColor: string;
+    showBorder: boolean;
+    blanks: Array<{
+      id: string;
+      correctOptionId: string | null;
+    }>;
+    options: Array<{
+      id: string;
+      text: string;
+    }>;
   };
 }
 

--- a/src/utils/matchPairs.ts
+++ b/src/utils/matchPairs.ts
@@ -1,0 +1,62 @@
+import { MatchPairsTile } from '../types/lessonEditor';
+
+export const MATCH_PAIRS_PLACEHOLDER_REGEX = /__+/g;
+
+const generateBlankId = () => `blank-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+export const countBlanksInPrompt = (prompt: string): number => {
+  if (!prompt) {
+    return 0;
+  }
+
+  const matches = prompt.match(MATCH_PAIRS_PLACEHOLDER_REGEX);
+  return matches ? matches.length : 0;
+};
+
+export const synchronizeBlanksWithPrompt = (
+  prompt: string,
+  existingBlanks: MatchPairsTile['content']['blanks']
+): MatchPairsTile['content']['blanks'] => {
+  const blankCount = countBlanksInPrompt(prompt);
+  const synchronized: MatchPairsTile['content']['blanks'] = [];
+
+  for (let index = 0; index < blankCount; index += 1) {
+    const existing = existingBlanks[index];
+    synchronized.push({
+      id: existing?.id ?? generateBlankId(),
+      correctOptionId: existing?.correctOptionId ?? null
+    });
+  }
+
+  return synchronized;
+};
+
+export const ensureValidBlankAssignments = (
+  blanks: MatchPairsTile['content']['blanks'],
+  options: MatchPairsTile['content']['options']
+): MatchPairsTile['content']['blanks'] => {
+  const optionIds = new Set(options.map((option) => option.id));
+
+  return blanks.map((blank) => ({
+    ...blank,
+    correctOptionId: blank.correctOptionId && optionIds.has(blank.correctOptionId)
+      ? blank.correctOptionId
+      : null
+  }));
+};
+
+export const promptToRichText = (prompt: string): string => {
+  if (!prompt) {
+    return '<p style="margin: 0;"><br /></p>';
+  }
+
+  const lines = prompt.split(/\n+/).map((line) => line.trim());
+
+  return lines
+    .map((line) => (
+      line.length > 0
+        ? `<p style="margin: 0;">${line}</p>`
+        : '<p style="margin: 0;"><br /></p>'
+    ))
+    .join('');
+};


### PR DESCRIPTION
## Summary
- add a MatchPairsTile type, creation helpers, and palette entry so editors can place the new task on the canvas
- implement MatchPairsInteractive with drag-and-drop blanks plus a dedicated side editor for configuring prompts, bank words, and answers
- integrate prompt editing, blank synchronisation, and testing controls into the existing lesson editor workflow

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dadbdcabc48321aab08569aabe431d