### PR TITLE
Add match pairs fill-in tile

### DIFF
--- a/src/Pages/LessonEditor.tsx
+++ b/src/Pages/LessonEditor.tsx
@@ -1,8 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { ArrowLeft, Save, RotateCcw, Grid, Edit } from 'lucide-react';
 import { Lesson, Course } from '../types/course.ts';
-import { LessonContent, LessonTile, ProgrammingTile, TextTile } from '../types/lessonEditor.ts';
-import { SequencingTile } from '../types/lessonEditor.ts';
+import { LessonContent, LessonTile, ProgrammingTile, TextTile, SequencingTile, MatchPairsTile } from '../types/lessonEditor.ts';
 import { useLessonEditor } from '../hooks/useLessonEditor.ts';
 import { LessonContentService } from '../services/lessonContentService.ts';
 import { TilePalette } from '../components/admin/side editor/TilePalette.tsx';
@@ -24,8 +23,13 @@ interface LessonEditorProps {
   onBack: () => void;
 }
 
-const isRichTextTile = (tile: LessonTile | null): tile is TextTile | ProgrammingTile | SequencingTile => {
-  return !!tile && (tile.type === 'text' || tile.type === 'programming' || tile.type === 'sequencing');
+const isRichTextTile = (
+  tile: LessonTile | null
+): tile is TextTile | ProgrammingTile | SequencingTile | MatchPairsTile => {
+  return (
+    !!tile &&
+    (tile.type === 'text' || tile.type === 'programming' || tile.type === 'sequencing' || tile.type === 'matchPairs')
+  );
 };
 
 export const LessonEditor: React.FC<LessonEditorProps> = ({ lesson, course, onBack }) => {
@@ -253,6 +257,9 @@ export const LessonEditor: React.FC<LessonEditorProps> = ({ lesson, course, onBa
       case 'sequencing':
         newTile = LessonContentService.createSequencingTile(position, currentPage);
         break;
+      case 'matchPairs':
+        newTile = LessonContentService.createMatchPairsTile(position, currentPage);
+        break;
       default:
         logger.warn(`Tile type ${tileType} not implemented yet`);
         warning('Funkcja niedostępna', `Typ kafelka "${tileType}" nie jest jeszcze dostępny`);
@@ -313,7 +320,10 @@ export const LessonEditor: React.FC<LessonEditorProps> = ({ lesson, course, onBa
         };
 
         // Special handling for text-based tiles to ensure content properties are merged
-        if ((tile.type === 'text' || tile.type === 'programming' || tile.type === 'sequencing') && updates.content) {
+        if (
+          (tile.type === 'text' || tile.type === 'programming' || tile.type === 'sequencing' || tile.type === 'matchPairs') &&
+          updates.content
+        ) {
           updatedTile.content = {
             ...tile.content,
             ...updates.content

--- a/src/components/admin/MatchPairsInteractive.tsx
+++ b/src/components/admin/MatchPairsInteractive.tsx
@@ -1,0 +1,727 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Puzzle,
+  PackageOpen,
+  Sparkles,
+  CheckCircle,
+  XCircle,
+  RotateCcw,
+  X,
+  ArrowLeftRight
+} from 'lucide-react';
+import { MatchPairsTile, MatchPairsOption } from '../../types/lessonEditor';
+import { TaskInstructionPanel } from './common/TaskInstructionPanel';
+
+interface MatchPairsInteractiveProps {
+  tile: MatchPairsTile;
+  isPreview?: boolean;
+  isTestingMode?: boolean;
+  onRequestTextEditing?: () => void;
+  instructionContent?: React.ReactNode;
+  variant?: 'embedded' | 'standalone';
+}
+
+interface DragData {
+  type: 'match-option';
+  optionId: string;
+  source: 'pool' | 'blank';
+  blankId?: string;
+}
+
+type TemplateSegment =
+  | { type: 'text'; value: string }
+  | { type: 'blank'; blankId: string };
+
+const hexToRgb = (hex: string): { r: number; g: number; b: number } | null => {
+  if (!hex) return null;
+
+  let normalized = hex.replace('#', '').trim();
+  if (normalized.length === 3) {
+    normalized = normalized
+      .split('')
+      .map(char => `${char}${char}`)
+      .join('');
+  }
+
+  if (normalized.length !== 6) return null;
+
+  const intValue = Number.parseInt(normalized, 16);
+  if (Number.isNaN(intValue)) return null;
+
+  return {
+    r: (intValue >> 16) & 255,
+    g: (intValue >> 8) & 255,
+    b: intValue & 255
+  };
+};
+
+const channelToLinear = (value: number): number => {
+  const scaled = value / 255;
+  return scaled <= 0.03928 ? scaled / 12.92 : Math.pow((scaled + 0.055) / 1.055, 2.4);
+};
+
+const getReadableTextColor = (hex: string): string => {
+  const rgb = hexToRgb(hex);
+  if (!rgb) return '#0f172a';
+
+  const luminance =
+    0.2126 * channelToLinear(rgb.r) +
+    0.7152 * channelToLinear(rgb.g) +
+    0.0722 * channelToLinear(rgb.b);
+
+  return luminance > 0.6 ? '#0f172a' : '#f8fafc';
+};
+
+const lightenColor = (hex: string, amount: number): string => {
+  const rgb = hexToRgb(hex);
+  if (!rgb) return hex;
+
+  const lightenChannel = (channel: number) => Math.round(channel + (255 - channel) * amount);
+  return `rgb(${lightenChannel(rgb.r)}, ${lightenChannel(rgb.g)}, ${lightenChannel(rgb.b)})`;
+};
+
+const darkenColor = (hex: string, amount: number): string => {
+  const rgb = hexToRgb(hex);
+  if (!rgb) return hex;
+
+  const darkenChannel = (channel: number) => Math.round(channel * (1 - amount));
+  return `rgb(${darkenChannel(rgb.r)}, ${darkenChannel(rgb.g)}, ${darkenChannel(rgb.b)})`;
+};
+
+const surfaceColor = (accent: string, textColor: string, lightenAmount: number, darkenAmount: number): string =>
+  textColor === '#0f172a' ? lightenColor(accent, lightenAmount) : darkenColor(accent, darkenAmount);
+
+// Convert the author-facing template string (with [[blank-id]] placeholders)
+// into a renderable sequence of text and interactive blank segments.
+const parseTemplate = (template: string): TemplateSegment[] => {
+  if (!template) return [];
+
+  const segments: TemplateSegment[] = [];
+  const regex = /\[\[([^\]]+)\]\]/g;
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = regex.exec(template)) !== null) {
+    if (match.index > lastIndex) {
+      segments.push({ type: 'text', value: template.slice(lastIndex, match.index) });
+    }
+    segments.push({ type: 'blank', blankId: match[1].trim() });
+    lastIndex = regex.lastIndex;
+  }
+
+  if (lastIndex < template.length) {
+    segments.push({ type: 'text', value: template.slice(lastIndex) });
+  }
+
+  if (segments.length === 0) {
+    segments.push({ type: 'text', value: template });
+  }
+
+  return segments;
+};
+
+// Ensure we never render duplicate options in the bank while keeping the
+// original author defined ordering (and a graceful alphabetical fallback).
+const dedupeAndSortOptions = (
+  options: MatchPairsOption[],
+  referenceOrder: string[],
+  locale: string
+): MatchPairsOption[] => {
+  const seen = new Set<string>();
+  const filtered: MatchPairsOption[] = [];
+
+  for (const option of options) {
+    if (!seen.has(option.id)) {
+      seen.add(option.id);
+      filtered.push(option);
+    }
+  }
+
+  return filtered.sort((a, b) => {
+    const indexA = referenceOrder.indexOf(a.id);
+    const indexB = referenceOrder.indexOf(b.id);
+
+    if (indexA === -1 && indexB === -1) {
+      return a.text.localeCompare(b.text, locale);
+    }
+
+    if (indexA === -1) return 1;
+    if (indexB === -1) return -1;
+    return indexA - indexB;
+  });
+};
+
+export const MatchPairsInteractive: React.FC<MatchPairsInteractiveProps> = ({
+  tile,
+  isPreview = false,
+  isTestingMode = false,
+  onRequestTextEditing,
+  instructionContent,
+  variant = 'embedded'
+}) => {
+  const canInteract = !isPreview;
+
+  const optionOrder = useMemo(() => tile.content.options.map(option => option.id), [tile.content.options]);
+  const [availableOptions, setAvailableOptions] = useState<MatchPairsOption[]>(() =>
+    dedupeAndSortOptions(tile.content.options, optionOrder, 'pl')
+  );
+  // Store which option is currently placed in every blank. This makes it easy
+  // to validate the task and to return options to the bank without mutation.
+  const [assignments, setAssignments] = useState<Record<string, MatchPairsOption | null>>(() => {
+    const initial: Record<string, MatchPairsOption | null> = {};
+    tile.content.blanks.forEach(blank => {
+      initial[blank.id] = null;
+    });
+    return initial;
+  });
+  const [draggingOptionId, setDraggingOptionId] = useState<string | null>(null);
+  const [dragOverBlankId, setDragOverBlankId] = useState<string | null>(null);
+  const [isBankHighlighted, setIsBankHighlighted] = useState(false);
+  const [isChecked, setIsChecked] = useState(false);
+  const [isCorrect, setIsCorrect] = useState<boolean | null>(null);
+  const [attempts, setAttempts] = useState(0);
+  const [wasIncompleteAttempt, setWasIncompleteAttempt] = useState(false);
+
+  // Reset drag & drop state whenever the author changes the exercise content
+  // (or when the editor toggles testing mode).
+  const initializeState = useCallback(() => {
+    setAvailableOptions(dedupeAndSortOptions(tile.content.options, optionOrder, 'pl'));
+    setAssignments(() => {
+      const initial: Record<string, MatchPairsOption | null> = {};
+      tile.content.blanks.forEach(blank => {
+        initial[blank.id] = null;
+      });
+      return initial;
+    });
+    setDraggingOptionId(null);
+    setDragOverBlankId(null);
+    setIsBankHighlighted(false);
+    setIsChecked(false);
+    setIsCorrect(null);
+    setWasIncompleteAttempt(false);
+    setAttempts(0);
+  }, [optionOrder, tile.content.blanks, tile.content.options]);
+
+  useEffect(() => {
+    initializeState();
+  }, [initializeState]);
+
+  // Fast lookup map for the option metadata, used every time the user drops a tile.
+  const optionMap = useMemo(() => {
+    const map = new Map<string, MatchPairsOption>();
+    tile.content.options.forEach(option => {
+      map.set(option.id, option);
+    });
+    return map;
+  }, [tile.content.options]);
+
+  const accentColor = tile.content.backgroundColor || '#2563eb';
+  const textColor = useMemo(() => getReadableTextColor(accentColor), [accentColor]);
+  const gradientStart = useMemo(() => lightenColor(accentColor, 0.06), [accentColor]);
+  const gradientEnd = useMemo(() => darkenColor(accentColor, 0.06), [accentColor]);
+  const frameBorderColor = useMemo(() => surfaceColor(accentColor, textColor, 0.45, 0.6), [accentColor, textColor]);
+  const panelBackground = useMemo(() => surfaceColor(accentColor, textColor, 0.65, 0.45), [accentColor, textColor]);
+  const panelBorder = useMemo(() => surfaceColor(accentColor, textColor, 0.5, 0.55), [accentColor, textColor]);
+  const iconBackground = useMemo(() => surfaceColor(accentColor, textColor, 0.55, 0.5), [accentColor, textColor]);
+  const mutedLabelColor = textColor === '#0f172a' ? '#475569' : '#e2e8f0';
+  const subtleCaptionColor = textColor === '#0f172a' ? '#334155' : '#e2e8f0';
+  const blankEmptyBackground = useMemo(() => surfaceColor(accentColor, textColor, 0.64, 0.35), [accentColor, textColor]);
+  const blankEmptyBorder = useMemo(() => surfaceColor(accentColor, textColor, 0.48, 0.55), [accentColor, textColor]);
+  const blankHoverBackground = useMemo(() => surfaceColor(accentColor, textColor, 0.72, 0.3), [accentColor, textColor]);
+  const blankHoverBorder = useMemo(() => surfaceColor(accentColor, textColor, 0.58, 0.45), [accentColor, textColor]);
+  const blankFilledBackground = useMemo(() => surfaceColor(accentColor, textColor, 0.52, 0.42), [accentColor, textColor]);
+  const blankFilledBorder = useMemo(() => surfaceColor(accentColor, textColor, 0.45, 0.55), [accentColor, textColor]);
+  const bankBackground = useMemo(() => surfaceColor(accentColor, textColor, 0.6, 0.42), [accentColor, textColor]);
+  const bankBorder = useMemo(() => surfaceColor(accentColor, textColor, 0.48, 0.5), [accentColor, textColor]);
+  const bankHighlightBackground = useMemo(() => surfaceColor(accentColor, textColor, 0.7, 0.34), [accentColor, textColor]);
+  const bankHighlightBorder = useMemo(() => surfaceColor(accentColor, textColor, 0.58, 0.45), [accentColor, textColor]);
+  const chipBackground = useMemo(() => surfaceColor(accentColor, textColor, 0.54, 0.48), [accentColor, textColor]);
+  const chipBorder = useMemo(() => surfaceColor(accentColor, textColor, 0.45, 0.58), [accentColor, textColor]);
+
+  // Start dragging either from the bank or from a filled blank.
+  const handleDragStart = (event: React.DragEvent, optionId: string, source: 'pool' | 'blank', blankId?: string) => {
+    if (!canInteract) return;
+
+    const data: DragData = {
+      type: 'match-option',
+      optionId,
+      source,
+      blankId
+    };
+    event.dataTransfer.setData('application/json', JSON.stringify(data));
+    event.dataTransfer.effectAllowed = 'move';
+    setDraggingOptionId(optionId);
+  };
+
+  const handleDragEnd = () => {
+    setDraggingOptionId(null);
+    setDragOverBlankId(null);
+    setIsBankHighlighted(false);
+  };
+
+  const parseDragData = (event: React.DragEvent): DragData | null => {
+    try {
+      const json = event.dataTransfer.getData('application/json');
+      if (!json) return null;
+      const data = JSON.parse(json) as DragData;
+      return data.type === 'match-option' ? data : null;
+    } catch (error) {
+      return null;
+    }
+  };
+
+  const handleBlankDragOver = (event: React.DragEvent, blankId: string) => {
+    if (!canInteract) return;
+    event.preventDefault();
+    event.dataTransfer.dropEffect = 'move';
+    setDragOverBlankId(blankId);
+  };
+
+  const handleBlankDragLeave = (blankId: string) => {
+    if (dragOverBlankId === blankId) {
+      setDragOverBlankId(null);
+    }
+  };
+
+  // Accept drop events on a blank, moving the option and returning the previous
+  // assignment (if any) back to the bank.
+  const handleDropOnBlank = (event: React.DragEvent, blankId: string) => {
+    if (!canInteract) return;
+    event.preventDefault();
+    setDragOverBlankId(null);
+
+    const data = parseDragData(event);
+    if (!data) return;
+    if (data.source === 'blank' && data.blankId === blankId) return;
+
+    const option = optionMap.get(data.optionId);
+    if (!option) return;
+
+    setAssignments(prevAssignments => {
+      const previousOption = prevAssignments[blankId];
+      const updated: Record<string, MatchPairsOption | null> = { ...prevAssignments };
+
+      if (data.source === 'blank' && data.blankId) {
+        updated[data.blankId] = null;
+      }
+
+      updated[blankId] = option;
+
+      setAvailableOptions(prevOptions => {
+        let updatedOptions = prevOptions;
+
+        if (data.source === 'pool') {
+          updatedOptions = prevOptions.filter(opt => opt.id !== option.id);
+        }
+
+        if (data.source === 'blank' && data.blankId && data.blankId !== blankId) {
+          updatedOptions = prevOptions.filter(opt => opt.id !== option.id);
+        }
+
+        if (previousOption && previousOption.id !== option.id) {
+          updatedOptions = [...updatedOptions, previousOption];
+        }
+
+        return dedupeAndSortOptions(updatedOptions, optionOrder, 'pl');
+      });
+
+      return updated;
+    });
+
+    setIsChecked(false);
+    setIsCorrect(null);
+    setWasIncompleteAttempt(false);
+  };
+
+  const handlePoolDragOver = (event: React.DragEvent) => {
+    if (!canInteract) return;
+    event.preventDefault();
+    event.dataTransfer.dropEffect = 'move';
+    setIsBankHighlighted(true);
+  };
+
+  const handlePoolDragLeave = () => {
+    setIsBankHighlighted(false);
+  };
+
+  // Allow learners to drag options back to the bank when they want to retry.
+  const handleDropToPool = (event: React.DragEvent) => {
+    if (!canInteract) return;
+    event.preventDefault();
+    setIsBankHighlighted(false);
+
+    const data = parseDragData(event);
+    if (!data || data.source !== 'blank' || !data.blankId) return;
+
+    setAssignments(prevAssignments => {
+      const option = prevAssignments[data.blankId];
+      if (!option) return prevAssignments;
+
+      const updated: Record<string, MatchPairsOption | null> = {
+        ...prevAssignments,
+        [data.blankId]: null
+      };
+
+      setAvailableOptions(prevOptions =>
+        dedupeAndSortOptions([...prevOptions, option], optionOrder, 'pl')
+      );
+
+      return updated;
+    });
+
+    setIsChecked(false);
+    setIsCorrect(null);
+    setWasIncompleteAttempt(false);
+  };
+
+  const handleClearBlank = (blankId: string) => {
+    if (!canInteract) return;
+
+    setAssignments(prevAssignments => {
+      const option = prevAssignments[blankId];
+      if (!option) return prevAssignments;
+
+      const updated: Record<string, MatchPairsOption | null> = {
+        ...prevAssignments,
+        [blankId]: null
+      };
+
+      setAvailableOptions(prevOptions =>
+        dedupeAndSortOptions([...prevOptions, option], optionOrder, 'pl')
+      );
+
+      return updated;
+    });
+
+    setIsChecked(false);
+    setIsCorrect(null);
+    setWasIncompleteAttempt(false);
+  };
+
+  const handleCheck = () => {
+    if (!canInteract) return;
+
+    const isComplete = tile.content.blanks.every(blank => assignments[blank.id]);
+    const result =
+      isComplete &&
+      tile.content.blanks.every(
+        blank => assignments[blank.id]?.id === (blank.correctOptionId ?? undefined)
+      );
+
+    setAttempts(prev => prev + 1);
+    setIsChecked(true);
+    setIsCorrect(result);
+    setWasIncompleteAttempt(!isComplete);
+  };
+
+  const handleReset = () => {
+    if (!canInteract) return;
+    initializeState();
+  };
+
+  const segments = useMemo(() => parseTemplate(tile.content.textTemplate), [tile.content.textTemplate]);
+
+  const feedbackMessage = useMemo(() => {
+    if (!isChecked) return null;
+
+    if (wasIncompleteAttempt) {
+      return {
+        tone: 'warning' as const,
+        text: 'Uzupełnij wszystkie luki, aby sprawdzić odpowiedź.'
+      };
+    }
+
+    if (isCorrect) {
+      return {
+        tone: 'success' as const,
+        text: tile.content.correctFeedback
+      };
+    }
+
+    return {
+      tone: 'error' as const,
+      text: tile.content.incorrectFeedback
+    };
+  }, [isChecked, isCorrect, tile.content.correctFeedback, tile.content.incorrectFeedback, wasIncompleteAttempt]);
+
+  const feedbackStyles = useMemo(() => {
+    if (!feedbackMessage) return null;
+
+    switch (feedbackMessage.tone) {
+      case 'success':
+        return {
+          icon: <CheckCircle className="w-4 h-4" />,
+          background: textColor === '#0f172a' ? '#f0fdf4' : 'rgba(12, 54, 26, 0.4)',
+          border: textColor === '#0f172a' ? '#86efac' : 'rgba(148, 226, 188, 0.65)',
+          color: textColor === '#0f172a' ? '#166534' : '#f0fdf4'
+        };
+      case 'warning':
+        return {
+          icon: <ArrowLeftRight className="w-4 h-4" />,
+          background: textColor === '#0f172a' ? '#fef3c7' : 'rgba(68, 56, 10, 0.5)',
+          border: textColor === '#0f172a' ? '#facc15' : 'rgba(255, 221, 89, 0.75)',
+          color: textColor === '#0f172a' ? '#92400e' : '#fef9c3'
+        };
+      default:
+        return {
+          icon: <XCircle className="w-4 h-4" />,
+          background: textColor === '#0f172a' ? '#fee2e2' : 'rgba(76, 17, 17, 0.5)',
+          border: textColor === '#0f172a' ? '#fca5a5' : 'rgba(254, 202, 202, 0.75)',
+          color: textColor === '#0f172a' ? '#7f1d1d' : '#fee2e2'
+        };
+    }
+  }, [feedbackMessage, textColor]);
+
+  const showBorder = tile.content.showBorder ?? true;
+  const isEmbedded = variant === 'embedded';
+
+  return (
+    <div
+      className={`w-full h-full flex flex-col gap-5 ${showBorder ? 'border rounded-3xl' : 'rounded-3xl'} p-5`}
+      style={{
+        backgroundColor: isEmbedded ? 'transparent' : accentColor,
+        backgroundImage: isEmbedded ? undefined : `linear-gradient(135deg, ${gradientStart}, ${gradientEnd})`,
+        color: textColor,
+        borderColor: !isEmbedded && showBorder ? frameBorderColor : undefined,
+        boxShadow: isEmbedded ? undefined : '0 24px 40px rgba(15, 23, 42, 0.22)'
+      }}
+    >
+      <TaskInstructionPanel
+        icon={<Puzzle className="w-4 h-4" />}
+        label="Instrukcja"
+        className="border"
+        style={{
+          backgroundColor: panelBackground,
+          borderColor: panelBorder,
+          color: textColor
+        }}
+        iconWrapperClassName="w-9 h-9 rounded-xl flex items-center justify-center shadow-sm"
+        iconWrapperStyle={{
+          backgroundColor: iconBackground,
+          color: textColor
+        }}
+        labelStyle={{ color: mutedLabelColor }}
+        bodyClassName="px-5 pb-5"
+      >
+        {instructionContent ?? (
+          <div
+            className="text-base leading-relaxed"
+            style={{
+              fontFamily: tile.content.fontFamily,
+              fontSize: `${tile.content.fontSize}px`,
+              whiteSpace: 'pre-wrap'
+            }}
+            dangerouslySetInnerHTML={{
+              __html: tile.content.richInstruction || tile.content.instruction
+            }}
+            onDoubleClick={onRequestTextEditing}
+          />
+        )}
+      </TaskInstructionPanel>
+
+      {(isTestingMode || attempts > 0) && (
+        <div className="flex items-center gap-3 text-xs uppercase tracking-[0.28em]" style={{ color: subtleCaptionColor }}>
+          {isTestingMode && <span>Tryb testowania</span>}
+          {attempts > 0 && <span>Próba #{attempts}</span>}
+        </div>
+      )}
+
+      <div className="flex-1 flex flex-col gap-5 overflow-hidden">
+        <div
+          className="rounded-2xl border flex-1 px-5 py-4 overflow-auto"
+          style={{ backgroundColor: panelBackground, borderColor: panelBorder }}
+        >
+          {segments.length === 0 ? (
+            <div className="h-full flex items-center justify-center text-sm" style={{ color: subtleCaptionColor }}>
+              Dodaj treść ćwiczenia, aby pojawiły się luki.
+            </div>
+          ) : (
+            <p
+              className="text-base leading-relaxed"
+              style={{
+                fontFamily: tile.content.fontFamily,
+                fontSize: `${tile.content.fontSize}px`,
+                whiteSpace: 'pre-wrap'
+              }}
+            >
+              {segments.map((segment, index) => {
+                if (segment.type === 'text') {
+                  return <React.Fragment key={`text-${index}`}>{segment.value}</React.Fragment>;
+                }
+
+                const blank = tile.content.blanks.find(b => b.id === segment.blankId);
+                const assignedOption = assignments[segment.blankId];
+
+                if (!blank) {
+                  return (
+                    <span key={`missing-${index}`} className="inline-block align-middle mx-1">
+                      <span
+                        className="px-3 py-2 rounded-lg border text-xs font-medium"
+                        style={{
+                          backgroundColor: blankEmptyBackground,
+                          borderColor: blankEmptyBorder,
+                          color: subtleCaptionColor
+                        }}
+                      >
+                        [[{segment.blankId}]]
+                      </span>
+                    </span>
+                  );
+                }
+
+                const isDragOver = dragOverBlankId === segment.blankId;
+                const hasValue = Boolean(assignedOption);
+
+                return (
+                  <span key={`blank-${segment.blankId}`} className="inline-block align-middle mx-1">
+                    <div
+                      className={`group relative inline-flex items-center gap-2 px-4 py-2 rounded-xl border-2 transition-all ${
+                        hasValue ? 'shadow-sm' : ''
+                      } ${canInteract ? 'cursor-pointer' : 'cursor-default'}`}
+                      style={{
+                        backgroundColor: hasValue
+                          ? blankFilledBackground
+                          : isDragOver
+                          ? blankHoverBackground
+                          : blankEmptyBackground,
+                        borderColor: hasValue
+                          ? blankFilledBorder
+                          : isDragOver
+                          ? blankHoverBorder
+                          : blankEmptyBorder,
+                        color: hasValue ? textColor : subtleCaptionColor,
+                        minWidth: 120,
+                        minHeight: 40
+                      }}
+                      onDoubleClick={onRequestTextEditing}
+                      draggable={Boolean(assignedOption) && canInteract}
+                      onDragStart={event =>
+                        assignedOption && handleDragStart(event, assignedOption.id, 'blank', segment.blankId)
+                      }
+                      onDragEnd={handleDragEnd}
+                      onDragOver={event => handleBlankDragOver(event, segment.blankId)}
+                      onDragLeave={() => handleBlankDragLeave(segment.blankId)}
+                      onDrop={event => handleDropOnBlank(event, segment.blankId)}
+                    >
+                      <div className="flex flex-col text-left">
+                        <span className="text-[11px] uppercase tracking-[0.2em]" style={{ color: mutedLabelColor }}>
+                          {blank.label}
+                        </span>
+                        <span className="text-sm font-semibold" style={{ color: hasValue ? textColor : subtleCaptionColor }}>
+                          {assignedOption ? assignedOption.text : 'Przeciągnij słowo'}
+                        </span>
+                      </div>
+
+                      {assignedOption && canInteract && (
+                        <button
+                          type="button"
+                          onClick={() => handleClearBlank(segment.blankId)}
+                          className="absolute -top-2 -right-2 w-6 h-6 rounded-full bg-white/80 text-slate-500 hover:text-slate-700 hover:bg-white flex items-center justify-center shadow-sm"
+                        >
+                          <X className="w-3 h-3" />
+                        </button>
+                      )}
+                    </div>
+                  </span>
+                );
+              })}
+            </p>
+          )}
+        </div>
+
+        <div
+          className="rounded-2xl border px-5 py-4 transition-colors"
+          style={{
+            backgroundColor: isBankHighlighted ? bankHighlightBackground : bankBackground,
+            borderColor: isBankHighlighted ? bankHighlightBorder : bankBorder
+          }}
+          onDragOver={handlePoolDragOver}
+          onDragLeave={handlePoolDragLeave}
+          onDrop={handleDropToPool}
+        >
+          <div className="flex items-center justify-between mb-4">
+            <div className="flex items-center gap-2 text-sm font-semibold" style={{ color: subtleCaptionColor }}>
+              <PackageOpen className="w-4 h-4" />
+              <span>Bank słów</span>
+            </div>
+            <span className="text-xs" style={{ color: mutedLabelColor }}>
+              Przeciągnij słowa do odpowiednich luk
+            </span>
+          </div>
+
+          <div className="flex flex-wrap gap-3">
+            {availableOptions.length === 0 ? (
+              <div
+                className="flex flex-col items-center justify-center gap-2 text-center text-sm py-6 flex-1"
+                style={{ color: subtleCaptionColor }}
+              >
+                <Sparkles className="w-5 h-5" />
+                <span>Świetnie! Wszystkie słowa zostały już użyte.</span>
+              </div>
+            ) : (
+              availableOptions.map(option => (
+                <div
+                  key={option.id}
+                  draggable={canInteract}
+                  onDragStart={event => handleDragStart(event, option.id, 'pool')}
+                  onDragEnd={handleDragEnd}
+                  className={`px-4 py-2 rounded-xl border-2 text-sm font-semibold transition-all ${
+                    draggingOptionId === option.id ? 'opacity-70 scale-95' : 'hover:shadow-md'
+                  } ${canInteract ? 'cursor-grab active:cursor-grabbing' : 'cursor-not-allowed opacity-70'}`}
+                  style={{
+                    backgroundColor: chipBackground,
+                    borderColor: chipBorder,
+                    color: textColor
+                  }}
+                >
+                  {option.text}
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+      </div>
+
+      {feedbackMessage && feedbackStyles && (
+        <div
+          className="rounded-2xl border px-4 py-3 flex items-center gap-3"
+          style={{
+            backgroundColor: feedbackStyles.background,
+            borderColor: feedbackStyles.border,
+            color: feedbackStyles.color
+          }}
+        >
+          <span className="flex items-center justify-center w-8 h-8 rounded-full border" style={{ borderColor: feedbackStyles.color }}>
+            {feedbackStyles.icon}
+          </span>
+          <p className="text-sm leading-relaxed">{feedbackMessage.text}</p>
+        </div>
+      )}
+
+      <div className="flex items-center justify-between pt-2">
+        <button
+          type="button"
+          onClick={handleReset}
+          disabled={!canInteract}
+          className="inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-white/30 text-sm font-medium text-white/80 hover:text-white hover:bg-white/10 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          <RotateCcw className="w-4 h-4" />
+          Resetuj
+        </button>
+        <button
+          type="button"
+          onClick={handleCheck}
+          disabled={!canInteract}
+          className="inline-flex items-center gap-2 px-5 py-2 rounded-lg text-sm font-semibold shadow-md transition-colors"
+          style={{
+            backgroundColor: darkenColor(accentColor, 0.15),
+            color: '#f8fafc'
+          }}
+        >
+          <CheckCircle className="w-4 h-4" />
+          Sprawdź odpowiedź
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/src/components/admin/side editor/MatchPairsEditor.tsx
+++ b/src/components/admin/side editor/MatchPairsEditor.tsx
@@ -1,0 +1,336 @@
+import React, { useRef } from 'react';
+import { Plus, Trash2, Sparkles, Square, Brackets, Info } from 'lucide-react';
+import { MatchPairsTile } from '../../../types/lessonEditor.ts';
+
+interface MatchPairsEditorProps {
+  tile: MatchPairsTile;
+  onUpdateTile: (tileId: string, updates: Partial<MatchPairsTile>) => void;
+  isTesting?: boolean;
+  onToggleTesting?: (tileId: string) => void;
+}
+
+export const MatchPairsEditor: React.FC<MatchPairsEditorProps> = ({
+  tile,
+  onUpdateTile,
+  isTesting = false,
+  onToggleTesting
+}) => {
+  const templateRef = useRef<HTMLTextAreaElement | null>(null);
+
+  const updateContent = (updates: Partial<MatchPairsTile['content']>) => {
+    onUpdateTile(tile.id, {
+      content: {
+        ...tile.content,
+        ...updates
+      },
+      updated_at: new Date().toISOString()
+    });
+  };
+
+  const handleContentUpdate = <K extends keyof MatchPairsTile['content']>(field: K, value: MatchPairsTile['content'][K]) => {
+    updateContent({ [field]: value } as Partial<MatchPairsTile['content']>);
+  };
+
+  const handleTemplateChange = (value: string) => {
+    handleContentUpdate('textTemplate', value);
+  };
+
+  // Allow authors to quickly insert placeholder markers at the caret position.
+  const insertPlaceholder = (blankId: string) => {
+    const placeholder = `[[${blankId}]]`;
+    const textarea = templateRef.current;
+
+    if (textarea) {
+      const { selectionStart, selectionEnd, value } = textarea;
+      const newValue = `${value.slice(0, selectionStart)}${placeholder}${value.slice(selectionEnd)}`;
+      handleTemplateChange(newValue);
+
+      requestAnimationFrame(() => {
+        textarea.focus();
+        const cursorPosition = selectionStart + placeholder.length;
+        textarea.selectionStart = cursorPosition;
+        textarea.selectionEnd = cursorPosition;
+      });
+    } else {
+      handleTemplateChange(`${tile.content.textTemplate} ${placeholder}`.trim());
+    }
+  };
+
+  const addBlank = () => {
+    const newBlankId = `blank-${Date.now()}`;
+    const updatedBlanks = [
+      ...tile.content.blanks,
+      { id: newBlankId, label: `Nowa luka ${tile.content.blanks.length + 1}`, correctOptionId: null }
+    ];
+
+    updateContent({
+      blanks: updatedBlanks,
+      textTemplate: `${tile.content.textTemplate}${tile.content.textTemplate ? ' ' : ''}[[${newBlankId}]]`
+    });
+  };
+
+  // Removing a blank also purges any stale markers from the template string.
+  const removeBlank = (blankId: string) => {
+    const updatedBlanks = tile.content.blanks.filter(blank => blank.id !== blankId);
+    const cleanedTemplate = tile.content.textTemplate.replace(new RegExp(`\\[\\[${blankId}\\]\\]`, 'g'), '');
+
+    updateContent({
+      blanks: updatedBlanks,
+      textTemplate: cleanedTemplate
+    });
+  };
+
+  const updateBlankLabel = (blankId: string, value: string) => {
+    const updatedBlanks = tile.content.blanks.map(blank =>
+      blank.id === blankId ? { ...blank, label: value } : blank
+    );
+    handleContentUpdate('blanks', updatedBlanks);
+  };
+
+  const updateBlankCorrectOption = (blankId: string, optionId: string | null) => {
+    const updatedBlanks = tile.content.blanks.map(blank =>
+      blank.id === blankId ? { ...blank, correctOptionId: optionId } : blank
+    );
+    handleContentUpdate('blanks', updatedBlanks);
+  };
+
+  const addOption = () => {
+    const newOptionId = `option-${Date.now()}`;
+    const updatedOptions = [
+      ...tile.content.options,
+      { id: newOptionId, text: `Nowe słowo ${tile.content.options.length + 1}` }
+    ];
+    handleContentUpdate('options', updatedOptions);
+  };
+
+  const updateOptionText = (optionId: string, value: string) => {
+    const updatedOptions = tile.content.options.map(option =>
+      option.id === optionId ? { ...option, text: value } : option
+    );
+    handleContentUpdate('options', updatedOptions);
+  };
+
+  const removeOption = (optionId: string) => {
+    const updatedOptions = tile.content.options.filter(option => option.id !== optionId);
+    const updatedBlanks = tile.content.blanks.map(blank => ({
+      ...blank,
+      correctOptionId: blank.correctOptionId === optionId ? null : blank.correctOptionId
+    }));
+    updateContent({ options: updatedOptions, blanks: updatedBlanks });
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="p-4 rounded-lg border border-gray-200 bg-white shadow-sm">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <h3 className="text-sm font-semibold text-gray-900">Tryb testowania</h3>
+            <p className="text-xs text-gray-600 mt-1">
+              {isTesting
+                ? 'Tryb ucznia jest aktywny. Kafelek na płótnie jest zablokowany przed przypadkową edycją.'
+                : 'Wyłącz interakcje edycyjne kafelka i sprawdź zadanie dokładnie tak, jak zobaczy je uczeń.'}
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => onToggleTesting?.(tile.id)}
+            disabled={!onToggleTesting}
+            className={`inline-flex items-center gap-2 px-3 py-2 text-xs font-medium rounded-lg transition-colors shadow-sm ${
+              isTesting
+                ? 'bg-slate-900 text-white hover:bg-slate-800'
+                : 'bg-blue-600 text-white hover:bg-blue-500'
+            } disabled:opacity-60 disabled:cursor-not-allowed`}
+          >
+            {isTesting ? <Square className="w-4 h-4" /> : <Sparkles className="w-4 h-4" />}
+            <span>{isTesting ? 'Zakończ testowanie' : 'Przetestuj zadanie'}</span>
+          </button>
+        </div>
+      </div>
+
+      <div className="space-y-3">
+        <label className="block text-sm font-medium text-gray-700">Tekst zadania z lukami</label>
+        <textarea
+          ref={templateRef}
+          value={tile.content.textTemplate}
+          onChange={(e) => handleTemplateChange(e.target.value)}
+          rows={6}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm"
+          placeholder="Np. Zdanie z [[blank-1]] lukami i [[blank-2]] słowami."
+        />
+        <div className="flex items-start gap-2 text-xs text-gray-600 bg-blue-50 border border-blue-100 rounded-lg p-3">
+          <Info className="w-4 h-4 text-blue-500 mt-0.5" />
+          <p>
+            Użyj składni <code className="bg-white px-1 py-0.5 rounded border">[[identyfikator-luki]]</code> aby wstawić miejsce na słowo.
+            Przyciski przy każdej luce pozwalają wstawić odpowiedni znacznik dokładnie w miejscu kursora.
+          </p>
+        </div>
+      </div>
+
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <h4 className="text-sm font-semibold text-gray-900">Luki ({tile.content.blanks.length})</h4>
+          <button
+            type="button"
+            onClick={addBlank}
+            className="inline-flex items-center gap-2 px-3 py-1.5 bg-blue-600 text-white text-xs rounded-lg hover:bg-blue-700 transition-colors"
+          >
+            <Plus className="w-3 h-3" />
+            Dodaj lukę
+          </button>
+        </div>
+
+        <div className="space-y-3">
+          {tile.content.blanks.map((blank, index) => (
+            <div key={blank.id} className="p-3 border border-gray-200 rounded-lg bg-white shadow-sm">
+              <div className="flex items-center justify-between mb-2">
+                <span className="text-xs font-medium text-gray-500 uppercase tracking-wide">Luka {index + 1}</span>
+                <button
+                  type="button"
+                  onClick={() => removeBlank(blank.id)}
+                  className="text-xs text-red-500 hover:text-red-600 inline-flex items-center gap-1"
+                >
+                  <Trash2 className="w-3 h-3" />
+                  Usuń
+                </button>
+              </div>
+
+              <div className="space-y-3">
+                <div>
+                  <label className="block text-xs font-medium text-gray-600 mb-1">Opis luki</label>
+                  <input
+                    type="text"
+                    value={blank.label}
+                    onChange={(e) => updateBlankLabel(blank.id, e.target.value)}
+                    className="w-full px-3 py-2 border border-gray-200 rounded focus:ring-1 focus:ring-blue-500 focus:border-transparent text-sm"
+                    placeholder="Krótki opis lub podpowiedź"
+                  />
+                </div>
+
+                <div>
+                  <label className="block text-xs font-medium text-gray-600 mb-1">Poprawna odpowiedź</label>
+                  <select
+                    value={blank.correctOptionId ?? ''}
+                    onChange={(e) => updateBlankCorrectOption(blank.id, e.target.value || null)}
+                    className="w-full px-3 py-2 border border-gray-200 rounded focus:ring-1 focus:ring-blue-500 focus:border-transparent text-sm"
+                  >
+                    <option value="">Wybierz poprawną odpowiedź</option>
+                    {tile.content.options.map(option => (
+                      <option key={option.id} value={option.id}>
+                        {option.text}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                <button
+                  type="button"
+                  onClick={() => insertPlaceholder(blank.id)}
+                  className="inline-flex items-center gap-2 px-3 py-1.5 text-xs text-blue-600 hover:text-blue-700 hover:bg-blue-50 rounded-lg border border-blue-100"
+                >
+                  <Brackets className="w-3 h-3" />
+                  Wstaw [[{blank.id}]] w tekście
+                </button>
+              </div>
+            </div>
+          ))}
+
+          {tile.content.blanks.length === 0 && (
+            <div className="text-xs text-amber-600 bg-amber-50 border border-amber-100 rounded-lg p-3">
+              Dodaj co najmniej jedną lukę, aby zadanie było interaktywne.
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <h4 className="text-sm font-semibold text-gray-900">Bank słów ({tile.content.options.length})</h4>
+          <button
+            type="button"
+            onClick={addOption}
+            className="inline-flex items-center gap-2 px-3 py-1.5 bg-slate-900 text-white text-xs rounded-lg hover:bg-slate-800 transition-colors"
+          >
+            <Plus className="w-3 h-3" />
+            Dodaj słowo
+          </button>
+        </div>
+
+        <div className="space-y-2">
+          {tile.content.options.map(option => (
+            <div key={option.id} className="flex items-center gap-2 p-3 border border-gray-200 rounded-lg bg-white shadow-sm">
+              <input
+                type="text"
+                value={option.text}
+                onChange={(e) => updateOptionText(option.id, e.target.value)}
+                className="flex-1 px-3 py-2 border border-gray-200 rounded focus:ring-1 focus:ring-blue-500 focus:border-transparent text-sm"
+                placeholder="Wpisz słowo lub frazę"
+              />
+              <button
+                type="button"
+                onClick={() => removeOption(option.id)}
+                className="p-2 text-red-500 hover:text-red-600 rounded-lg hover:bg-red-50"
+              >
+                <Trash2 className="w-4 h-4" />
+              </button>
+            </div>
+          ))}
+
+          {tile.content.options.length === 0 && (
+            <div className="text-xs text-amber-600 bg-amber-50 border border-amber-100 rounded-lg p-3">
+              Dodaj słowa lub frazy, aby uczniowie mogli je przeciągać w odpowiednie miejsca.
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-2">Feedback poprawny</label>
+          <textarea
+            value={tile.content.correctFeedback}
+            onChange={(e) => handleContentUpdate('correctFeedback', e.target.value)}
+            rows={3}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm"
+            placeholder="Świetnie, udało Ci się uzupełnić wszystkie luki!"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-2">Feedback niepoprawny</label>
+          <textarea
+            value={tile.content.incorrectFeedback}
+            onChange={(e) => handleContentUpdate('incorrectFeedback', e.target.value)}
+            rows={3}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm"
+            placeholder="Spróbuj ponownie — upewnij się, że każde słowo pasuje do kontekstu zdania."
+          />
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-2">Kolor tła kafelka</label>
+          <input
+            type="color"
+            value={tile.content.backgroundColor}
+            onChange={(e) => handleContentUpdate('backgroundColor', e.target.value)}
+            className="w-full h-12 border border-gray-300 rounded-lg cursor-pointer"
+          />
+        </div>
+        <div className="flex items-end">
+          <label className="flex items-center gap-3 bg-gray-50 border border-gray-200 rounded-lg px-4 py-3 w-full cursor-pointer">
+            <input
+              type="checkbox"
+              checked={tile.content.showBorder}
+              onChange={(e) => handleContentUpdate('showBorder', e.target.checked)}
+              className="w-5 h-5 text-blue-600"
+            />
+            <div>
+              <span className="text-sm font-medium text-gray-900">Pokaż obramowanie kafelka</span>
+              <p className="text-xs text-gray-600">Dzięki obramowaniu kafelek będzie bardziej wyeksponowany na planszy.</p>
+            </div>
+          </label>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/admin/side editor/TilePalette.tsx
+++ b/src/components/admin/side editor/TilePalette.tsx
@@ -37,6 +37,11 @@ const TILE_TYPES: TilePaletteItem[] = [
     type: 'sequencing',
     title: 'Ćwiczenie sekwencyjne',
     icon: 'ArrowUpDown'
+  },
+  {
+    type: 'matchPairs',
+    title: 'Dopasuj wyrazy (luki)',
+    icon: 'Puzzle'
   }
 ];
 

--- a/src/components/admin/side editor/TileSideEditor.tsx
+++ b/src/components/admin/side editor/TileSideEditor.tsx
@@ -1,9 +1,18 @@
 import React from 'react';
 import { Plus, Trash2, Type, X } from 'lucide-react';
-import { TextTile, ImageTile, LessonTile, ProgrammingTile, SequencingTile, QuizTile } from '../../../types/lessonEditor.ts';
+import {
+  TextTile,
+  ImageTile,
+  LessonTile,
+  ProgrammingTile,
+  SequencingTile,
+  QuizTile,
+  MatchPairsTile
+} from '../../../types/lessonEditor.ts';
 import { ImageUploadComponent } from './ImageUploadComponent.tsx';
 import { ImagePositionControl } from './ImagePositionControl.tsx';
 import { SequencingEditor } from './SequencingEditor.tsx';
+import { MatchPairsEditor } from './MatchPairsEditor.tsx';
 
 interface TileSideEditorProps {
   tile: LessonTile | undefined;
@@ -263,6 +272,18 @@ export const TileSideEditor: React.FC<TileSideEditorProps> = ({
         return (
           <SequencingEditor
             tile={sequencingTile}
+            onUpdateTile={onUpdateTile}
+            isTesting={isTesting}
+            onToggleTesting={onToggleTesting}
+          />
+        );
+      }
+
+      case 'matchPairs': {
+        const matchPairsTile = tile as MatchPairsTile;
+        return (
+          <MatchPairsEditor
+            tile={matchPairsTile}
             onUpdateTile={onUpdateTile}
             isTesting={isTesting}
             onToggleTesting={onToggleTesting}

--- a/src/components/admin/top editor/TopToolbar.tsx
+++ b/src/components/admin/top editor/TopToolbar.tsx
@@ -5,7 +5,7 @@ import { FontSizeSelector } from './FontSizeSelector.tsx';
 import { TextColorPicker } from './TextColorPicker.tsx';
 import { FontSelector } from './FontSelector.tsx';
 import { AlignmentControls } from './AlignmentControls.tsx';
-import { LessonTile, ProgrammingTile, TextTile, SequencingTile } from '../../../types/lessonEditor.ts';
+import { LessonTile, ProgrammingTile, TextTile, SequencingTile, MatchPairsTile } from '../../../types/lessonEditor.ts';
 
 
 interface TopToolbarProps {
@@ -16,7 +16,7 @@ interface TopToolbarProps {
   isTextEditing: boolean;
   onFinishTextEditing?: () => void;
   editor?: Editor | null;
-  selectedTile?: TextTile | ProgrammingTile | SequencingTile | null;
+  selectedTile?: TextTile | ProgrammingTile | SequencingTile | MatchPairsTile | null;
   onUpdateTile?: (tileId: string, updates: Partial<LessonTile>) => void;
   className?: string;
 }
@@ -65,7 +65,7 @@ export const TopToolbar: React.FC<TopToolbarProps> = ({
   }, [editor]);
 
   useEffect(() => {
-    if (selectedTile?.type === 'text' || selectedTile?.type === 'sequencing') {
+    if (selectedTile?.type === 'text' || selectedTile?.type === 'sequencing' || selectedTile?.type === 'matchPairs') {
       setVerticalAlign(selectedTile.content.verticalAlign || 'top');
     }
   }, [selectedTile]);

--- a/src/hooks/useTileInteractions.ts
+++ b/src/hooks/useTileInteractions.ts
@@ -1,5 +1,13 @@
 import { useState, useEffect, RefObject } from 'react';
-import { LessonContent, LessonTile, GridPosition, EditorState, TextTile, ImageTile, SequencingTile } from '../types/lessonEditor';
+import {
+  LessonContent,
+  LessonTile,
+  GridPosition,
+  EditorState,
+  TextTile,
+  ImageTile,
+  SequencingTile
+} from '../types/lessonEditor';
 import { EditorAction } from '../state/editorReducer';
 import { GridUtils } from '../utils/gridUtils';
 import { logger } from '../utils/logger';
@@ -33,6 +41,7 @@ export const useTileInteractions = ({
       tile.type === 'text' ||
       tile.type === 'programming' ||
       tile.type === 'sequencing' ||
+      tile.type === 'matchPairs' ||
       tile.type === 'quiz'
     ) {
       dispatch({ type: 'startTextEditing', tileId: tile.id });

--- a/src/services/lessonContentService.ts
+++ b/src/services/lessonContentService.ts
@@ -1,4 +1,4 @@
-import { LessonContent, LessonTile, TextTile } from '../types/lessonEditor';
+import { LessonContent, LessonTile, TextTile, MatchPairsTile } from '../types/lessonEditor';
 import { ProgrammingTile, SequencingTile } from '../types/lessonEditor';
 import { GridUtils } from '../utils/gridUtils';
 import { logger } from '../utils/logger';
@@ -397,6 +397,73 @@ export class LessonContentService {
         ],
         correctFeedback: 'Świetnie! Prawidłowa kolejność.',
         incorrectFeedback: 'Spróbuj ponownie. Sprawdź kolejność elementów.'
+      },
+      created_at: now,
+      updated_at: now,
+      z_index: 1
+    };
+  }
+
+  /**
+   * Create a new match pairs (fill-in-the-blanks) tile
+   */
+  static createMatchPairsTile(position: { x: number; y: number }, page = 1): MatchPairsTile {
+    const id = `tile-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+    const now = new Date().toISOString();
+
+    const gridPos = GridUtils.pixelToGrid(position, {
+      width: GridUtils.GRID_COLUMNS,
+      height: 6,
+      gridSize: GridUtils.GRID_CELL_SIZE,
+      snapToGrid: true
+    });
+
+    gridPos.colSpan = 4;
+    gridPos.rowSpan = 5;
+
+    const pixelPos = GridUtils.gridToPixel(gridPos, {
+      width: GridUtils.GRID_COLUMNS,
+      height: 6,
+      gridSize: GridUtils.GRID_CELL_SIZE,
+      snapToGrid: true
+    });
+
+    const pixelSize = GridUtils.gridSizeToPixel(gridPos, {
+      width: GridUtils.GRID_COLUMNS,
+      height: 6,
+      gridSize: GridUtils.GRID_CELL_SIZE,
+      snapToGrid: true
+    });
+
+    return {
+      id,
+      type: 'matchPairs',
+      position: pixelPos,
+      size: pixelSize,
+      gridPosition: gridPos,
+      page,
+      content: {
+        instruction: 'Uzupełnij tekst, przeciągając słowa z banku do odpowiednich luk.',
+        richInstruction:
+          '<p style="margin: 0;">Uzupełnij tekst, przeciągając słowa z banku do odpowiednich luk.</p>',
+        textTemplate:
+          'Programowanie to [[blank-1]] umiejętność, która wymaga [[blank-2]] i ciągłej nauki.',
+        blanks: [
+          { id: 'blank-1', label: 'Pierwsza luka', correctOptionId: 'option-1' },
+          { id: 'blank-2', label: 'Druga luka', correctOptionId: 'option-2' }
+        ],
+        options: [
+          { id: 'option-1', text: 'praktyczna' },
+          { id: 'option-2', text: 'cierpliwości' },
+          { id: 'option-3', text: 'wyobraźni' }
+        ],
+        fontFamily: 'Inter, system-ui, sans-serif',
+        fontSize: 16,
+        verticalAlign: 'top',
+        backgroundColor: '#2563eb',
+        showBorder: true,
+        correctFeedback: 'Świetna robota! Wszystkie luki zostały wypełnione poprawnie.',
+        incorrectFeedback: 'Sprawdź jeszcze raz. Niektóre luki zawierają niewłaściwe słowa.'
       },
       created_at: now,
       updated_at: now,

--- a/src/types/lessonEditor.ts
+++ b/src/types/lessonEditor.ts
@@ -17,7 +17,7 @@ export interface GridPosition {
 
 export interface LessonTile {
   id: string;
-  type: 'text' | 'image' | 'visualization' | 'quiz' | 'programming' | 'sequencing';
+  type: 'text' | 'image' | 'visualization' | 'quiz' | 'programming' | 'sequencing' | 'matchPairs';
   position: Position;
   size: Size;
   gridPosition: GridPosition;
@@ -123,6 +123,35 @@ export interface SequencingTile extends LessonTile {
       text: string;
       correctPosition: number; // 0-based index for correct order
     }>;
+    correctFeedback: string;
+    incorrectFeedback: string;
+  };
+}
+
+export interface MatchPairsBlank {
+  id: string;
+  label: string;
+  correctOptionId: string | null;
+}
+
+export interface MatchPairsOption {
+  id: string;
+  text: string;
+}
+
+export interface MatchPairsTile extends LessonTile {
+  type: 'matchPairs';
+  content: {
+    instruction: string;
+    richInstruction?: string;
+    textTemplate: string;
+    blanks: MatchPairsBlank[];
+    options: MatchPairsOption[];
+    fontFamily: string;
+    fontSize: number;
+    verticalAlign: 'top' | 'center' | 'bottom';
+    backgroundColor: string;
+    showBorder: boolean;
     correctFeedback: string;
     incorrectFeedback: string;
   };


### PR DESCRIPTION
## Summary
- add a drag-and-drop "Match Pairs" interactive tile with TaskInstructionPanel driven instructions
- provide a side editor for configuring blanks, bank options, and feedback messaging
- wire the new tile type into the palette, lesson editor, and tile services

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dadbdcabc48321aab08569aabe431d