### PR TITLE
Refactor tile rendering into dedicated components

### DIFF
--- a/src/components/admin/LessonCanvas.tsx
+++ b/src/components/admin/LessonCanvas.tsx
@@ -131,7 +131,7 @@ export const LessonCanvas = forwardRef<HTMLDivElement, LessonCanvasProps>(({
             isImageEditing={editorState.mode === 'imageEditing' && editorState.selectedTileId === tile.id}
             isTestingMode={testingTileIds.includes(tile.id)}
             onMouseDown={(e) => handleTileMouseDown(e, tile)}
-            onImageMouseDown={(e) => handleImageMouseDown(e, tile)}
+            onImageMouseDown={(e, imageTile) => handleImageMouseDown(e, imageTile)}
             isDraggingImage={editorState.interaction.type === 'imageDrag'}
             onDoubleClick={() => handleTileDoubleClick(tile)}
             onUpdateTile={onUpdateTile}

--- a/src/components/admin/TileRenderer.tsx
+++ b/src/components/admin/TileRenderer.tsx
@@ -1,79 +1,160 @@
-import React, { useState, useEffect } from 'react';
-import { Move, Trash2, Play, Code2 } from 'lucide-react';
-import { LessonTile, TextTile, ImageTile, QuizTile, ProgrammingTile, SequencingTile, MatchPairsTile } from '../../types/lessonEditor';
+import React, { useState } from 'react';
+import type { ComponentProps } from 'react';
+import { Move, Trash2 } from 'lucide-react';
+import type { Editor } from '@tiptap/react';
+import type { LessonTile, ImageTile } from '../../types/lessonEditor';
 import { GridUtils } from '../../utils/gridUtils';
-import { Editor, EditorContent, useEditor } from '@tiptap/react';
-import StarterKit from '@tiptap/starter-kit';
-import Underline from '@tiptap/extension-underline';
-import { TextStyle } from '@tiptap/extension-text-style';
-import Color from '@tiptap/extension-color';
-import FontFamily from '@tiptap/extension-font-family';
-import FontSize from '../../extensions/FontSize';
-import BulletList from '@tiptap/extension-bullet-list';
-import OrderedList from '@tiptap/extension-ordered-list';
-import ListItem from '@tiptap/extension-list-item';
-import TextAlign from '../../extensions/TextAlign';
-import { SequencingInteractive } from './SequencingInteractive';
-import { MatchPairsInteractive } from './MatchPairsInteractive';
-import { TaskInstructionPanel } from './common/TaskInstructionPanel';
-import { QuizInteractive } from './QuizInteractive';
-
-const hexToRgb = (hex: string): { r: number; g: number; b: number } | null => {
-  if (!hex) return null;
-
-  let normalized = hex.replace('#', '').trim();
-  if (normalized.length === 3) {
-    normalized = normalized.split('').map((char) => `${char}${char}`).join('');
-  }
-
-  if (normalized.length !== 6) return null;
-
-  const intValue = Number.parseInt(normalized, 16);
-  if (Number.isNaN(intValue)) return null;
-
-  return {
-    r: (intValue >> 16) & 255,
-    g: (intValue >> 8) & 255,
-    b: intValue & 255,
-  };
-};
-
-const channelToLinear = (value: number): number => {
-  const scaled = value / 255;
-  return scaled <= 0.03928 ? scaled / 12.92 : Math.pow((scaled + 0.055) / 1.055, 2.4);
-};
-
-const getReadableTextColor = (hex: string): string => {
-  const rgb = hexToRgb(hex);
-  if (!rgb) return '#0f172a';
-
-  const luminance = (0.2126 * channelToLinear(rgb.r)) +
-    (0.7152 * channelToLinear(rgb.g)) +
-    (0.0722 * channelToLinear(rgb.b));
-
-  return luminance > 0.6 ? '#0f172a' : '#f8fafc';
-};
-
-const lightenColor = (hex: string, amount: number): string => {
-  const rgb = hexToRgb(hex);
-  if (!rgb) return hex;
-
-  const lightenChannel = (channel: number) => Math.round(channel + (255 - channel) * amount);
-  return `rgb(${lightenChannel(rgb.r)}, ${lightenChannel(rgb.g)}, ${lightenChannel(rgb.b)})`;
-};
-
-const darkenColor = (hex: string, amount: number): string => {
-  const rgb = hexToRgb(hex);
-  if (!rgb) return hex;
-
-  const darkenChannel = (channel: number) => Math.round(channel * (1 - amount));
-  return `rgb(${darkenChannel(rgb.r)}, ${darkenChannel(rgb.g)}, ${darkenChannel(rgb.b)})`;
-};
-
-const surfaceColor = (accent: string, textColor: string, lightenAmount: number, darkenAmount: number): string =>
-  textColor === '#0f172a' ? lightenColor(accent, lightenAmount) : darkenColor(accent, darkenAmount);
+import { TILE_COMPONENTS, type TileComponentMap } from './tiles';
+import { getReadableTextColor } from './tiles/utils';
 
 const TILE_CORNER = 'rounded-xl';
+
+type SupportedTileType = keyof TileComponentMap;
+type TileByType<T extends SupportedTileType> = Extract<LessonTile, { type: T }>;
+
+interface TilePropsBuilderContext {
+  isSelected: boolean;
+  isEditingText: boolean;
+  isImageEditing: boolean;
+  isTestingMode: boolean;
+  isDraggingImage: boolean;
+  computedBackground: string;
+  defaultTextColor: string;
+  onUpdateTile: (tileId: string, updates: Partial<LessonTile>) => void;
+  onFinishTextEditing: () => void;
+  onEditorReady: (editor: Editor | null) => void;
+  onDoubleClick: () => void;
+  onImageMouseDown: (event: React.MouseEvent, tile: ImageTile) => void;
+}
+
+const TILE_PROPS_BUILDERS: {
+  [K in SupportedTileType]: (
+    context: TilePropsBuilderContext & { tile: TileByType<K> }
+  ) => ComponentProps<TileComponentMap[K]>;
+} = {
+  text: ({
+    tile,
+    isSelected,
+    isEditingText,
+    computedBackground,
+    onUpdateTile,
+    onFinishTextEditing,
+    onEditorReady,
+    defaultTextColor,
+  }) => ({
+    tile,
+    isSelected,
+    isEditingText,
+    computedBackground,
+    onUpdateTile,
+    onFinishTextEditing,
+    onEditorReady,
+    textColor: defaultTextColor,
+  }),
+  image: ({
+    tile,
+    isSelected,
+    isEditingText,
+    computedBackground,
+    onUpdateTile,
+    onFinishTextEditing,
+    onEditorReady,
+    isImageEditing,
+    isDraggingImage,
+    onImageMouseDown,
+  }) => ({
+    tile,
+    isSelected,
+    isEditingText,
+    computedBackground,
+    onUpdateTile,
+    onFinishTextEditing,
+    onEditorReady,
+    isImageEditing,
+    isDraggingImage,
+    onImageMouseDown,
+  }),
+  programming: ({
+    tile,
+    isSelected,
+    isEditingText,
+    computedBackground,
+    onUpdateTile,
+    onFinishTextEditing,
+    onEditorReady,
+  }) => ({
+    tile,
+    isSelected,
+    isEditingText,
+    computedBackground,
+    onUpdateTile,
+    onFinishTextEditing,
+    onEditorReady,
+  }),
+  quiz: ({
+    tile,
+    isSelected,
+    isEditingText,
+    computedBackground,
+    onUpdateTile,
+    onFinishTextEditing,
+    onEditorReady,
+    isTestingMode,
+    onDoubleClick,
+  }) => ({
+    tile,
+    isSelected,
+    isEditingText,
+    computedBackground,
+    onUpdateTile,
+    onFinishTextEditing,
+    onEditorReady,
+    isTestingMode,
+    onDoubleClick,
+  }),
+  sequencing: ({
+    tile,
+    isSelected,
+    isEditingText,
+    computedBackground,
+    onUpdateTile,
+    onFinishTextEditing,
+    onEditorReady,
+    isTestingMode,
+    onDoubleClick,
+  }) => ({
+    tile,
+    isSelected,
+    isEditingText,
+    computedBackground,
+    onUpdateTile,
+    onFinishTextEditing,
+    onEditorReady,
+    isTestingMode,
+    onDoubleClick,
+  }),
+  matchPairs: ({
+    tile,
+    isSelected,
+    isEditingText,
+    computedBackground,
+    onUpdateTile,
+    onFinishTextEditing,
+    onEditorReady,
+    isTestingMode,
+    onDoubleClick,
+  }) => ({
+    tile,
+    isSelected,
+    isEditingText,
+    computedBackground,
+    onUpdateTile,
+    onFinishTextEditing,
+    onEditorReady,
+    isTestingMode,
+    onDoubleClick,
+  }),
+};
 
 interface TileRendererProps {
   tile: LessonTile;
@@ -83,7 +164,7 @@ interface TileRendererProps {
   isImageEditing: boolean;
   isTestingMode?: boolean;
   onMouseDown: (e: React.MouseEvent) => void;
-  onImageMouseDown: (e: React.MouseEvent) => void;
+  onImageMouseDown: (e: React.MouseEvent, tile: ImageTile) => void;
   isDraggingImage: boolean;
   onDoubleClick: () => void;
   onUpdateTile: (tileId: string, updates: Partial<LessonTile>) => void;
@@ -92,117 +173,6 @@ interface TileRendererProps {
   showGrid: boolean;
   onEditorReady: (editor: Editor | null) => void;
 }
-
-interface RichTextEditorProps {
-  textTile: TextTile;
-  tileId: string;
-  onUpdateTile: (tileId: string, updates: Partial<LessonTile>) => void;
-  onFinishTextEditing: () => void;
-  onEditorReady: (editor: Editor | null) => void;
-  textColor?: string;
-}
-
-const RichTextEditor: React.FC<RichTextEditorProps> = ({ textTile, tileId, onUpdateTile, onFinishTextEditing, onEditorReady, textColor }) => {
-  const editor = useEditor({
-    extensions: [
-      StarterKit.configure({
-        bulletList: false,
-        orderedList: false,
-        listItem: false,
-      }),
-      BulletList.configure({
-        HTMLAttributes: { class: 'bullet-list' },
-        keepMarks: true,
-        keepAttributes: true,
-      }),
-      OrderedList.configure({
-        HTMLAttributes: { class: 'ordered-list' },
-        keepMarks: true,
-        keepAttributes: true,
-      }),
-      ListItem,
-      Underline,
-      TextStyle,
-      Color.configure({ types: ['textStyle'] }),
-      FontFamily.configure({ types: ['textStyle'] }),
-      FontSize,
-      TextAlign.configure({ types: ['paragraph'] }),
-    ],
-    content:
-      textTile.content.richText ||
-      `<p style="margin: 0;">${textTile.content.text || ''}</p>`,
-    onUpdate: ({ editor }) => {
-      const html = editor.getHTML();
-      const plain = editor.getText();
-      onUpdateTile(tileId, {
-        content: {
-          ...textTile.content,
-          text: plain,
-          richText: html
-        }
-      });
-    },
-    autofocus: true
-  });
-
-  useEffect(() => {
-    onEditorReady(editor);
-    return () => onEditorReady(null);
-  }, [editor, onEditorReady]);
-
-  if (!editor) return null;
-
-  const handleBlur = (e: React.FocusEvent) => {
-    const toolbar = document.querySelector('.top-toolbar');
-    if (toolbar && e.relatedTarget && toolbar.contains(e.relatedTarget as Node)) {
-      e.preventDefault();
-      editor.commands.focus();
-      return;
-    }
-    onFinishTextEditing();
-  };
-
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Tab') {
-      e.preventDefault();
-      if (editor.isActive('listItem')) {
-        if (e.shiftKey) {
-          editor.chain().focus().liftListItem('listItem').run();
-        } else {
-          editor.chain().focus().sinkListItem('listItem').run();
-        }
-      } else {
-        editor.chain().focus().insertContent('\t').run();
-      }
-    }
-  };
-
-  return (
-    <div
-      className="w-full h-full p-3 overflow-hidden relative tile-text-content tiptap-editor"
-      style={{
-        fontSize: `${textTile.content.fontSize}px`,
-        fontFamily: textTile.content.fontFamily,
-        color: textColor,
-        display: 'flex',
-        flexDirection: 'column',
-        justifyContent:
-          textTile.content.verticalAlign === 'center'
-            ? 'center'
-            : textTile.content.verticalAlign === 'bottom'
-            ? 'flex-end'
-            : 'flex-start',
-      }}
-    >
-      <EditorContent
-        editor={editor}
-        className="w-full focus:outline-none break-words rich-text-content tile-formatted-text"
-        onBlur={handleBlur}
-        onKeyDown={handleKeyDown}
-      />
-    </div>
-  );
-};
 
 export const TileRenderer: React.FC<TileRendererProps> = ({
   tile,
@@ -249,36 +219,6 @@ export const TileRenderer: React.FC<TileRendererProps> = ({
     document.dispatchEvent(resizeEvent);
   };
 
-  const handleImageDragStart = (e: React.MouseEvent, imageTile: ImageTile) => {
-    console.log('🖱️ Image drag start in TileRenderer - delegating to parent');
-    onImageMouseDown(e, imageTile);
-  };
-
-  const handleImageWheel = (e: React.WheelEvent, imageTile: ImageTile) => {
-    // Only handle wheel events when tile is selected and in image editing mode
-    if (!isSelected || !isImageEditing) return;
-    
-    e.preventDefault();
-    e.stopPropagation();
-    
-    console.log('🎯 Image wheel event - deltaY:', e.deltaY);
-    
-    const currentScale = imageTile.content.scale || 1;
-    const zoomSpeed = 0.1;
-    const zoomDirection = e.deltaY > 0 ? -1 : 1; // Negative deltaY = zoom in, positive = zoom out
-    const newScale = Math.max(0.1, Math.min(3, currentScale + (zoomDirection * zoomSpeed)));
-    
-    console.log('🎯 Zoom - current:', currentScale, 'new:', newScale, 'direction:', zoomDirection);
-    
-    // Update the tile with new scale
-    onUpdateTile(tile.id, {
-      content: {
-        ...imageTile.content,
-        scale: newScale
-      }
-    });
-  };
-
   // Handle mouse events carefully to preserve text selection
   const handleMouseEnter = () => {
     // Only set hover state if not in text editing mode
@@ -294,471 +234,42 @@ export const TileRenderer: React.FC<TileRendererProps> = ({
     }
   };
 
-  const renderTileContent = () => {
-    let contentToRender: JSX.Element;
-
-    switch (tile.type) {
-
-      case 'text':
-        {
-          const textTile = tile as TextTile;
-
-          // If this text tile is being edited, use Tiptap editor
-          if (isEditingText && isSelected) {
-            contentToRender = (
-              <RichTextEditor
-                textTile={textTile}
-                tileId={tile.id}
-                onUpdateTile={onUpdateTile}
-                onFinishTextEditing={onFinishTextEditing}
-                onEditorReady={onEditorReady}
-                textColor={defaultTextColor}
-              />
-            );
-          } else {
-            // Normal text tile display
-            contentToRender = (
-              <>
-                <div
-                  className="w-full h-full p-3 overflow-hidden tile-text-content"
-                  style={{
-                    fontSize: `${textTile.content.fontSize}px`,
-                    fontFamily: textTile.content.fontFamily,
-                    color: defaultTextColor,
-                    display: 'flex',
-                    flexDirection: 'column',
-                    justifyContent: textTile.content.verticalAlign === 'center' ? 'center' :
-                                   textTile.content.verticalAlign === 'bottom' ? 'flex-end' : 'flex-start'
-                  }}
-                >
-                  <div
-                    className="break-words rich-text-content tile-formatted-text w-full"
-                    style={{
-                      minHeight: '1em',
-                      outline: 'none'
-                    }}
-                    dangerouslySetInnerHTML={{
-                      __html: textTile.content.richText || `<p style="margin: 0;">${textTile.content.text || 'Kliknij dwukrotnie, aby edytować'}</p>`
-                    }}
-                  />
-                </div>
-              </>
-            );
-          }
-          break;
-        }
-
-      case 'image':
-        {
-          const imageTile = tile as ImageTile;
-          const imagePosition = imageTile.content.position || { x: 0, y: 0 };
-          const imageScale = imageTile.content.scale || 1;
-
-          console.log('Rendering image tile:', imageTile.id, 'position:', imagePosition, 'scale:', imageScale, 'updated_at:', imageTile.updated_at);
-
-          contentToRender = (
-            <div className="w-full h-full overflow-hidden relative">
-              <div
-                className="w-full h-full relative overflow-hidden"
-                style={{ cursor: isSelected && isImageEditing ? 'grab' : 'default' }}
-              >
-                <img
-                  src={imageTile.content.url}
-                  alt={imageTile.content.alt}
-                  className={`absolute select-none ${
-                    isSelected && isImageEditing ? 'cursor-grab active:cursor-grabbing' : ''
-                  }`}
-                  style={{
-                    left: imagePosition.x,
-                    top: imagePosition.y,
-                    transform: `scale(${imageScale})`,
-                    transformOrigin: '0 0',
-                    maxWidth: 'none',
-                    maxHeight: 'none',
-                    cursor: isSelected && isImageEditing ? (isDraggingImage ? 'grabbing' : 'grab') : 'default'
-                  }}
-                  onMouseDown={isSelected && isImageEditing ? (e) => {
-                    console.log('🖱️ Image onMouseDown triggered in TileRenderer');
-                    handleImageDragStart(e, imageTile);
-                  } : undefined}
-                  onWheel={isSelected && isImageEditing ? (e) => {
-                    handleImageWheel(e, imageTile);
-                  } : undefined}
-                  draggable={false}
-                  onError={(e) => {
-                    console.error('Image failed to load:', imageTile.content.url.substring(0, 100));
-                    (e.target as HTMLImageElement).src = 'https://images.pexels.com/photos/3184291/pexels-photo-3184291.jpeg?auto=compress&cs=tinysrgb&w=400';
-                  }}
-                  onLoad={() => {
-                    console.log('Image loaded successfully');
-                  }}
-                />
-              </div>
-              {imageTile.content.caption && (
-                <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/70 to-transparent text-white text-xs p-3">
-                  {imageTile.content.caption}
-                </div>
-              )}
-            </div>
-          );
-          break;
-        }
-
-
-
-      case 'programming': {
-        const programmingTile = tile as ProgrammingTile;
-
-        const accentColor = programmingTile.content.backgroundColor || computedBackground;
-        const textColor = getReadableTextColor(accentColor);
-        const isDarkText = textColor === '#0f172a';
-        const mutedTextColor = isDarkText ? '#475569' : '#e2e8f0';
-        const panelBackground = surfaceColor(accentColor, textColor, 0.6, 0.4);
-        const panelBorderColor = surfaceColor(accentColor, textColor, 0.48, 0.55);
-        const chipBackground = surfaceColor(accentColor, textColor, 0.52, 0.48);
-        const statusDotColor = surfaceColor(accentColor, textColor, 0.35, 0.35);
-
-        const descriptionContainerStyle: React.CSSProperties = {
-          backgroundColor: panelBackground,
-          color: textColor,
-          border: `1px solid ${panelBorderColor}`
-        };
-
-        const codeContainerStyle: React.CSSProperties = {
-          borderColor: darkenColor(accentColor, isDarkText ? 0.35 : 0.55),
-          backgroundColor: darkenColor(accentColor, isDarkText ? 0.55 : 0.75),
-          color: '#f8fafc'
-        };
-
-        let codeDisplayContent = '';
-
-        if (programmingTile.content.startingCode) {
-          codeDisplayContent += programmingTile.content.startingCode + '\n\n';
-        }
-
-        codeDisplayContent += 'wpisz swój kod tutaj';
-
-        if (programmingTile.content.endingCode) {
-          codeDisplayContent += '\n\n' + programmingTile.content.endingCode;
-        }
-
-        const codeLines = codeDisplayContent.split('\n');
-
-        const renderDescriptionBlock = (content: React.ReactNode) => (
-          <TaskInstructionPanel
-            icon={<Code2 className="w-4 h-4" />}
-            label="Zadanie"
-            className="flex-shrink-0 max-h-[45%] overflow-hidden border transition-colors duration-300"
-            style={descriptionContainerStyle}
-            iconWrapperStyle={{ backgroundColor: chipBackground, color: textColor }}
-            labelStyle={{ color: mutedTextColor }}
-          >
-            {content}
-          </TaskInstructionPanel>
-        );
-
-        const renderCodePreview = () => (
-          <div className="flex-1 flex flex-col rounded-xl overflow-hidden border" style={codeContainerStyle}>
-            <div
-              className="flex items-center justify-between px-5 py-4 border-b"
-              style={{
-                borderColor: surfaceColor(accentColor, textColor, 0.42, 0.62),
-                backgroundColor: darkenColor(accentColor, isDarkText ? 0.45 : 0.7)
-              }}
-            >
-              <div className="flex items-center gap-3">
-                <div
-                  className="flex items-center justify-center w-10 h-10 rounded-xl"
-                  style={{
-                    backgroundColor: darkenColor(accentColor, isDarkText ? 0.3 : 0.55),
-                    color: '#f8fafc'
-                  }}
-                >
-                  <Play className="w-4 h-4 text-white" />
-                </div>
-                <div className="flex flex-col">
-                  <span className="text-sm font-semibold text-white">Python</span>
-                  <span className="text-xs" style={{ color: '#cbd5f5' }}>
-                    Tryb nauki
-                  </span>
-                </div>
-              </div>
-              <div className="flex items-center gap-3 text-xs" style={{ color: '#cbd5f5' }}>
-                <span className="flex items-center gap-1">
-                  <span
-                    className="w-2 h-2 rounded-full animate-pulse"
-                    style={{ backgroundColor: statusDotColor }}
-                  />
-                  Gotowy do uruchomienia
-                </span>
-              </div>
-            </div>
-
-            <div className="flex-1 font-mono text-[13px] leading-6 px-5 py-4 text-slate-100 overflow-auto">
-              {codeLines.map((line, index) => (
-                <div key={index} className="flex">
-                  <span className="w-8 pr-4 text-right text-slate-500 select-none">{index + 1}</span>
-                  <code className="flex-1 whitespace-pre">{line}</code>
-                </div>
-              ))}
-            </div>
-          </div>
-        );
-
-        if (isEditingText && isSelected) {
-          contentToRender = (
-            <div className="w-full h-full flex flex-col gap-5 p-5" style={{ color: textColor }}>
-              {renderDescriptionBlock(
-                <RichTextEditor
-                  textTile={{
-                    ...tile,
-                    type: 'text',
-                    content: {
-                      text: programmingTile.content.description,
-                      richText: programmingTile.content.richDescription,
-                      fontFamily: programmingTile.content.fontFamily,
-                      fontSize: programmingTile.content.fontSize,
-                      verticalAlign: 'top',
-                      backgroundColor: programmingTile.content.backgroundColor,
-                      showBorder: programmingTile.content.showBorder
-                    }
-                  } as TextTile}
-                  tileId={tile.id}
-                  textColor={textColor}
-                  onUpdateTile={(tileId, updates) => {
-                    if (updates.content) {
-                      onUpdateTile(tileId, {
-                        content: {
-                          ...programmingTile.content,
-                          description: updates.content.text || programmingTile.content.description,
-                          richDescription: updates.content.richText || programmingTile.content.richDescription
-                        }
-                      });
-                    }
-                  }}
-                  onFinishTextEditing={onFinishTextEditing}
-                  onEditorReady={onEditorReady}
-                />
-              )}
-
-              {renderCodePreview()}
-            </div>
-          );
-        } else {
-          contentToRender = (
-            <div className="w-full h-full flex flex-col gap-5 p-5" style={{ color: textColor }}>
-              {renderDescriptionBlock(
-                <div
-                  className="text-sm leading-relaxed"
-                  style={{
-                    fontFamily: programmingTile.content.fontFamily,
-                    fontSize: `${programmingTile.content.fontSize}px`
-                  }}
-                  dangerouslySetInnerHTML={{
-                    __html: programmingTile.content.richDescription || programmingTile.content.description
-                  }}
-                />
-              )}
-
-              {renderCodePreview()}
-            </div>
-          );
-        }
-        break;
-      }
-      case 'quiz': {
-        const quizTile = tile as QuizTile;
-        const questionTextColor = getReadableTextColor(
-          quizTile.content.backgroundColor || computedBackground
-        );
-
-        if (isEditingText && isSelected) {
-          const questionEditorTile: TextTile = {
-            ...tile,
-            type: 'text',
-            content: {
-              text: quizTile.content.question,
-              richText: quizTile.content.richQuestion,
-              fontFamily: quizTile.content.questionFontFamily || 'Inter',
-              fontSize: quizTile.content.questionFontSize ?? 16,
-              verticalAlign: 'top',
-              backgroundColor: quizTile.content.backgroundColor || computedBackground,
-              showBorder:
-                typeof quizTile.content.showBorder === 'boolean'
-                  ? quizTile.content.showBorder
-                  : true
-            }
-          };
-
-          contentToRender = (
-            <QuizInteractive
-              tile={quizTile}
-              isPreview
-              instructionContent={
-                <RichTextEditor
-                  textTile={questionEditorTile}
-                  tileId={tile.id}
-                  onUpdateTile={(tileId, updates) => {
-                    if (!updates.content) return;
-
-                    onUpdateTile(tileId, {
-                      content: {
-                        ...quizTile.content,
-                        question: updates.content.text ?? quizTile.content.question,
-                        richQuestion: updates.content.richText ?? quizTile.content.richQuestion,
-                        questionFontFamily:
-                          updates.content.fontFamily ?? quizTile.content.questionFontFamily,
-                        questionFontSize:
-                          updates.content.fontSize ?? quizTile.content.questionFontSize
-                      }
-                    });
-                  }}
-                  onFinishTextEditing={onFinishTextEditing}
-                  onEditorReady={onEditorReady}
-                  textColor={questionTextColor}
-                />
-              }
-            />
-          );
-        } else {
-          contentToRender = (
-            <QuizInteractive
-              tile={quizTile}
-              isTestingMode={isTestingMode}
-              onRequestTextEditing={onDoubleClick}
-            />
-          );
-        }
-        break;
-      }
-
-      case 'sequencing': {
-        const sequencingTile = tile as SequencingTile;
-        const accentColor = sequencingTile.content.backgroundColor || computedBackground;
-        const textColor = getReadableTextColor(accentColor);
-
-        const renderSequencingContent = (instructionContent?: React.ReactNode, isPreviewMode = false) => (
-          <SequencingInteractive
-            tile={sequencingTile}
-            isTestingMode={isTestingMode}
-            instructionContent={instructionContent}
-            isPreview={isPreviewMode}
-            onRequestTextEditing={isPreviewMode ? undefined : onDoubleClick}
-          />
-        );
-
-        if (isEditingText && isSelected) {
-          const questionEditorTile = {
-            ...tile,
-            type: 'text',
-            content: {
-              text: sequencingTile.content.question,
-              richText: sequencingTile.content.richQuestion,
-              fontFamily: sequencingTile.content.fontFamily,
-              fontSize: sequencingTile.content.fontSize,
-              verticalAlign: sequencingTile.content.verticalAlign,
-              backgroundColor: sequencingTile.content.backgroundColor,
-              showBorder: sequencingTile.content.showBorder
-            }
-          } as TextTile;
-
-          contentToRender = renderSequencingContent(
-            <RichTextEditor
-              textTile={questionEditorTile}
-              tileId={tile.id}
-              textColor={textColor}
-              onUpdateTile={(tileId, updates) => {
-                if (!updates.content) return;
-
-                onUpdateTile(tileId, {
-                  content: {
-                    ...sequencingTile.content,
-                    question: updates.content.text ?? sequencingTile.content.question,
-                    richQuestion: updates.content.richText ?? sequencingTile.content.richQuestion,
-                    fontFamily: updates.content.fontFamily ?? sequencingTile.content.fontFamily,
-                    fontSize: updates.content.fontSize ?? sequencingTile.content.fontSize,
-                    verticalAlign: updates.content.verticalAlign ?? sequencingTile.content.verticalAlign
-                  }
-                });
-              }}
-              onFinishTextEditing={onFinishTextEditing}
-              onEditorReady={onEditorReady}
-            />,
-            true
-          );
-        } else {
-          contentToRender = renderSequencingContent();
-        }
-        break;
-      }
-
-      case 'matchPairs': {
-        const matchPairsTile = tile as MatchPairsTile;
-        const accentColor = matchPairsTile.content.backgroundColor || computedBackground;
-        const textColor = getReadableTextColor(accentColor);
-
-        const renderMatchPairs = (instructionContent?: React.ReactNode, isPreviewMode = false) => (
-          <MatchPairsInteractive
-            tile={matchPairsTile}
-            isTestingMode={isTestingMode}
-            instructionContent={instructionContent}
-            isPreview={isPreviewMode}
-            onRequestTextEditing={isPreviewMode ? undefined : onDoubleClick}
-          />
-        );
-
-        if (isEditingText && isSelected) {
-          const instructionEditorTile = {
-            ...tile,
-            type: 'text',
-            content: {
-              text: matchPairsTile.content.instruction,
-              richText: matchPairsTile.content.richInstruction,
-              fontFamily: 'Inter, system-ui, sans-serif',
-              fontSize: 16,
-              verticalAlign: 'top',
-              backgroundColor: matchPairsTile.content.backgroundColor,
-              showBorder: true
-            }
-          } as TextTile;
-
-          contentToRender = renderMatchPairs(
-            <RichTextEditor
-              textTile={instructionEditorTile}
-              tileId={tile.id}
-              textColor={textColor}
-              onUpdateTile={(tileId, updates) => {
-                if (!updates.content) return;
-
-                onUpdateTile(tileId, {
-                  content: {
-                    ...matchPairsTile.content,
-                    instruction: updates.content.text ?? matchPairsTile.content.instruction,
-                    richInstruction: updates.content.richText ?? matchPairsTile.content.richInstruction
-                  }
-                });
-              }}
-              onFinishTextEditing={onFinishTextEditing}
-              onEditorReady={onEditorReady}
-            />,
-            true
-          );
-        } else {
-          contentToRender = renderMatchPairs();
-        }
-        break;
-      }
-      default:
-        contentToRender = (
-          <div className="w-full h-full flex items-center justify-center">
-            <span className="text-gray-500 text-sm">Nieznany typ kafelka</span>
-          </div>
-        );
-        break;
-      }
-
-    return contentToRender;
+  const tilePropsContext: TilePropsBuilderContext = {
+    isSelected,
+    isEditingText,
+    isImageEditing,
+    isTestingMode,
+    isDraggingImage,
+    computedBackground,
+    defaultTextColor,
+    onUpdateTile,
+    onFinishTextEditing,
+    onEditorReady,
+    onDoubleClick,
+    onImageMouseDown,
   };
+
+  const renderTileContent = () => {
+    const type = tile.type as SupportedTileType;
+    const TileComponent = TILE_COMPONENTS[type];
+    const buildProps = TILE_PROPS_BUILDERS[type];
+
+    if (TileComponent && buildProps) {
+      const componentProps = buildProps({
+        ...tilePropsContext,
+        tile: tile as TileByType<typeof type>,
+      });
+
+      return <TileComponent {...componentProps} />;
+    }
+
+    return (
+      <div className="w-full h-full flex items-center justify-center">
+        <span className="text-gray-500 text-sm">Nieznany typ kafelka</span>
+      </div>
+    );
+  };
+
   const renderResizeHandles = () => {
     if (!isSelected || isEditingText || isImageEditing || isTestingMode) return null;
 

--- a/src/components/admin/tiles/ImageTileView.tsx
+++ b/src/components/admin/tiles/ImageTileView.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import type { ImageTile } from '../../../types/lessonEditor';
+import type { ImageTileViewProps } from './types';
+
+export const ImageTileView: React.FC<ImageTileViewProps> = ({
+  tile,
+  isSelected,
+  isImageEditing,
+  isDraggingImage,
+  onImageMouseDown,
+  onUpdateTile,
+}) => {
+  const imageTile = tile as ImageTile;
+  const imagePosition = imageTile.content.position || { x: 0, y: 0 };
+  const imageScale = imageTile.content.scale || 1;
+
+  console.log(
+    'Rendering image tile:',
+    imageTile.id,
+    'position:',
+    imagePosition,
+    'scale:',
+    imageScale,
+    'updated_at:',
+    imageTile.updated_at,
+  );
+
+  const handleImageWheel = (e: React.WheelEvent) => {
+    if (!isSelected || !isImageEditing) return;
+
+    e.preventDefault();
+    e.stopPropagation();
+
+    console.log('🎯 Image wheel event - deltaY:', e.deltaY);
+
+    const currentScale = imageTile.content.scale || 1;
+    const zoomSpeed = 0.1;
+    const zoomDirection = e.deltaY > 0 ? -1 : 1;
+    const newScale = Math.max(0.1, Math.min(3, currentScale + (zoomDirection * zoomSpeed)));
+
+    console.log('🎯 Zoom - current:', currentScale, 'new:', newScale, 'direction:', zoomDirection);
+
+    onUpdateTile(tile.id, {
+      content: {
+        ...imageTile.content,
+        scale: newScale,
+      },
+    });
+  };
+
+  return (
+    <div className="w-full h-full overflow-hidden relative">
+      <div
+        className="w-full h-full relative overflow-hidden"
+        style={{ cursor: isSelected && isImageEditing ? 'grab' : 'default' }}
+      >
+        <img
+          src={imageTile.content.url}
+          alt={imageTile.content.alt}
+          className={`absolute select-none ${
+            isSelected && isImageEditing ? 'cursor-grab active:cursor-grabbing' : ''
+          }`}
+          style={{
+            left: imagePosition.x,
+            top: imagePosition.y,
+            transform: `scale(${imageScale})`,
+            transformOrigin: '0 0',
+            maxWidth: 'none',
+            maxHeight: 'none',
+            cursor: isSelected && isImageEditing ? (isDraggingImage ? 'grabbing' : 'grab') : 'default',
+          }}
+          onMouseDown={
+            isSelected && isImageEditing
+              ? (e) => {
+                  console.log('🖱️ Image onMouseDown triggered in TileRenderer');
+                  onImageMouseDown(e, imageTile);
+                }
+              : undefined
+          }
+          onWheel={isSelected && isImageEditing ? handleImageWheel : undefined}
+          draggable={false}
+          onError={(e) => {
+            console.error('Image failed to load:', imageTile.content.url.substring(0, 100));
+            (e.target as HTMLImageElement).src =
+              'https://images.pexels.com/photos/3184291/pexels-photo-3184291.jpeg?auto=compress&cs=tinysrgb&w=400';
+          }}
+          onLoad={() => {
+            console.log('Image loaded successfully');
+          }}
+        />
+      </div>
+      {imageTile.content.caption && (
+        <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/70 to-transparent text-white text-xs p-3">
+          {imageTile.content.caption}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/admin/tiles/MatchPairsTileView.tsx
+++ b/src/components/admin/tiles/MatchPairsTileView.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { MatchPairsInteractive } from '../MatchPairsInteractive';
+import { RichTextEditor } from './RichTextEditor';
+import type { MatchPairsTile, TextTile } from '../../../types/lessonEditor';
+import type { MatchPairsTileViewProps } from './types';
+import { getReadableTextColor } from './utils';
+
+export const MatchPairsTileView: React.FC<MatchPairsTileViewProps> = ({
+  tile,
+  isSelected,
+  isEditingText,
+  isTestingMode,
+  computedBackground,
+  onUpdateTile,
+  onFinishTextEditing,
+  onEditorReady,
+  onDoubleClick,
+}) => {
+  const matchPairsTile = tile as MatchPairsTile;
+  const accentColor = matchPairsTile.content.backgroundColor || computedBackground;
+  const textColor = getReadableTextColor(accentColor);
+
+  const renderMatchPairs = (instructionContent?: React.ReactNode, isPreviewMode = false) => (
+    <MatchPairsInteractive
+      tile={matchPairsTile}
+      isTestingMode={isTestingMode}
+      instructionContent={instructionContent}
+      isPreview={isPreviewMode}
+      onRequestTextEditing={isPreviewMode ? undefined : onDoubleClick}
+    />
+  );
+
+  if (isEditingText && isSelected) {
+    const instructionEditorTile = {
+      ...tile,
+      type: 'text',
+      content: {
+        text: matchPairsTile.content.instruction,
+        richText: matchPairsTile.content.richInstruction,
+        fontFamily: 'Inter, system-ui, sans-serif',
+        fontSize: 16,
+        verticalAlign: 'top',
+        backgroundColor: matchPairsTile.content.backgroundColor,
+        showBorder: true,
+      },
+    } as TextTile;
+
+    return renderMatchPairs(
+      <RichTextEditor
+        textTile={instructionEditorTile}
+        tileId={tile.id}
+        textColor={textColor}
+        onUpdateTile={(tileId, updates) => {
+          if (!updates.content) return;
+
+          onUpdateTile(tileId, {
+            content: {
+              ...matchPairsTile.content,
+              instruction: updates.content.text ?? matchPairsTile.content.instruction,
+              richInstruction:
+                updates.content.richText ?? matchPairsTile.content.richInstruction,
+            },
+          });
+        }}
+        onFinishTextEditing={onFinishTextEditing}
+        onEditorReady={onEditorReady}
+      />,
+      true,
+    );
+  }
+
+  return renderMatchPairs();
+};

--- a/src/components/admin/tiles/ProgrammingTileView.tsx
+++ b/src/components/admin/tiles/ProgrammingTileView.tsx
@@ -1,0 +1,177 @@
+import React from 'react';
+import { Play, Code2 } from 'lucide-react';
+import { TaskInstructionPanel } from '../common/TaskInstructionPanel';
+import { RichTextEditor } from './RichTextEditor';
+import type { ProgrammingTile, TextTile } from '../../../types/lessonEditor';
+import type { ProgrammingTileViewProps } from './types';
+import { darkenColor, getReadableTextColor, surfaceColor } from './utils';
+
+export const ProgrammingTileView: React.FC<ProgrammingTileViewProps> = ({
+  tile,
+  isSelected,
+  isEditingText,
+  computedBackground,
+  onUpdateTile,
+  onFinishTextEditing,
+  onEditorReady,
+}) => {
+  const programmingTile = tile as ProgrammingTile;
+
+  const accentColor = programmingTile.content.backgroundColor || computedBackground;
+  const textColor = getReadableTextColor(accentColor);
+  const isDarkText = textColor === '#0f172a';
+  const mutedTextColor = isDarkText ? '#475569' : '#e2e8f0';
+  const panelBackground = surfaceColor(accentColor, textColor, 0.6, 0.4);
+  const panelBorderColor = surfaceColor(accentColor, textColor, 0.48, 0.55);
+  const chipBackground = surfaceColor(accentColor, textColor, 0.52, 0.48);
+  const statusDotColor = surfaceColor(accentColor, textColor, 0.35, 0.35);
+
+  const descriptionContainerStyle: React.CSSProperties = {
+    backgroundColor: panelBackground,
+    color: textColor,
+    border: `1px solid ${panelBorderColor}`,
+  };
+
+  const codeContainerStyle: React.CSSProperties = {
+    borderColor: darkenColor(accentColor, isDarkText ? 0.35 : 0.55),
+    backgroundColor: darkenColor(accentColor, isDarkText ? 0.55 : 0.75),
+    color: '#f8fafc',
+  };
+
+  let codeDisplayContent = '';
+
+  if (programmingTile.content.startingCode) {
+    codeDisplayContent += programmingTile.content.startingCode + '\n\n';
+  }
+
+  codeDisplayContent += 'wpisz swój kod tutaj';
+
+  if (programmingTile.content.endingCode) {
+    codeDisplayContent += '\n\n' + programmingTile.content.endingCode;
+  }
+
+  const codeLines = codeDisplayContent.split('\n');
+
+  const renderDescriptionBlock = (content: React.ReactNode) => (
+    <TaskInstructionPanel
+      icon={<Code2 className="w-4 h-4" />}
+      label="Zadanie"
+      className="flex-shrink-0 max-h-[45%] overflow-hidden border transition-colors duration-300"
+      style={descriptionContainerStyle}
+      iconWrapperStyle={{ backgroundColor: chipBackground, color: textColor }}
+      labelStyle={{ color: mutedTextColor }}
+    >
+      {content}
+    </TaskInstructionPanel>
+  );
+
+  const renderCodePreview = () => (
+    <div className="flex-1 flex flex-col rounded-xl overflow-hidden border" style={codeContainerStyle}>
+      <div
+        className="flex items-center justify-between px-5 py-4 border-b"
+        style={{
+          borderColor: surfaceColor(accentColor, textColor, 0.42, 0.62),
+          backgroundColor: darkenColor(accentColor, isDarkText ? 0.45 : 0.7),
+        }}
+      >
+        <div className="flex items-center gap-3">
+          <div
+            className="flex items-center justify-center w-10 h-10 rounded-xl"
+            style={{
+              backgroundColor: darkenColor(accentColor, isDarkText ? 0.3 : 0.55),
+              color: '#f8fafc',
+            }}
+          >
+            <Play className="w-4 h-4 text-white" />
+          </div>
+          <div className="flex flex-col">
+            <span className="text-sm font-semibold text-white">Python</span>
+            <span className="text-xs" style={{ color: '#cbd5f5' }}>
+              Tryb nauki
+            </span>
+          </div>
+        </div>
+        <div className="flex items-center gap-3 text-xs" style={{ color: '#cbd5f5' }}>
+          <span className="flex items-center gap-1">
+            <span
+              className="w-2 h-2 rounded-full animate-pulse"
+              style={{ backgroundColor: statusDotColor }}
+            />
+            Gotowy do uruchomienia
+          </span>
+        </div>
+      </div>
+
+      <div className="flex-1 font-mono text-[13px] leading-6 px-5 py-4 text-slate-100 overflow-auto">
+        {codeLines.map((line, index) => (
+          <div key={index} className="flex">
+            <span className="w-8 pr-4 text-right text-slate-500 select-none">{index + 1}</span>
+            <code className="flex-1 whitespace-pre">{line}</code>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+
+  if (isEditingText && isSelected) {
+    return (
+      <div className="w-full h-full flex flex-col gap-5 p-5" style={{ color: textColor }}>
+        {renderDescriptionBlock(
+          <RichTextEditor
+            textTile={{
+              ...tile,
+              type: 'text',
+              content: {
+                text: programmingTile.content.description,
+                richText: programmingTile.content.richDescription,
+                fontFamily: programmingTile.content.fontFamily,
+                fontSize: programmingTile.content.fontSize,
+                verticalAlign: 'top',
+                backgroundColor: programmingTile.content.backgroundColor,
+                showBorder: programmingTile.content.showBorder,
+              },
+            } as TextTile}
+            tileId={tile.id}
+            textColor={textColor}
+            onUpdateTile={(tileId, updates) => {
+              if (updates.content) {
+                onUpdateTile(tileId, {
+                  content: {
+                    ...programmingTile.content,
+                    description: updates.content.text || programmingTile.content.description,
+                    richDescription:
+                      updates.content.richText || programmingTile.content.richDescription,
+                  },
+                });
+              }
+            }}
+            onFinishTextEditing={onFinishTextEditing}
+            onEditorReady={onEditorReady}
+          />,
+        )}
+
+        {renderCodePreview()}
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full h-full flex flex-col gap-5 p-5" style={{ color: textColor }}>
+      {renderDescriptionBlock(
+        <div
+          className="text-sm leading-relaxed"
+          style={{
+            fontFamily: programmingTile.content.fontFamily,
+            fontSize: `${programmingTile.content.fontSize}px`,
+          }}
+          dangerouslySetInnerHTML={{
+            __html:
+              programmingTile.content.richDescription || programmingTile.content.description,
+          }}
+        />,
+      )}
+
+      {renderCodePreview()}
+    </div>
+  );
+};

--- a/src/components/admin/tiles/QuizTileView.tsx
+++ b/src/components/admin/tiles/QuizTileView.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { QuizInteractive } from '../QuizInteractive';
+import { RichTextEditor } from './RichTextEditor';
+import type { QuizTile, TextTile } from '../../../types/lessonEditor';
+import type { QuizTileViewProps } from './types';
+import { getReadableTextColor } from './utils';
+
+export const QuizTileView: React.FC<QuizTileViewProps> = ({
+  tile,
+  isSelected,
+  isEditingText,
+  isTestingMode,
+  computedBackground,
+  onUpdateTile,
+  onFinishTextEditing,
+  onEditorReady,
+  onDoubleClick,
+}) => {
+  const quizTile = tile as QuizTile;
+  const questionTextColor = getReadableTextColor(
+    quizTile.content.backgroundColor || computedBackground,
+  );
+
+  if (isEditingText && isSelected) {
+    const questionEditorTile: TextTile = {
+      ...tile,
+      type: 'text',
+      content: {
+        text: quizTile.content.question,
+        richText: quizTile.content.richQuestion,
+        fontFamily: quizTile.content.questionFontFamily || 'Inter',
+        fontSize: quizTile.content.questionFontSize ?? 16,
+        verticalAlign: 'top',
+        backgroundColor: quizTile.content.backgroundColor || computedBackground,
+        showBorder:
+          typeof quizTile.content.showBorder === 'boolean'
+            ? quizTile.content.showBorder
+            : true,
+      },
+    };
+
+    return (
+      <QuizInteractive
+        tile={quizTile}
+        isPreview
+        instructionContent={
+          <RichTextEditor
+            textTile={questionEditorTile}
+            tileId={tile.id}
+            onUpdateTile={(tileId, updates) => {
+              if (!updates.content) return;
+
+              onUpdateTile(tileId, {
+                content: {
+                  ...quizTile.content,
+                  question: updates.content.text ?? quizTile.content.question,
+                  richQuestion: updates.content.richText ?? quizTile.content.richQuestion,
+                  questionFontFamily:
+                    updates.content.fontFamily ?? quizTile.content.questionFontFamily,
+                  questionFontSize:
+                    updates.content.fontSize ?? quizTile.content.questionFontSize,
+                },
+              });
+            }}
+            onFinishTextEditing={onFinishTextEditing}
+            onEditorReady={onEditorReady}
+            textColor={questionTextColor}
+          />
+        }
+      />
+    );
+  }
+
+  return (
+    <QuizInteractive
+      tile={quizTile}
+      isTestingMode={isTestingMode}
+      onRequestTextEditing={onDoubleClick}
+    />
+  );
+};

--- a/src/components/admin/tiles/RichTextEditor.tsx
+++ b/src/components/admin/tiles/RichTextEditor.tsx
@@ -1,0 +1,131 @@
+import React, { useEffect } from 'react';
+import { EditorContent, useEditor, type Editor } from '@tiptap/react';
+import StarterKit from '@tiptap/starter-kit';
+import Underline from '@tiptap/extension-underline';
+import { TextStyle } from '@tiptap/extension-text-style';
+import Color from '@tiptap/extension-color';
+import FontFamily from '@tiptap/extension-font-family';
+import BulletList from '@tiptap/extension-bullet-list';
+import OrderedList from '@tiptap/extension-ordered-list';
+import ListItem from '@tiptap/extension-list-item';
+import { TextAlign } from '../../../extensions/TextAlign';
+import FontSize from '../../../extensions/FontSize';
+import type { LessonTile, TextTile } from '../../../types/lessonEditor';
+
+interface RichTextEditorProps {
+  textTile: TextTile;
+  tileId: string;
+  onUpdateTile: (tileId: string, updates: Partial<LessonTile>) => void;
+  onFinishTextEditing: () => void;
+  onEditorReady: (editor: Editor | null) => void;
+  textColor?: string;
+}
+
+export const RichTextEditor: React.FC<RichTextEditorProps> = ({
+  textTile,
+  tileId,
+  onUpdateTile,
+  onFinishTextEditing,
+  onEditorReady,
+  textColor,
+}) => {
+  const editor = useEditor({
+    extensions: [
+      StarterKit.configure({
+        bulletList: false,
+        orderedList: false,
+        listItem: false,
+      }),
+      BulletList.configure({
+        HTMLAttributes: { class: 'bullet-list' },
+        keepMarks: true,
+        keepAttributes: true,
+      }),
+      OrderedList.configure({
+        HTMLAttributes: { class: 'ordered-list' },
+        keepMarks: true,
+        keepAttributes: true,
+      }),
+      ListItem,
+      Underline,
+      TextStyle,
+      Color.configure({ types: ['textStyle'] }),
+      FontFamily.configure({ types: ['textStyle'] }),
+      FontSize,
+      TextAlign.configure({ types: ['paragraph'] }),
+    ],
+    content:
+      textTile.content.richText ||
+      `<p style="margin: 0;">${textTile.content.text || ''}</p>`,
+    onUpdate: ({ editor }) => {
+      const html = editor.getHTML();
+      const plain = editor.getText();
+      onUpdateTile(tileId, {
+        content: {
+          ...textTile.content,
+          text: plain,
+          richText: html,
+        },
+      });
+    },
+    autofocus: true,
+  });
+
+  useEffect(() => {
+    onEditorReady(editor);
+    return () => onEditorReady(null);
+  }, [editor, onEditorReady]);
+
+  if (!editor) return null;
+
+  const handleBlur = (e: React.FocusEvent) => {
+    const toolbar = document.querySelector('.top-toolbar');
+    if (toolbar && e.relatedTarget && toolbar.contains(e.relatedTarget as Node)) {
+      e.preventDefault();
+      editor.commands.focus();
+      return;
+    }
+    onFinishTextEditing();
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Tab') {
+      e.preventDefault();
+      if (editor.isActive('listItem')) {
+        if (e.shiftKey) {
+          editor.chain().focus().liftListItem('listItem').run();
+        } else {
+          editor.chain().focus().sinkListItem('listItem').run();
+        }
+      } else {
+        editor.chain().focus().insertContent('\t').run();
+      }
+    }
+  };
+
+  return (
+    <div
+      className="w-full h-full p-3 overflow-hidden relative tile-text-content tiptap-editor"
+      style={{
+        fontSize: `${textTile.content.fontSize}px`,
+        fontFamily: textTile.content.fontFamily,
+        color: textColor,
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent:
+          textTile.content.verticalAlign === 'center'
+            ? 'center'
+            : textTile.content.verticalAlign === 'bottom'
+            ? 'flex-end'
+            : 'flex-start',
+      }}
+    >
+      <EditorContent
+        editor={editor}
+        className="w-full focus:outline-none break-words rich-text-content tile-formatted-text"
+        onBlur={handleBlur}
+        onKeyDown={handleKeyDown}
+      />
+    </div>
+  );
+};

--- a/src/components/admin/tiles/SequencingTileView.tsx
+++ b/src/components/admin/tiles/SequencingTileView.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { SequencingInteractive } from '../SequencingInteractive';
+import { RichTextEditor } from './RichTextEditor';
+import type { SequencingTile, TextTile } from '../../../types/lessonEditor';
+import type { SequencingTileViewProps } from './types';
+import { getReadableTextColor } from './utils';
+
+export const SequencingTileView: React.FC<SequencingTileViewProps> = ({
+  tile,
+  isSelected,
+  isEditingText,
+  isTestingMode,
+  computedBackground,
+  onUpdateTile,
+  onFinishTextEditing,
+  onEditorReady,
+  onDoubleClick,
+}) => {
+  const sequencingTile = tile as SequencingTile;
+  const accentColor = sequencingTile.content.backgroundColor || computedBackground;
+  const textColor = getReadableTextColor(accentColor);
+
+  const renderSequencingContent = (
+    instructionContent?: React.ReactNode,
+    isPreviewMode = false,
+  ) => (
+    <SequencingInteractive
+      tile={sequencingTile}
+      isTestingMode={isTestingMode}
+      instructionContent={instructionContent}
+      isPreview={isPreviewMode}
+      onRequestTextEditing={isPreviewMode ? undefined : onDoubleClick}
+    />
+  );
+
+  if (isEditingText && isSelected) {
+    const questionEditorTile = {
+      ...tile,
+      type: 'text',
+      content: {
+        text: sequencingTile.content.question,
+        richText: sequencingTile.content.richQuestion,
+        fontFamily: sequencingTile.content.fontFamily,
+        fontSize: sequencingTile.content.fontSize,
+        verticalAlign: sequencingTile.content.verticalAlign,
+        backgroundColor: sequencingTile.content.backgroundColor,
+        showBorder: sequencingTile.content.showBorder,
+      },
+    } as TextTile;
+
+    return renderSequencingContent(
+      <RichTextEditor
+        textTile={questionEditorTile}
+        tileId={tile.id}
+        textColor={textColor}
+        onUpdateTile={(tileId, updates) => {
+          if (!updates.content) return;
+
+          onUpdateTile(tileId, {
+            content: {
+              ...sequencingTile.content,
+              question: updates.content.text ?? sequencingTile.content.question,
+              richQuestion: updates.content.richText ?? sequencingTile.content.richQuestion,
+              fontFamily: updates.content.fontFamily ?? sequencingTile.content.fontFamily,
+              fontSize: updates.content.fontSize ?? sequencingTile.content.fontSize,
+              verticalAlign:
+                updates.content.verticalAlign ?? sequencingTile.content.verticalAlign,
+            },
+          });
+        }}
+        onFinishTextEditing={onFinishTextEditing}
+        onEditorReady={onEditorReady}
+      />,
+      true,
+    );
+  }
+
+  return renderSequencingContent();
+};

--- a/src/components/admin/tiles/TextTileView.tsx
+++ b/src/components/admin/tiles/TextTileView.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import type { TextTile } from '../../../types/lessonEditor';
+import { RichTextEditor } from './RichTextEditor';
+import type { TextTileViewProps } from './types';
+
+export const TextTileView: React.FC<TextTileViewProps> = ({
+  tile,
+  isSelected,
+  isEditingText,
+  textColor,
+  onUpdateTile,
+  onFinishTextEditing,
+  onEditorReady,
+}) => {
+  const textTile = tile as TextTile;
+
+  if (isEditingText && isSelected) {
+    return (
+      <RichTextEditor
+        textTile={textTile}
+        tileId={tile.id}
+        onUpdateTile={onUpdateTile}
+        onFinishTextEditing={onFinishTextEditing}
+        onEditorReady={onEditorReady}
+        textColor={textColor}
+      />
+    );
+  }
+
+  return (
+    <div
+      className="w-full h-full p-3 overflow-hidden tile-text-content"
+      style={{
+        fontSize: `${textTile.content.fontSize}px`,
+        fontFamily: textTile.content.fontFamily,
+        color: textColor,
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent:
+          textTile.content.verticalAlign === 'center'
+            ? 'center'
+            : textTile.content.verticalAlign === 'bottom'
+            ? 'flex-end'
+            : 'flex-start',
+      }}
+    >
+      <div
+        className="break-words rich-text-content tile-formatted-text w-full"
+        style={{
+          minHeight: '1em',
+          outline: 'none',
+        }}
+        dangerouslySetInnerHTML={{
+          __html:
+            textTile.content.richText ||
+            `<p style="margin: 0;">${textTile.content.text || 'Kliknij dwukrotnie, aby edytować'}</p>`,
+        }}
+      />
+    </div>
+  );
+};

--- a/src/components/admin/tiles/index.ts
+++ b/src/components/admin/tiles/index.ts
@@ -1,0 +1,44 @@
+import type React from 'react';
+import { MatchPairsTileView } from './MatchPairsTileView';
+import { ProgrammingTileView } from './ProgrammingTileView';
+import { QuizTileView } from './QuizTileView';
+import { SequencingTileView } from './SequencingTileView';
+import { TextTileView } from './TextTileView';
+import { ImageTileView } from './ImageTileView';
+import type {
+  TextTileViewProps,
+  ImageTileViewProps,
+  ProgrammingTileViewProps,
+  QuizTileViewProps,
+  SequencingTileViewProps,
+  MatchPairsTileViewProps,
+} from './types';
+import type { LessonTile } from '../../../types/lessonEditor';
+
+export type TileComponentMap = {
+  text: React.ComponentType<TextTileViewProps>;
+  image: React.ComponentType<ImageTileViewProps>;
+  programming: React.ComponentType<ProgrammingTileViewProps>;
+  quiz: React.ComponentType<QuizTileViewProps>;
+  sequencing: React.ComponentType<SequencingTileViewProps>;
+  matchPairs: React.ComponentType<MatchPairsTileViewProps>;
+};
+
+export const TILE_COMPONENTS: Partial<TileComponentMap> = {
+  text: TextTileView,
+  image: ImageTileView,
+  programming: ProgrammingTileView,
+  quiz: QuizTileView,
+  sequencing: SequencingTileView,
+  matchPairs: MatchPairsTileView,
+};
+
+export type TileComponentType = LessonTile['type'];
+export {
+  TextTileView,
+  ImageTileView,
+  ProgrammingTileView,
+  QuizTileView,
+  SequencingTileView,
+  MatchPairsTileView,
+};

--- a/src/components/admin/tiles/types.ts
+++ b/src/components/admin/tiles/types.ts
@@ -1,0 +1,40 @@
+import type { Editor } from '@tiptap/react';
+import type {
+  LessonTile,
+  TextTile,
+  ImageTile,
+  ProgrammingTile,
+  QuizTile,
+  SequencingTile,
+  MatchPairsTile,
+} from '../../../types/lessonEditor';
+
+export interface BaseTileViewProps<T extends LessonTile> {
+  tile: T;
+  isSelected: boolean;
+  isEditingText: boolean;
+  computedBackground: string;
+  onUpdateTile: (tileId: string, updates: Partial<LessonTile>) => void;
+  onFinishTextEditing: () => void;
+  onEditorReady: (editor: Editor | null) => void;
+  isTestingMode?: boolean;
+  onDoubleClick?: () => void;
+}
+
+export interface TextTileViewProps extends BaseTileViewProps<TextTile> {
+  textColor: string;
+}
+
+export interface ImageTileViewProps extends BaseTileViewProps<ImageTile> {
+  isImageEditing: boolean;
+  isDraggingImage: boolean;
+  onImageMouseDown: (event: React.MouseEvent, tile: ImageTile) => void;
+}
+
+export type ProgrammingTileViewProps = BaseTileViewProps<ProgrammingTile>;
+
+export type QuizTileViewProps = BaseTileViewProps<QuizTile>;
+
+export type SequencingTileViewProps = BaseTileViewProps<SequencingTile>;
+
+export type MatchPairsTileViewProps = BaseTileViewProps<MatchPairsTile>;

--- a/src/components/admin/tiles/utils.ts
+++ b/src/components/admin/tiles/utils.ts
@@ -1,0 +1,61 @@
+export const hexToRgb = (hex: string): { r: number; g: number; b: number } | null => {
+  if (!hex) return null;
+
+  let normalized = hex.replace('#', '').trim();
+  if (normalized.length === 3) {
+    normalized = normalized.split('').map((char) => `${char}${char}`).join('');
+  }
+
+  if (normalized.length !== 6) return null;
+
+  const intValue = Number.parseInt(normalized, 16);
+  if (Number.isNaN(intValue)) return null;
+
+  return {
+    r: (intValue >> 16) & 255,
+    g: (intValue >> 8) & 255,
+    b: intValue & 255,
+  };
+};
+
+const channelToLinear = (value: number): number => {
+  const scaled = value / 255;
+  return scaled <= 0.03928 ? scaled / 12.92 : Math.pow((scaled + 0.055) / 1.055, 2.4);
+};
+
+export const getReadableTextColor = (hex: string): string => {
+  const rgb = hexToRgb(hex);
+  if (!rgb) return '#0f172a';
+
+  const luminance = (0.2126 * channelToLinear(rgb.r)) +
+    (0.7152 * channelToLinear(rgb.g)) +
+    (0.0722 * channelToLinear(rgb.b));
+
+  return luminance > 0.6 ? '#0f172a' : '#f8fafc';
+};
+
+export const lightenColor = (hex: string, amount: number): string => {
+  const rgb = hexToRgb(hex);
+  if (!rgb) return hex;
+
+  const lightenChannel = (channel: number) => Math.round(channel + (255 - channel) * amount);
+  return `rgb(${lightenChannel(rgb.r)}, ${lightenChannel(rgb.g)}, ${lightenChannel(rgb.b)})`;
+};
+
+export const darkenColor = (hex: string, amount: number): string => {
+  const rgb = hexToRgb(hex);
+  if (!rgb) return hex;
+
+  const darkenChannel = (channel: number) => Math.round(channel * (1 - amount));
+  return `rgb(${darkenChannel(rgb.r)}, ${darkenChannel(rgb.g)}, ${darkenChannel(rgb.b)})`;
+};
+
+export const surfaceColor = (
+  accent: string,
+  textColor: string,
+  lightenAmount: number,
+  darkenAmount: number
+): string => (textColor === '#0f172a'
+  ? lightenColor(accent, lightenAmount)
+  : darkenColor(accent, darkenAmount)
+);


### PR DESCRIPTION
## Summary
- extract tile-type rendering into dedicated components under `src/components/admin/tiles`
- add a registry that maps lesson tile types to their view components and update `TileRenderer` to use it
- adjust canvas tile rendering to the new image callback signature

## Testing
- npm run lint *(fails: pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68daf9fdb64883218fc77a2869173152