### PR TITLE
Add match pairs fill-in-the-blanks tile

### DIFF
--- a/src/Pages/LessonEditor.tsx
+++ b/src/Pages/LessonEditor.tsx
@@ -1,8 +1,14 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { ArrowLeft, Save, RotateCcw, Grid, Edit } from 'lucide-react';
 import { Lesson, Course } from '../types/course.ts';
-import { LessonContent, LessonTile, ProgrammingTile, TextTile } from '../types/lessonEditor.ts';
-import { SequencingTile } from '../types/lessonEditor.ts';
+import {
+  LessonContent,
+  LessonTile,
+  ProgrammingTile,
+  TextTile,
+  SequencingTile,
+  MatchPairsTile
+} from '../types/lessonEditor.ts';
 import { useLessonEditor } from '../hooks/useLessonEditor.ts';
 import { LessonContentService } from '../services/lessonContentService.ts';
 import { TilePalette } from '../components/admin/side editor/TilePalette.tsx';
@@ -24,8 +30,16 @@ interface LessonEditorProps {
   onBack: () => void;
 }
 
-const isRichTextTile = (tile: LessonTile | null): tile is TextTile | ProgrammingTile | SequencingTile => {
-  return !!tile && (tile.type === 'text' || tile.type === 'programming' || tile.type === 'sequencing');
+const isRichTextTile = (
+  tile: LessonTile | null
+): tile is TextTile | ProgrammingTile | SequencingTile | MatchPairsTile => {
+  return (
+    !!tile &&
+    (tile.type === 'text' ||
+      tile.type === 'programming' ||
+      tile.type === 'sequencing' ||
+      tile.type === 'matchPairs')
+  );
 };
 
 export const LessonEditor: React.FC<LessonEditorProps> = ({ lesson, course, onBack }) => {
@@ -253,6 +267,9 @@ export const LessonEditor: React.FC<LessonEditorProps> = ({ lesson, course, onBa
       case 'sequencing':
         newTile = LessonContentService.createSequencingTile(position, currentPage);
         break;
+      case 'matchPairs':
+        newTile = LessonContentService.createMatchPairsTile(position, currentPage);
+        break;
       default:
         logger.warn(`Tile type ${tileType} not implemented yet`);
         warning('Funkcja niedostępna', `Typ kafelka "${tileType}" nie jest jeszcze dostępny`);
@@ -313,7 +330,12 @@ export const LessonEditor: React.FC<LessonEditorProps> = ({ lesson, course, onBa
         };
 
         // Special handling for text-based tiles to ensure content properties are merged
-        if ((tile.type === 'text' || tile.type === 'programming' || tile.type === 'sequencing') && updates.content) {
+        if ((
+          tile.type === 'text' ||
+          tile.type === 'programming' ||
+          tile.type === 'sequencing' ||
+          tile.type === 'matchPairs'
+        ) && updates.content) {
           updatedTile.content = {
             ...tile.content,
             ...updates.content

--- a/src/components/admin/MatchPairsInteractive.tsx
+++ b/src/components/admin/MatchPairsInteractive.tsx
@@ -1,0 +1,671 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  CheckCircle2,
+  GripVertical,
+  Puzzle,
+  RotateCcw,
+  Sparkles,
+  XCircle
+} from 'lucide-react';
+import { MatchPairsTile } from '../../types/lessonEditor';
+import { TaskInstructionPanel } from './common/TaskInstructionPanel';
+
+interface MatchPairsInteractiveProps {
+  tile: MatchPairsTile;
+  isPreview?: boolean;
+  isTestingMode?: boolean;
+  onRequestTextEditing?: () => void;
+  instructionContent?: React.ReactNode;
+}
+
+type EvaluationState = 'idle' | 'correct' | 'incorrect';
+
+type DragSource = 'bank' | { type: 'blank'; id: string };
+
+interface DragPayload {
+  type: 'match-pairs-option';
+  optionId: string;
+  fromBlankId?: string;
+}
+
+interface TemplateSegment {
+  type: 'text' | 'blank';
+  value: string;
+  blankId?: string;
+}
+
+const hexToRgb = (hex: string): { r: number; g: number; b: number } | null => {
+  if (!hex) return null;
+
+  let normalized = hex.replace('#', '').trim();
+  if (normalized.length === 3) {
+    normalized = normalized
+      .split('')
+      .map(char => `${char}${char}`)
+      .join('');
+  }
+
+  if (normalized.length !== 6) return null;
+
+  const intValue = Number.parseInt(normalized, 16);
+  if (Number.isNaN(intValue)) return null;
+
+  return {
+    r: (intValue >> 16) & 255,
+    g: (intValue >> 8) & 255,
+    b: intValue & 255
+  };
+};
+
+const channelToLinear = (value: number): number => {
+  const scaled = value / 255;
+  return scaled <= 0.03928 ? scaled / 12.92 : Math.pow((scaled + 0.055) / 1.055, 2.4);
+};
+
+const getReadableTextColor = (hex: string): string => {
+  const rgb = hexToRgb(hex);
+  if (!rgb) return '#0f172a';
+
+  const luminance =
+    0.2126 * channelToLinear(rgb.r) +
+    0.7152 * channelToLinear(rgb.g) +
+    0.0722 * channelToLinear(rgb.b);
+
+  return luminance > 0.6 ? '#0f172a' : '#f8fafc';
+};
+
+const lightenColor = (hex: string, amount: number): string => {
+  const rgb = hexToRgb(hex);
+  if (!rgb) return hex;
+
+  const lightenChannel = (channel: number) => Math.round(channel + (255 - channel) * amount);
+  return `rgb(${lightenChannel(rgb.r)}, ${lightenChannel(rgb.g)}, ${lightenChannel(rgb.b)})`;
+};
+
+const darkenColor = (hex: string, amount: number): string => {
+  const rgb = hexToRgb(hex);
+  if (!rgb) return hex;
+
+  const darkenChannel = (channel: number) => Math.round(channel * (1 - amount));
+  return `rgb(${darkenChannel(rgb.r)}, ${darkenChannel(rgb.g)}, ${darkenChannel(rgb.b)})`;
+};
+
+const surfaceColor = (
+  accent: string,
+  textColor: string,
+  lightenAmount: number,
+  darkenAmount: number
+): string => (textColor === '#0f172a' ? lightenColor(accent, lightenAmount) : darkenColor(accent, darkenAmount));
+
+const parseTemplate = (template: string, blanks: MatchPairsTile['content']['blanks']): TemplateSegment[] => {
+  if (!template) {
+    return [{ type: 'text', value: '' }];
+  }
+
+  const placeholderRegex = /\{\{\s*([^}]+?)\s*\}\}/g;
+  const segments: TemplateSegment[] = [];
+  let lastIndex = 0;
+
+  let match: RegExpExecArray | null;
+  while ((match = placeholderRegex.exec(template)) !== null) {
+    const [placeholder, placeholderIdRaw] = match;
+    const placeholderId = placeholderIdRaw.trim();
+
+    if (match.index > lastIndex) {
+      segments.push({ type: 'text', value: template.slice(lastIndex, match.index) });
+    }
+
+    const blankExists = blanks.some(blank => blank.id === placeholderId);
+    if (blankExists) {
+      segments.push({ type: 'blank', value: placeholder, blankId: placeholderId });
+    } else {
+      segments.push({ type: 'text', value: placeholder });
+    }
+
+    lastIndex = match.index + placeholder.length;
+  }
+
+  if (lastIndex < template.length) {
+    segments.push({ type: 'text', value: template.slice(lastIndex) });
+  }
+
+  if (segments.length === 0) {
+    segments.push({ type: 'text', value: template });
+  }
+
+  return segments;
+};
+
+const readDragPayload = (event: React.DragEvent): DragPayload | null => {
+  const json = event.dataTransfer.getData('application/json') || event.dataTransfer.getData('text/plain');
+  if (!json) return null;
+
+  try {
+    const parsed = JSON.parse(json);
+    if (parsed && parsed.type === 'match-pairs-option' && typeof parsed.optionId === 'string') {
+      return parsed as DragPayload;
+    }
+  } catch (error) {
+    console.warn('Failed to parse drag payload', error);
+  }
+
+  return null;
+};
+
+export const MatchPairsInteractive: React.FC<MatchPairsInteractiveProps> = ({
+  tile,
+  isPreview = false,
+  isTestingMode = false,
+  onRequestTextEditing,
+  instructionContent
+}) => {
+  const [placements, setPlacements] = useState<Record<string, string | null>>(() => {
+    const initial: Record<string, string | null> = {};
+    tile.content.blanks.forEach(blank => {
+      initial[blank.id] = null;
+    });
+    return initial;
+  });
+  const [evaluationState, setEvaluationState] = useState<EvaluationState>('idle');
+  const [draggingOption, setDraggingOption] = useState<{ id: string; source: DragSource } | null>(null);
+  const [activeBlank, setActiveBlank] = useState<string | null>(null);
+  const [isBankHighlighted, setIsBankHighlighted] = useState(false);
+  const [optionOrder, setOptionOrder] = useState<string[]>(() => tile.content.options.map(option => option.id));
+
+  useEffect(() => {
+    const blankIds = new Set(tile.content.blanks.map(blank => blank.id));
+    setPlacements(prev => {
+      const next: Record<string, string | null> = {};
+      tile.content.blanks.forEach(blank => {
+        const previousValue = prev[blank.id] ?? null;
+        next[blank.id] = blankIds.has(blank.id) ? previousValue : null;
+      });
+      return next;
+    });
+    setEvaluationState('idle');
+  }, [tile.content.blanks, tile.content.template]);
+
+  useEffect(() => {
+    if (!tile.content.shuffleOptions) {
+      setOptionOrder(tile.content.options.map(option => option.id));
+      return;
+    }
+
+    const ids = tile.content.options.map(option => option.id);
+    const shuffled = [...ids];
+
+    for (let i = shuffled.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+    }
+
+    setOptionOrder(shuffled);
+  }, [tile.content.options, tile.content.shuffleOptions, isTestingMode]);
+
+  const optionMap = useMemo(() => {
+    const map = new Map<string, MatchPairsTile['content']['options'][number]>();
+    tile.content.options.forEach(option => {
+      map.set(option.id, option);
+    });
+    return map;
+  }, [tile.content.options]);
+
+  const accentColor = tile.content.backgroundColor || '#1d4ed8';
+  const textColor = useMemo(() => getReadableTextColor(accentColor), [accentColor]);
+  const mutedTextColor = textColor === '#0f172a' ? '#475569' : '#dbeafe';
+  const canInteract = !isPreview && isTestingMode;
+
+  const panelBackground = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.64, 0.45),
+    [accentColor, textColor]
+  );
+  const panelBorder = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.52, 0.58),
+    [accentColor, textColor]
+  );
+  const iconBackground = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.54, 0.48),
+    [accentColor, textColor]
+  );
+  const templateBackground = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.62, 0.4),
+    [accentColor, textColor]
+  );
+  const templateBorder = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.54, 0.5),
+    [accentColor, textColor]
+  );
+  const bankBackground = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.58, 0.42),
+    [accentColor, textColor]
+  );
+  const bankBorder = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.48, 0.58),
+    [accentColor, textColor]
+  );
+  const chipBackground = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.52, 0.48),
+    [accentColor, textColor]
+  );
+  const chipBorder = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.44, 0.56),
+    [accentColor, textColor]
+  );
+  const chipHoverBackground = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.64, 0.36),
+    [accentColor, textColor]
+  );
+
+  const segments = useMemo(
+    () => parseTemplate(tile.content.template, tile.content.blanks),
+    [tile.content.template, tile.content.blanks]
+  );
+
+  const unplacedOptionIds = useMemo(() => {
+    const placed = new Set(Object.values(placements).filter(Boolean) as string[]);
+    return optionOrder.filter(id => optionMap.has(id) && !placed.has(id));
+  }, [optionOrder, placements, optionMap]);
+
+  const handleDoubleClick = useCallback(
+    (event: React.MouseEvent) => {
+      if (isPreview || isTestingMode) return;
+
+      event.preventDefault();
+      event.stopPropagation();
+      onRequestTextEditing?.();
+    },
+    [isPreview, isTestingMode, onRequestTextEditing]
+  );
+
+  const updatePlacements = useCallback(
+    (blankId: string, optionId: string | null) => {
+      setPlacements(prev => {
+        const next: Record<string, string | null> = { ...prev };
+
+        if (optionId) {
+          Object.entries(prev).forEach(([existingBlankId, assignedOptionId]) => {
+            if (existingBlankId !== blankId && assignedOptionId === optionId) {
+              next[existingBlankId] = null;
+            }
+          });
+        }
+
+        next[blankId] = optionId;
+        return next;
+      });
+      setEvaluationState('idle');
+    },
+    []
+  );
+
+  const handleDropToBlank = useCallback(
+    (event: React.DragEvent, blankId: string) => {
+      if (!canInteract) return;
+
+      event.preventDefault();
+      const payload = readDragPayload(event);
+      setActiveBlank(null);
+
+      if (!payload) return;
+
+      updatePlacements(blankId, payload.optionId);
+
+      if (payload.fromBlankId && payload.fromBlankId !== blankId) {
+        updatePlacements(payload.fromBlankId, null);
+      }
+
+      setDraggingOption(null);
+    },
+    [canInteract, updatePlacements]
+  );
+
+  const handleDropToBank = useCallback(
+    (event: React.DragEvent) => {
+      if (!canInteract) return;
+
+      event.preventDefault();
+      setIsBankHighlighted(false);
+      const payload = readDragPayload(event);
+      if (!payload?.fromBlankId) return;
+
+      updatePlacements(payload.fromBlankId, null);
+      setDraggingOption(null);
+    },
+    [canInteract, updatePlacements]
+  );
+
+  const handleDragStart = useCallback(
+    (event: React.DragEvent, optionId: string, source: DragSource) => {
+      if (!canInteract) return;
+
+      const payload: DragPayload = {
+        type: 'match-pairs-option',
+        optionId,
+        fromBlankId: typeof source === 'object' ? source.id : undefined
+      };
+
+      try {
+        event.dataTransfer.setData('application/json', JSON.stringify(payload));
+      } catch {
+        event.dataTransfer.setData('text/plain', JSON.stringify(payload));
+      }
+
+      event.dataTransfer.effectAllowed = 'move';
+      setDraggingOption({ id: optionId, source });
+      setEvaluationState('idle');
+    },
+    [canInteract]
+  );
+
+  const handleDragEnd = useCallback(() => {
+    setDraggingOption(null);
+    setActiveBlank(null);
+    setIsBankHighlighted(false);
+  }, []);
+
+  const handleEvaluate = () => {
+    if (!canInteract) return;
+
+    const allFilled = tile.content.blanks.every(blank => placements[blank.id]);
+    if (!allFilled) {
+      setEvaluationState('incorrect');
+      return;
+    }
+
+    const isCorrect = tile.content.blanks.every(
+      blank => placements[blank.id] === blank.correctOptionId
+    );
+
+    setEvaluationState(isCorrect ? 'correct' : 'incorrect');
+  };
+
+  const handleReset = () => {
+    if (!canInteract) return;
+
+    setPlacements(() => {
+      const reset: Record<string, string | null> = {};
+      tile.content.blanks.forEach(blank => {
+        reset[blank.id] = null;
+      });
+      return reset;
+    });
+    setEvaluationState('idle');
+    setDraggingOption(null);
+  };
+
+  const renderInstructionContent = () => {
+    if (instructionContent) return instructionContent;
+
+    return (
+      <div
+        className="text-sm leading-relaxed"
+        style={{
+          fontFamily: tile.content.fontFamily,
+          fontSize: `${tile.content.fontSize}px`
+        }}
+        dangerouslySetInnerHTML={{
+          __html:
+            tile.content.richInstructions ||
+            `<p style="margin: 0;">${tile.content.instructions}</p>`
+        }}
+      />
+    );
+  };
+
+  const renderOptionChip = (optionId: string, variant: 'bank' | 'blank', blankId?: string) => {
+    const option = optionMap.get(optionId);
+    if (!option) return null;
+
+    const isDragging = draggingOption?.id === optionId;
+
+    return (
+      <div
+        key={`${variant}-${optionId}-${blankId ?? 'bank'}`}
+        draggable={canInteract}
+        onDragStart={event => handleDragStart(event, optionId, variant === 'bank' ? 'bank' : { type: 'blank', id: blankId! })}
+        onDragEnd={handleDragEnd}
+        className={`group relative inline-flex items-center gap-2 px-3 py-2 rounded-lg border text-sm font-medium shadow-sm transition-all select-none ${
+          isDragging ? 'opacity-70 scale-95' : 'hover:shadow-md'
+        } ${
+          variant === 'bank'
+            ? 'cursor-grab active:cursor-grabbing'
+            : canInteract
+              ? 'cursor-grab'
+              : 'cursor-default'
+        }`}
+        style={{
+          backgroundColor: variant === 'bank' ? chipBackground : surfaceColor(accentColor, textColor, 0.48, 0.56),
+          borderColor: chipBorder,
+          color: textColor
+        }}
+      >
+        <GripVertical className="w-3 h-3 text-inherit/70" />
+        <span>{option.text}</span>
+        {variant === 'blank' && canInteract && (
+          <button
+            type="button"
+            onClick={event => {
+              event.stopPropagation();
+              updatePlacements(blankId!, null);
+            }}
+            className="p-1 rounded-full hover:bg-white/10 transition-colors"
+          >
+            <XCircle className="w-3 h-3" />
+          </button>
+        )}
+      </div>
+    );
+  };
+
+  const evaluationBadge = () => {
+    if (evaluationState === 'correct') {
+      return (
+        <div className="flex items-center gap-2 text-sm font-medium" style={{ color: textColor }}>
+          <CheckCircle2 className="w-4 h-4" />
+          <span>Świetnie! Wszystkie odpowiedzi są poprawne.</span>
+        </div>
+      );
+    }
+
+    if (evaluationState === 'incorrect') {
+      return (
+        <div className="flex items-center gap-2 text-sm font-medium text-rose-100">
+          <XCircle className="w-4 h-4" />
+          <span>Sprawdź jeszcze raz. Niektóre luki zawierają niepoprawne odpowiedzi.</span>
+        </div>
+      );
+    }
+
+    return (
+      <div className="flex items-center gap-2 text-sm font-medium" style={{ color: mutedTextColor }}>
+        <Sparkles className="w-4 h-4" />
+        <span>Przeciągnij odpowiedzi do luk i kliknij „Sprawdź”.</span>
+      </div>
+    );
+  };
+
+  return (
+    <div className="w-full h-full flex flex-col gap-5" onDoubleClick={handleDoubleClick}>
+      <TaskInstructionPanel
+        icon={<Puzzle className="w-4 h-4" />}
+        label="Instrukcja"
+        className="flex-shrink-0 border rounded-3xl"
+        style={{ backgroundColor: panelBackground, borderColor: panelBorder, color: textColor }}
+        iconWrapperStyle={{ backgroundColor: iconBackground, color: textColor }}
+        labelStyle={{ color: mutedTextColor }}
+      >
+        {renderInstructionContent()}
+      </TaskInstructionPanel>
+
+      <div className="flex-1 flex flex-col gap-4 rounded-3xl border p-5" style={{ borderColor: templateBorder, backgroundColor: templateBackground, color: textColor }}>
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2 text-xs uppercase tracking-[0.24em]" style={{ color: mutedTextColor }}>
+              <Sparkles className="w-3 h-3" />
+              <span>Tekst z lukami</span>
+            </div>
+            {isTestingMode && (
+              <div className="text-[11px] font-medium px-2 py-1 rounded-full" style={{
+                backgroundColor: surfaceColor(accentColor, textColor, 0.54, 0.5),
+                color: textColor
+              }}>
+                Tryb testowania
+              </div>
+            )}
+          </div>
+
+          <div className="text-base leading-7 flex flex-wrap gap-y-2">
+            {segments.map((segment, index) => {
+              if (segment.type === 'text') {
+                return (
+                  <span key={`text-${index}`} className="whitespace-pre-wrap">
+                    {segment.value}
+                  </span>
+                );
+              }
+
+              const blankId = segment.blankId!;
+              const blank = tile.content.blanks.find(item => item.id === blankId);
+              const assignedOptionId = placements[blankId];
+              const assignedOption = assignedOptionId ? optionMap.get(assignedOptionId) : null;
+              const label = blank?.label || `Luka ${index + 1}`;
+
+              const isActive = activeBlank === blankId;
+              const isCorrect =
+                evaluationState !== 'idle' &&
+                assignedOptionId &&
+                assignedOptionId === blank?.correctOptionId;
+              const isIncorrect =
+                evaluationState === 'incorrect' &&
+                assignedOptionId &&
+                blank?.correctOptionId &&
+                assignedOptionId !== blank.correctOptionId;
+
+              return (
+                <span
+                  key={`blank-${blankId}-${index}`}
+                  onDragOver={event => {
+                    if (!canInteract) return;
+                    event.preventDefault();
+                    event.dataTransfer.dropEffect = 'move';
+                    setActiveBlank(blankId);
+                  }}
+                  onDragLeave={() => setActiveBlank(prev => (prev === blankId ? null : prev))}
+                  onDrop={event => handleDropToBlank(event, blankId)}
+                  className={`inline-flex items-center justify-center min-w-[120px] px-3 py-2 rounded-xl border text-sm font-medium transition-colors duration-200 ${
+                    canInteract ? 'cursor-pointer select-none' : 'cursor-default'
+                  } ${
+                    isActive
+                      ? 'ring-2 ring-offset-2 ring-offset-transparent'
+                      : ''
+                  }`}
+                  style={{
+                    backgroundColor: isActive
+                      ? chipHoverBackground
+                      : surfaceColor(accentColor, textColor, 0.6, 0.44),
+                    borderColor: isCorrect
+                      ? '#22c55e'
+                      : isIncorrect
+                        ? '#ef4444'
+                        : chipBorder,
+                    color: textColor
+                  }}
+                >
+                  {assignedOption
+                    ? renderOptionChip(assignedOption.id, 'blank', blankId)
+                    : (
+                      <span className="text-xs font-medium opacity-70 uppercase tracking-widest">
+                        {label}
+                      </span>
+                    )}
+                </span>
+              );
+            })}
+          </div>
+        </div>
+
+        <div
+          className={`rounded-2xl border px-5 py-4 transition-colors ${
+            isBankHighlighted ? 'ring-2 ring-offset-2' : ''
+          }`}
+          style={{
+            backgroundColor: isBankHighlighted
+              ? surfaceColor(accentColor, textColor, 0.68, 0.36)
+              : bankBackground,
+            borderColor: bankBorder,
+            color: textColor
+          }}
+          onDragOver={event => {
+            if (!canInteract) return;
+            if (draggingOption?.source === 'bank') return;
+
+            event.preventDefault();
+            event.dataTransfer.dropEffect = 'move';
+            setIsBankHighlighted(true);
+          }}
+          onDragLeave={() => setIsBankHighlighted(false)}
+          onDrop={handleDropToBank}
+        >
+          <div className="flex items-center justify-between mb-3">
+            <div className="flex items-center gap-2 text-xs uppercase tracking-[0.24em]" style={{ color: mutedTextColor }}>
+              <Puzzle className="w-3 h-3" />
+              <span>Bank odpowiedzi</span>
+            </div>
+            <span className="text-xs font-medium" style={{ color: mutedTextColor }}>
+              {unplacedOptionIds.length} / {tile.content.options.length} dostępnych
+            </span>
+          </div>
+
+          {unplacedOptionIds.length === 0 ? (
+            <div className="text-sm font-medium opacity-70" style={{ color: mutedTextColor }}>
+              Wszystkie wyrazy zostały użyte. Aby zwolnić miejsce, przenieś odpowiedź z powrotem do banku.
+            </div>
+          ) : (
+            <div className="flex flex-wrap gap-2">
+              {unplacedOptionIds.map(optionId => renderOptionChip(optionId, 'bank'))}
+            </div>
+          )}
+        </div>
+
+        <div className="flex flex-col gap-3 mt-auto">
+          <div className="flex items-center justify-between">
+            {evaluationBadge()}
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={handleReset}
+                disabled={!canInteract}
+                className="inline-flex items-center gap-2 px-3 py-2 rounded-lg text-xs font-semibold border transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
+                style={{
+                  backgroundColor: surfaceColor(accentColor, textColor, 0.66, 0.38),
+                  borderColor: surfaceColor(accentColor, textColor, 0.56, 0.46),
+                  color: textColor
+                }}
+              >
+                <RotateCcw className="w-4 h-4" />
+                Resetuj
+              </button>
+              <button
+                type="button"
+                onClick={handleEvaluate}
+                disabled={!canInteract}
+                className="inline-flex items-center gap-2 px-4 py-2 rounded-lg text-xs font-semibold shadow-md transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
+                style={{
+                  backgroundColor: textColor === '#0f172a'
+                    ? darkenColor(accentColor, 0.2)
+                    : lightenColor(accentColor, 0.12),
+                  color: getReadableTextColor(
+                    textColor === '#0f172a' ? darkenColor(accentColor, 0.2) : lightenColor(accentColor, 0.12)
+                  )
+                }}
+              >
+                <CheckCircle2 className="w-4 h-4" />
+                Sprawdź
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/admin/TileRenderer.tsx
+++ b/src/components/admin/TileRenderer.tsx
@@ -1,6 +1,14 @@
 import React, { useState, useEffect } from 'react';
 import { Move, Trash2, Play, Code2 } from 'lucide-react';
-import { LessonTile, TextTile, ImageTile, QuizTile, ProgrammingTile, SequencingTile } from '../../types/lessonEditor';
+import {
+  LessonTile,
+  TextTile,
+  ImageTile,
+  QuizTile,
+  ProgrammingTile,
+  SequencingTile,
+  MatchPairsTile
+} from '../../types/lessonEditor';
 import { GridUtils } from '../../utils/gridUtils';
 import { Editor, EditorContent, useEditor } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
@@ -16,6 +24,7 @@ import TextAlign from '../../extensions/TextAlign';
 import { SequencingInteractive } from './SequencingInteractive';
 import { TaskInstructionPanel } from './common/TaskInstructionPanel';
 import { QuizInteractive } from './QuizInteractive';
+import { MatchPairsInteractive } from './MatchPairsInteractive';
 
 const hexToRgb = (hex: string): { r: number; g: number; b: number } | null => {
   if (!hex) return null;
@@ -687,6 +696,71 @@ export const TileRenderer: React.FC<TileRendererProps> = ({
           );
         } else {
           contentToRender = renderSequencingContent();
+        }
+        break;
+      }
+
+      case 'matchPairs': {
+        const matchPairsTile = tile as MatchPairsTile;
+        const accentColor = matchPairsTile.content.backgroundColor || computedBackground;
+        const textColor = getReadableTextColor(accentColor);
+
+        const renderMatchPairsContent = (
+          instructionContent?: React.ReactNode,
+          isPreviewMode = false
+        ) => (
+          <MatchPairsInteractive
+            tile={matchPairsTile}
+            isTestingMode={isTestingMode}
+            instructionContent={instructionContent}
+            isPreview={isPreviewMode}
+            onRequestTextEditing={isPreviewMode ? undefined : onDoubleClick}
+          />
+        );
+
+        if (isEditingText && isSelected) {
+          const instructionEditorTile: TextTile = {
+            ...tile,
+            type: 'text',
+            content: {
+              text: matchPairsTile.content.instructions,
+              richText: matchPairsTile.content.richInstructions,
+              fontFamily: matchPairsTile.content.fontFamily,
+              fontSize: matchPairsTile.content.fontSize,
+              verticalAlign: 'top',
+              backgroundColor: matchPairsTile.content.backgroundColor,
+              showBorder: matchPairsTile.content.showBorder
+            }
+          };
+
+          contentToRender = renderMatchPairsContent(
+            <RichTextEditor
+              textTile={instructionEditorTile}
+              tileId={tile.id}
+              textColor={textColor}
+              onUpdateTile={(tileId, updates) => {
+                if (!updates.content) return;
+
+                onUpdateTile(tileId, {
+                  content: {
+                    ...matchPairsTile.content,
+                    instructions:
+                      updates.content.text ?? matchPairsTile.content.instructions,
+                    richInstructions:
+                      updates.content.richText ?? matchPairsTile.content.richInstructions,
+                    fontFamily:
+                      updates.content.fontFamily ?? matchPairsTile.content.fontFamily,
+                    fontSize: updates.content.fontSize ?? matchPairsTile.content.fontSize
+                  }
+                });
+              }}
+              onFinishTextEditing={onFinishTextEditing}
+              onEditorReady={onEditorReady}
+            />,
+            true
+          );
+        } else {
+          contentToRender = renderMatchPairsContent();
         }
         break;
       }

--- a/src/components/admin/side editor/MatchPairsEditor.tsx
+++ b/src/components/admin/side editor/MatchPairsEditor.tsx
@@ -1,0 +1,314 @@
+import React, { useMemo } from 'react';
+import { AlertCircle, Plus, Shuffle, Sparkles, Square, Trash2 } from 'lucide-react';
+import { MatchPairsTile } from '../../../types/lessonEditor';
+
+interface MatchPairsEditorProps {
+  tile: MatchPairsTile;
+  onUpdateTile: (tileId: string, updates: Partial<MatchPairsTile>) => void;
+  isTesting?: boolean;
+  onToggleTesting?: (tileId: string) => void;
+}
+
+const extractPlaceholders = (template: string): string[] => {
+  const regex = /\{\{\s*([^}]+?)\s*\}\}/g;
+  const placeholders: string[] = [];
+  let match: RegExpExecArray | null;
+
+  while ((match = regex.exec(template)) !== null) {
+    const placeholderId = match[1]?.trim();
+    if (placeholderId && !placeholders.includes(placeholderId)) {
+      placeholders.push(placeholderId);
+    }
+  }
+
+  return placeholders;
+};
+
+export const MatchPairsEditor: React.FC<MatchPairsEditorProps> = ({
+  tile,
+  onUpdateTile,
+  isTesting = false,
+  onToggleTesting
+}) => {
+  const handleContentUpdate = (updates: Partial<MatchPairsTile['content']>) => {
+    onUpdateTile(tile.id, {
+      content: {
+        ...tile.content,
+        ...updates
+      },
+      updated_at: new Date().toISOString()
+    });
+  };
+
+  const handleTemplateChange = (value: string) => {
+    const placeholders = extractPlaceholders(value);
+    const updatedBlanks = placeholders.map((placeholderId, index) => {
+      const existing = tile.content.blanks.find(blank => blank.id === placeholderId);
+      return (
+        existing ?? {
+          id: placeholderId,
+          label: `Luka ${index + 1}`,
+          correctOptionId: null
+        }
+      );
+    });
+
+    handleContentUpdate({
+      template: value,
+      blanks: updatedBlanks
+    });
+  };
+
+  const handleBlankUpdate = (blankId: string, updates: Partial<MatchPairsTile['content']['blanks'][number]>) => {
+    const updatedBlanks = tile.content.blanks.map(blank =>
+      blank.id === blankId ? { ...blank, ...updates } : blank
+    );
+    handleContentUpdate({ blanks: updatedBlanks });
+  };
+
+  const handleOptionTextChange = (optionId: string, value: string) => {
+    const updated = tile.content.options.map(option =>
+      option.id === optionId ? { ...option, text: value } : option
+    );
+    handleContentUpdate({ options: updated });
+  };
+
+  const handleAddOption = () => {
+    const newOption = {
+      id: `option-${Date.now()}`,
+      text: `Nowy wyraz ${tile.content.options.length + 1}`
+    };
+
+    handleContentUpdate({ options: [...tile.content.options, newOption] });
+  };
+
+  const handleRemoveOption = (optionId: string) => {
+    if (tile.content.options.length <= 3) {
+      return;
+    }
+
+    const updatedOptions = tile.content.options.filter(option => option.id !== optionId);
+    const updatedBlanks = tile.content.blanks.map(blank =>
+      blank.correctOptionId === optionId ? { ...blank, correctOptionId: null } : blank
+    );
+
+    handleContentUpdate({
+      options: updatedOptions,
+      blanks: updatedBlanks
+    });
+  };
+
+  const placeholders = useMemo(
+    () => extractPlaceholders(tile.content.template),
+    [tile.content.template]
+  );
+
+  const missingPlaceholders = placeholders.length === 0;
+
+  return (
+    <div className="space-y-6">
+      <div className="p-4 rounded-lg border border-gray-200 bg-white shadow-sm">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <h3 className="text-sm font-semibold text-gray-900">Tryb testowania</h3>
+            <p className="text-xs text-gray-600 mt-1">
+              {isTesting
+                ? 'Tryb ucznia jest aktywny. Kafelek na płótnie jest zablokowany przed przypadkową edycją.'
+                : 'Wyłącz interakcje edycyjne kafelka i sprawdź zadanie dokładnie tak, jak zobaczy je uczeń.'}
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => onToggleTesting?.(tile.id)}
+            disabled={!onToggleTesting}
+            className={`inline-flex items-center gap-2 px-3 py-2 text-xs font-medium rounded-lg transition-colors shadow-sm ${
+              isTesting
+                ? 'bg-slate-900 text-white hover:bg-slate-800'
+                : 'bg-blue-600 text-white hover:bg-blue-500'
+            } disabled:opacity-60 disabled:cursor-not-allowed`}
+          >
+            {isTesting ? <Square className="w-4 h-4" /> : <Sparkles className="w-4 h-4" />}
+            <span>{isTesting ? 'Zakończ testowanie' : 'Przetestuj zadanie'}</span>
+          </button>
+        </div>
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-2">
+          Tekst z lukami
+        </label>
+        <textarea
+          value={tile.content.template}
+          onChange={event => handleTemplateChange(event.target.value)}
+          rows={5}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm"
+          placeholder="np. Kot {{blank-1}} na płocie i {{blank-2}} na księżyc."
+        />
+        <p className="text-xs text-gray-500 mt-2 flex items-center gap-2">
+          <AlertCircle className="w-4 h-4" />
+          Użyj nawiasów klamrowych <code className="bg-gray-100 px-1 rounded">{`{{blank-1}}`}</code> aby zaznaczyć miejsce luki. Nazwy luk muszą być unikalne.
+        </p>
+        {missingPlaceholders && (
+          <div className="mt-2 text-xs text-amber-600 bg-amber-50 border border-amber-200 px-3 py-2 rounded">
+            Dodaj co najmniej jedną lukę, aby ćwiczenie było aktywne.
+          </div>
+        )}
+      </div>
+
+      <div>
+        <div className="flex items-center justify-between mb-3">
+          <label className="block text-sm font-medium text-gray-700">
+            Luki ({tile.content.blanks.length})
+          </label>
+        </div>
+        <div className="space-y-3">
+          {tile.content.blanks.map((blank, index) => (
+            <div key={blank.id} className="p-4 border border-gray-200 rounded-lg bg-white shadow-sm space-y-3">
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="text-xs uppercase tracking-[0.24em] text-gray-500">Luka {index + 1}</p>
+                  <p className="text-sm font-semibold text-gray-900">{`{{${blank.id}}}`}</p>
+                </div>
+              </div>
+
+              <div className="grid grid-cols-1 gap-3">
+                <div>
+                  <label className="text-xs font-medium text-gray-600 mb-1 block">
+                    Podpowiedź widoczna w pustym polu
+                  </label>
+                  <input
+                    type="text"
+                    value={blank.label}
+                    onChange={event => handleBlankUpdate(blank.id, { label: event.target.value })}
+                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm"
+                    placeholder={`Luka ${index + 1}`}
+                  />
+                </div>
+
+                <div>
+                  <label className="text-xs font-medium text-gray-600 mb-1 block">
+                    Poprawna odpowiedź
+                  </label>
+                  <select
+                    value={blank.correctOptionId ?? ''}
+                    onChange={event =>
+                      handleBlankUpdate(blank.id, {
+                        correctOptionId: event.target.value ? event.target.value : null
+                      })
+                    }
+                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm"
+                  >
+                    <option value="">– wybierz z listy –</option>
+                    {tile.content.options.map(option => (
+                      <option key={option.id} value={option.id}>
+                        {option.text}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              </div>
+            </div>
+          ))}
+
+          {tile.content.blanks.length === 0 && (
+            <div className="text-xs text-gray-500">Brak zdefiniowanych luk. Dodaj je w treści zadania.</div>
+          )}
+        </div>
+      </div>
+
+      <div>
+        <div className="flex items-center justify-between mb-3">
+          <label className="block text-sm font-medium text-gray-700">
+            Bank odpowiedzi ({tile.content.options.length})
+          </label>
+          <button
+            type="button"
+            onClick={handleAddOption}
+            className="inline-flex items-center gap-2 px-3 py-1.5 bg-blue-600 text-white text-xs font-semibold rounded-lg hover:bg-blue-700 transition-colors"
+          >
+            <Plus className="w-3 h-3" />
+            Dodaj wyraz
+          </button>
+        </div>
+
+        <div className="space-y-2">
+          {tile.content.options.map(option => (
+            <div key={option.id} className="flex items-center gap-3 p-3 bg-white border border-gray-200 rounded-lg shadow-sm">
+              <input
+                type="text"
+                value={option.text}
+                onChange={event => handleOptionTextChange(option.id, event.target.value)}
+                className="flex-1 px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm"
+                placeholder="np. wyraz"
+              />
+              <button
+                type="button"
+                onClick={() => handleRemoveOption(option.id)}
+                className="p-2 text-red-400 hover:text-red-600 transition-colors"
+                title="Usuń odpowiedź"
+              >
+                <Trash2 className="w-4 h-4" />
+              </button>
+            </div>
+          ))}
+        </div>
+
+        {tile.content.options.length <= 3 && (
+          <p className="text-xs text-amber-600 mt-2 flex items-center gap-2">
+            <AlertCircle className="w-4 h-4" />
+            Dodaj więcej odpowiedzi, aby zadanie było ciekawsze (minimum 3).
+          </p>
+        )}
+      </div>
+
+      <div className="grid grid-cols-1 gap-4">
+        <div className="p-4 rounded-lg border border-gray-200 bg-white shadow-sm space-y-3">
+          <div className="flex items-center justify-between">
+            <div>
+              <h4 className="text-sm font-semibold text-gray-900">Losowa kolejność banku</h4>
+              <p className="text-xs text-gray-600 mt-1">
+                Każde odświeżenie zadania miesza odpowiedzi. Wyłącz, aby zachować stałe ułożenie.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={() => handleContentUpdate({ shuffleOptions: !tile.content.shuffleOptions })}
+              className={`inline-flex items-center gap-2 px-3 py-1.5 rounded-lg text-xs font-semibold border transition-colors ${
+                tile.content.shuffleOptions
+                  ? 'bg-blue-600 text-white border-blue-600'
+                  : 'bg-white text-gray-700 border-gray-300'
+              }`}
+            >
+              <Shuffle className="w-4 h-4" />
+              {tile.content.shuffleOptions ? 'Włączone' : 'Wyłączone'}
+            </button>
+          </div>
+        </div>
+
+        <div className="p-4 rounded-lg border border-gray-200 bg-white shadow-sm space-y-3">
+          <div>
+            <label className="block text-sm font-semibold text-gray-900 mb-2">
+              Kolor tła kafelka
+            </label>
+            <input
+              type="color"
+              value={tile.content.backgroundColor}
+              onChange={event => handleContentUpdate({ backgroundColor: event.target.value })}
+              className="w-full h-12 border border-gray-300 rounded-lg cursor-pointer"
+            />
+          </div>
+
+          <label className="flex items-center gap-3 text-sm text-gray-700">
+            <input
+              type="checkbox"
+              checked={tile.content.showBorder}
+              onChange={event => handleContentUpdate({ showBorder: event.target.checked })}
+              className="w-4 h-4 text-blue-600 border-gray-300 rounded"
+            />
+            <span>Pokaż obramowanie kafelka</span>
+          </label>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/admin/side editor/TilePalette.tsx
+++ b/src/components/admin/side editor/TilePalette.tsx
@@ -37,6 +37,11 @@ const TILE_TYPES: TilePaletteItem[] = [
     type: 'sequencing',
     title: 'Ćwiczenie sekwencyjne',
     icon: 'ArrowUpDown'
+  },
+  {
+    type: 'matchPairs',
+    title: 'Dopasowywanie luk',
+    icon: 'Puzzle'
   }
 ];
 

--- a/src/components/admin/side editor/TileSideEditor.tsx
+++ b/src/components/admin/side editor/TileSideEditor.tsx
@@ -1,9 +1,18 @@
 import React from 'react';
 import { Plus, Trash2, Type, X } from 'lucide-react';
-import { TextTile, ImageTile, LessonTile, ProgrammingTile, SequencingTile, QuizTile } from '../../../types/lessonEditor.ts';
+import {
+  TextTile,
+  ImageTile,
+  LessonTile,
+  ProgrammingTile,
+  SequencingTile,
+  QuizTile,
+  MatchPairsTile
+} from '../../../types/lessonEditor.ts';
 import { ImageUploadComponent } from './ImageUploadComponent.tsx';
 import { ImagePositionControl } from './ImagePositionControl.tsx';
 import { SequencingEditor } from './SequencingEditor.tsx';
+import { MatchPairsEditor } from './MatchPairsEditor.tsx';
 
 interface TileSideEditorProps {
   tile: LessonTile | undefined;
@@ -97,6 +106,7 @@ export const TileSideEditor: React.FC<TileSideEditorProps> = ({
       case 'image': return 'Edytor Obrazu';
       case 'visualization': return 'Edytor Wizualizacji';
       case 'quiz': return 'Edytor Quiz';
+      case 'matchPairs': return 'Edytor luk w tekście';
       default: return 'Edytor Kafelka';
     }
   };
@@ -263,6 +273,18 @@ export const TileSideEditor: React.FC<TileSideEditorProps> = ({
         return (
           <SequencingEditor
             tile={sequencingTile}
+            onUpdateTile={onUpdateTile}
+            isTesting={isTesting}
+            onToggleTesting={onToggleTesting}
+          />
+        );
+      }
+
+      case 'matchPairs': {
+        const matchPairsTile = tile as MatchPairsTile;
+        return (
+          <MatchPairsEditor
+            tile={matchPairsTile}
             onUpdateTile={onUpdateTile}
             isTesting={isTesting}
             onToggleTesting={onToggleTesting}

--- a/src/components/admin/top editor/TopToolbar.tsx
+++ b/src/components/admin/top editor/TopToolbar.tsx
@@ -5,7 +5,13 @@ import { FontSizeSelector } from './FontSizeSelector.tsx';
 import { TextColorPicker } from './TextColorPicker.tsx';
 import { FontSelector } from './FontSelector.tsx';
 import { AlignmentControls } from './AlignmentControls.tsx';
-import { LessonTile, ProgrammingTile, TextTile, SequencingTile } from '../../../types/lessonEditor.ts';
+import {
+  LessonTile,
+  ProgrammingTile,
+  TextTile,
+  SequencingTile,
+  MatchPairsTile
+} from '../../../types/lessonEditor.ts';
 
 
 interface TopToolbarProps {
@@ -16,7 +22,7 @@ interface TopToolbarProps {
   isTextEditing: boolean;
   onFinishTextEditing?: () => void;
   editor?: Editor | null;
-  selectedTile?: TextTile | ProgrammingTile | SequencingTile | null;
+  selectedTile?: TextTile | ProgrammingTile | SequencingTile | MatchPairsTile | null;
   onUpdateTile?: (tileId: string, updates: Partial<LessonTile>) => void;
   className?: string;
 }
@@ -165,7 +171,11 @@ export const TopToolbar: React.FC<TopToolbarProps> = ({
             selectedHorizontal={horizontalAlign}
             selectedVertical={verticalAlign}
             onHorizontalChange={handleHorizontalChange}
-            onVerticalChange={selectedTile?.type === 'programming' ? undefined : handleVerticalChange}
+            onVerticalChange={
+              selectedTile?.type === 'programming' || selectedTile?.type === 'matchPairs'
+                ? undefined
+                : handleVerticalChange
+            }
           />
           
           <div className="w-px h-6 bg-gray-300"></div>

--- a/src/services/lessonContentService.ts
+++ b/src/services/lessonContentService.ts
@@ -1,5 +1,5 @@
 import { LessonContent, LessonTile, TextTile } from '../types/lessonEditor';
-import { ProgrammingTile, SequencingTile } from '../types/lessonEditor';
+import { MatchPairsTile, ProgrammingTile, SequencingTile } from '../types/lessonEditor';
 import { GridUtils } from '../utils/gridUtils';
 import { logger } from '../utils/logger';
 
@@ -397,6 +397,75 @@ export class LessonContentService {
         ],
         correctFeedback: 'Świetnie! Prawidłowa kolejność.',
         incorrectFeedback: 'Spróbuj ponownie. Sprawdź kolejność elementów.'
+      },
+      created_at: now,
+      updated_at: now,
+      z_index: 1
+    };
+  }
+
+  /**
+   * Create a new match pairs (fill-in-the-blanks) tile
+   */
+  static createMatchPairsTile(position: { x: number; y: number }, page = 1): MatchPairsTile {
+    const id = `tile-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+    const now = new Date().toISOString();
+
+    const gridPos = GridUtils.pixelToGrid(position, {
+      width: GridUtils.GRID_COLUMNS,
+      height: 6,
+      gridSize: GridUtils.GRID_CELL_SIZE,
+      snapToGrid: true
+    });
+
+    gridPos.colSpan = 4;
+    gridPos.rowSpan = 4;
+
+    const pixelPos = GridUtils.gridToPixel(gridPos, {
+      width: GridUtils.GRID_COLUMNS,
+      height: 6,
+      gridSize: GridUtils.GRID_CELL_SIZE,
+      snapToGrid: true
+    });
+
+    const pixelSize = GridUtils.gridSizeToPixel(gridPos, {
+      width: GridUtils.GRID_COLUMNS,
+      height: 6,
+      gridSize: GridUtils.GRID_CELL_SIZE,
+      snapToGrid: true
+    });
+
+    const defaultOptions = [
+      { id: 'option-1', text: 'czyta' },
+      { id: 'option-2', text: 'cichym' },
+      { id: 'option-3', text: 'wieczorem' },
+      { id: 'option-4', text: 'głośnym' }
+    ];
+
+    return {
+      id,
+      type: 'matchPairs',
+      position: pixelPos,
+      size: pixelSize,
+      gridPosition: gridPos,
+      page,
+      content: {
+        instructions: 'Przeciągnij właściwe wyrazy do luk w tekście.',
+        richInstructions:
+          '<p style="margin: 0;">Przeciągnij właściwe wyrazy do luk w tekście.</p>',
+        fontFamily: 'Inter, system-ui, sans-serif',
+        fontSize: 16,
+        backgroundColor: '#D4D4D4',
+        showBorder: true,
+        template:
+          'Anna {{blank-1}} książkę w {{blank-2}} salonie podczas {{blank-3}}.',
+        blanks: [
+          { id: 'blank-1', label: 'Czynność', correctOptionId: 'option-1' },
+          { id: 'blank-2', label: 'Opis miejsca', correctOptionId: 'option-2' },
+          { id: 'blank-3', label: 'Czas', correctOptionId: 'option-3' }
+        ],
+        options: defaultOptions,
+        shuffleOptions: true
       },
       created_at: now,
       updated_at: now,

--- a/src/types/lessonEditor.ts
+++ b/src/types/lessonEditor.ts
@@ -17,7 +17,7 @@ export interface GridPosition {
 
 export interface LessonTile {
   id: string;
-  type: 'text' | 'image' | 'visualization' | 'quiz' | 'programming' | 'sequencing';
+  type: 'text' | 'image' | 'visualization' | 'quiz' | 'programming' | 'sequencing' | 'matchPairs';
   position: Position;
   size: Size;
   gridPosition: GridPosition;
@@ -125,6 +125,29 @@ export interface SequencingTile extends LessonTile {
     }>;
     correctFeedback: string;
     incorrectFeedback: string;
+  };
+}
+
+export interface MatchPairsTile extends LessonTile {
+  type: 'matchPairs';
+  content: {
+    instructions: string;
+    richInstructions?: string;
+    fontFamily: string;
+    fontSize: number;
+    backgroundColor: string;
+    showBorder: boolean;
+    template: string;
+    blanks: Array<{
+      id: string;
+      label: string;
+      correctOptionId: string | null;
+    }>;
+    options: Array<{
+      id: string;
+      text: string;
+    }>;
+    shuffleOptions: boolean;
   };
 }
 


### PR DESCRIPTION
## Summary
- add a Match Pairs interactive tile with drag-and-drop blanks, evaluation logic, and TaskInstructionPanel integration
- provide a dedicated side editor for configuring template text, blanks, answer bank, and styling
- register the new tile type across lesson creation, palette, renderer, toolbar, and default service factory

## Testing
- npm run lint *(fails: pre-existing lint issues in unrelated files)*
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dadbdcabc48321aab08569aabe431d