### PR TITLE
Refactor admin rich text editor usage

### DIFF
--- a/src/components/admin/MatchPairsInteractive.tsx
+++ b/src/components/admin/MatchPairsInteractive.tsx
@@ -3,13 +3,14 @@ import { CheckCircle, XCircle, RefreshCw, Sparkles, Puzzle, RotateCcw } from 'lu
 import { MatchPairsTile } from '../../types/lessonEditor';
 import { createBlankId, createPlaceholderRegex } from '../../utils/matchPairs';
 import { TaskInstructionPanel } from './common/TaskInstructionPanel';
+import { RichTextEditor, RichTextEditorProps } from './common/RichTextEditor';
 
 interface MatchPairsInteractiveProps {
   tile: MatchPairsTile;
   isPreview?: boolean;
   isTestingMode?: boolean;
-  instructionContent?: React.ReactNode;
   onRequestTextEditing?: () => void;
+  instructionEditorProps?: RichTextEditorProps;
 }
 
 type Segment =
@@ -127,8 +128,8 @@ export const MatchPairsInteractive: React.FC<MatchPairsInteractiveProps> = ({
   tile,
   isPreview = false,
   isTestingMode = false,
-  instructionContent,
-  onRequestTextEditing
+  onRequestTextEditing,
+  instructionEditorProps
 }) => {
   const [placements, setPlacements] = useState<Record<string, string | null>>({});
   const [evaluation, setEvaluation] = useState<EvaluationState>('idle');
@@ -384,7 +385,9 @@ export const MatchPairsInteractive: React.FC<MatchPairsInteractiveProps> = ({
           }}
           labelStyle={{ color: mutedLabelColor }}
         >
-          {instructionContent ?? (
+          {instructionEditorProps ? (
+            <RichTextEditor {...instructionEditorProps} />
+          ) : (
             <div
               className="text-base leading-relaxed"
               dangerouslySetInnerHTML={{

--- a/src/components/admin/QuizInteractive.tsx
+++ b/src/components/admin/QuizInteractive.tsx
@@ -2,13 +2,14 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { CheckCircle2, Circle, HelpCircle, RotateCcw, XCircle } from 'lucide-react';
 import { QuizTile } from '../../types/lessonEditor';
 import { TaskInstructionPanel } from './common/TaskInstructionPanel';
+import { RichTextEditor, RichTextEditorProps } from './common/RichTextEditor';
 
 interface QuizInteractiveProps {
   tile: QuizTile;
   isPreview?: boolean;
   isTestingMode?: boolean;
   onRequestTextEditing?: () => void;
-  instructionContent?: React.ReactNode;
+  instructionEditorProps?: RichTextEditorProps;
 }
 
 type EvaluationState = 'idle' | 'correct' | 'incorrect';
@@ -77,7 +78,7 @@ export const QuizInteractive: React.FC<QuizInteractiveProps> = ({
   isPreview = false,
   isTestingMode = false,
   onRequestTextEditing,
-  instructionContent
+  instructionEditorProps
 }) => {
   const [selectedAnswers, setSelectedAnswers] = useState<number[]>([]);
   const [evaluationState, setEvaluationState] = useState<EvaluationState>('idle');
@@ -177,8 +178,8 @@ export const QuizInteractive: React.FC<QuizInteractiveProps> = ({
   };
 
   const renderInstructionContent = () => {
-    if (instructionContent) {
-      return instructionContent;
+    if (instructionEditorProps) {
+      return <RichTextEditor {...instructionEditorProps} />;
     }
 
     return (

--- a/src/components/admin/SequencingInteractive.tsx
+++ b/src/components/admin/SequencingInteractive.tsx
@@ -2,13 +2,14 @@ import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import { CheckCircle, XCircle, RotateCcw, Sparkles, GripVertical, Shuffle, ArrowLeftRight } from 'lucide-react';
 import { SequencingTile } from '../../types/lessonEditor';
 import { TaskInstructionPanel } from './common/TaskInstructionPanel';
+import { RichTextEditor, RichTextEditorProps } from './common/RichTextEditor';
 
 interface SequencingInteractiveProps {
   tile: SequencingTile;
   isPreview?: boolean;
   isTestingMode?: boolean;
   onRequestTextEditing?: () => void;
-  instructionContent?: React.ReactNode;
+  instructionEditorProps?: RichTextEditorProps;
   variant?: 'standalone' | 'embedded';
 }
 
@@ -90,7 +91,7 @@ export const SequencingInteractive: React.FC<SequencingInteractiveProps> = ({
   isPreview = false,
   isTestingMode = false,
   onRequestTextEditing,
-  instructionContent,
+  instructionEditorProps,
   variant = 'embedded'
 }) => {
   const [availableItems, setAvailableItems] = useState<DraggedItem[]>([]);
@@ -542,7 +543,9 @@ export const SequencingInteractive: React.FC<SequencingInteractiveProps> = ({
           labelStyle={{ color: mutedLabelColor }}
           bodyClassName="px-5 pb-5"
         >
-          {instructionContent ?? (
+          {instructionEditorProps ? (
+            <RichTextEditor {...instructionEditorProps} />
+          ) : (
             <div
               className="text-base leading-relaxed"
               style={{

--- a/src/components/admin/TileRenderer.tsx
+++ b/src/components/admin/TileRenderer.tsx
@@ -1,22 +1,13 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { Move, Trash2, Play, Code2 } from 'lucide-react';
 import { LessonTile, TextTile, ImageTile, QuizTile, ProgrammingTile, SequencingTile, MatchPairsTile } from '../../types/lessonEditor';
 import { GridUtils } from '../../utils/gridUtils';
-import { Editor, EditorContent, useEditor } from '@tiptap/react';
-import StarterKit from '@tiptap/starter-kit';
-import Underline from '@tiptap/extension-underline';
-import { TextStyle } from '@tiptap/extension-text-style';
-import Color from '@tiptap/extension-color';
-import FontFamily from '@tiptap/extension-font-family';
-import FontSize from '../../extensions/FontSize';
-import BulletList from '@tiptap/extension-bullet-list';
-import OrderedList from '@tiptap/extension-ordered-list';
-import ListItem from '@tiptap/extension-list-item';
-import TextAlign from '../../extensions/TextAlign';
+import { Editor } from '@tiptap/react';
 import { SequencingInteractive } from './SequencingInteractive';
 import { MatchPairsInteractive } from './MatchPairsInteractive';
 import { TaskInstructionPanel } from './common/TaskInstructionPanel';
 import { QuizInteractive } from './QuizInteractive';
+import { RichTextEditor, createRichTextAdapter, RichTextEditorProps } from './common/RichTextEditor';
 
 const hexToRgb = (hex: string): { r: number; g: number; b: number } | null => {
   if (!hex) return null;
@@ -92,117 +83,6 @@ interface TileRendererProps {
   showGrid: boolean;
   onEditorReady: (editor: Editor | null) => void;
 }
-
-interface RichTextEditorProps {
-  textTile: TextTile;
-  tileId: string;
-  onUpdateTile: (tileId: string, updates: Partial<LessonTile>) => void;
-  onFinishTextEditing: () => void;
-  onEditorReady: (editor: Editor | null) => void;
-  textColor?: string;
-}
-
-const RichTextEditor: React.FC<RichTextEditorProps> = ({ textTile, tileId, onUpdateTile, onFinishTextEditing, onEditorReady, textColor }) => {
-  const editor = useEditor({
-    extensions: [
-      StarterKit.configure({
-        bulletList: false,
-        orderedList: false,
-        listItem: false,
-      }),
-      BulletList.configure({
-        HTMLAttributes: { class: 'bullet-list' },
-        keepMarks: true,
-        keepAttributes: true,
-      }),
-      OrderedList.configure({
-        HTMLAttributes: { class: 'ordered-list' },
-        keepMarks: true,
-        keepAttributes: true,
-      }),
-      ListItem,
-      Underline,
-      TextStyle,
-      Color.configure({ types: ['textStyle'] }),
-      FontFamily.configure({ types: ['textStyle'] }),
-      FontSize,
-      TextAlign.configure({ types: ['paragraph'] }),
-    ],
-    content:
-      textTile.content.richText ||
-      `<p style="margin: 0;">${textTile.content.text || ''}</p>`,
-    onUpdate: ({ editor }) => {
-      const html = editor.getHTML();
-      const plain = editor.getText();
-      onUpdateTile(tileId, {
-        content: {
-          ...textTile.content,
-          text: plain,
-          richText: html
-        }
-      });
-    },
-    autofocus: true
-  });
-
-  useEffect(() => {
-    onEditorReady(editor);
-    return () => onEditorReady(null);
-  }, [editor, onEditorReady]);
-
-  if (!editor) return null;
-
-  const handleBlur = (e: React.FocusEvent) => {
-    const toolbar = document.querySelector('.top-toolbar');
-    if (toolbar && e.relatedTarget && toolbar.contains(e.relatedTarget as Node)) {
-      e.preventDefault();
-      editor.commands.focus();
-      return;
-    }
-    onFinishTextEditing();
-  };
-
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Tab') {
-      e.preventDefault();
-      if (editor.isActive('listItem')) {
-        if (e.shiftKey) {
-          editor.chain().focus().liftListItem('listItem').run();
-        } else {
-          editor.chain().focus().sinkListItem('listItem').run();
-        }
-      } else {
-        editor.chain().focus().insertContent('\t').run();
-      }
-    }
-  };
-
-  return (
-    <div
-      className="w-full h-full p-3 overflow-hidden relative tile-text-content tiptap-editor"
-      style={{
-        fontSize: `${textTile.content.fontSize}px`,
-        fontFamily: textTile.content.fontFamily,
-        color: textColor,
-        display: 'flex',
-        flexDirection: 'column',
-        justifyContent:
-          textTile.content.verticalAlign === 'center'
-            ? 'center'
-            : textTile.content.verticalAlign === 'bottom'
-            ? 'flex-end'
-            : 'flex-start',
-      }}
-    >
-      <EditorContent
-        editor={editor}
-        className="w-full focus:outline-none break-words rich-text-content tile-formatted-text"
-        onBlur={handleBlur}
-        onKeyDown={handleKeyDown}
-      />
-    </div>
-  );
-};
 
 export const TileRenderer: React.FC<TileRendererProps> = ({
   tile,
@@ -305,12 +185,30 @@ export const TileRenderer: React.FC<TileRendererProps> = ({
 
           // If this text tile is being edited, use Tiptap editor
           if (isEditingText && isSelected) {
+            const adapter = createRichTextAdapter({
+              source: textTile.content,
+              fields: {
+                text: 'text',
+                richText: 'richText',
+                fontFamily: 'fontFamily',
+                fontSize: 'fontSize',
+                verticalAlign: 'verticalAlign'
+              },
+              defaults: {
+                backgroundColor: textTile.content.backgroundColor,
+                showBorder: textTile.content.showBorder
+              }
+            });
+
             contentToRender = (
               <RichTextEditor
-                textTile={textTile}
-                tileId={tile.id}
-                onUpdateTile={onUpdateTile}
-                onFinishTextEditing={onFinishTextEditing}
+                content={adapter.content}
+                onChange={(updatedContent) => {
+                  onUpdateTile(tile.id, {
+                    content: adapter.applyChanges(updatedContent)
+                  });
+                }}
+                onFinish={onFinishTextEditing}
                 onEditorReady={onEditorReady}
                 textColor={defaultTextColor}
               />
@@ -506,37 +404,33 @@ export const TileRenderer: React.FC<TileRendererProps> = ({
         );
 
         if (isEditingText && isSelected) {
+          const adapter = createRichTextAdapter({
+            source: programmingTile.content,
+            fields: {
+              text: 'description',
+              richText: 'richDescription',
+              fontFamily: 'fontFamily',
+              fontSize: 'fontSize'
+            },
+            defaults: {
+              backgroundColor: programmingTile.content.backgroundColor,
+              showBorder: programmingTile.content.showBorder,
+              verticalAlign: 'top'
+            }
+          });
+
           contentToRender = (
             <div className="w-full h-full flex flex-col gap-5 p-5" style={{ color: textColor }}>
               {renderDescriptionBlock(
                 <RichTextEditor
-                  textTile={{
-                    ...tile,
-                    type: 'text',
-                    content: {
-                      text: programmingTile.content.description,
-                      richText: programmingTile.content.richDescription,
-                      fontFamily: programmingTile.content.fontFamily,
-                      fontSize: programmingTile.content.fontSize,
-                      verticalAlign: 'top',
-                      backgroundColor: programmingTile.content.backgroundColor,
-                      showBorder: programmingTile.content.showBorder
-                    }
-                  } as TextTile}
-                  tileId={tile.id}
                   textColor={textColor}
-                  onUpdateTile={(tileId, updates) => {
-                    if (updates.content) {
-                      onUpdateTile(tileId, {
-                        content: {
-                          ...programmingTile.content,
-                          description: updates.content.text || programmingTile.content.description,
-                          richDescription: updates.content.richText || programmingTile.content.richDescription
-                        }
-                      });
-                    }
+                  content={adapter.content}
+                  onChange={(updatedContent) => {
+                    onUpdateTile(tile.id, {
+                      content: adapter.applyChanges(updatedContent)
+                    });
                   }}
-                  onFinishTextEditing={onFinishTextEditing}
+                  onFinish={onFinishTextEditing}
                   onEditorReady={onEditorReady}
                 />
               )}
@@ -573,12 +467,15 @@ export const TileRenderer: React.FC<TileRendererProps> = ({
         );
 
         if (isEditingText && isSelected) {
-          const questionEditorTile: TextTile = {
-            ...tile,
-            type: 'text',
-            content: {
-              text: quizTile.content.question,
-              richText: quizTile.content.richQuestion,
+          const questionAdapter = createRichTextAdapter({
+            source: quizTile.content,
+            fields: {
+              text: 'question',
+              richText: 'richQuestion',
+              fontFamily: 'questionFontFamily',
+              fontSize: 'questionFontSize'
+            },
+            defaults: {
               fontFamily: quizTile.content.questionFontFamily || 'Inter',
               fontSize: quizTile.content.questionFontSize ?? 16,
               verticalAlign: 'top',
@@ -588,36 +485,23 @@ export const TileRenderer: React.FC<TileRendererProps> = ({
                   ? quizTile.content.showBorder
                   : true
             }
-          };
+          });
 
           contentToRender = (
             <QuizInteractive
               tile={quizTile}
               isPreview
-              instructionContent={
-                <RichTextEditor
-                  textTile={questionEditorTile}
-                  tileId={tile.id}
-                  onUpdateTile={(tileId, updates) => {
-                    if (!updates.content) return;
-
-                    onUpdateTile(tileId, {
-                      content: {
-                        ...quizTile.content,
-                        question: updates.content.text ?? quizTile.content.question,
-                        richQuestion: updates.content.richText ?? quizTile.content.richQuestion,
-                        questionFontFamily:
-                          updates.content.fontFamily ?? quizTile.content.questionFontFamily,
-                        questionFontSize:
-                          updates.content.fontSize ?? quizTile.content.questionFontSize
-                      }
-                    });
-                  }}
-                  onFinishTextEditing={onFinishTextEditing}
-                  onEditorReady={onEditorReady}
-                  textColor={questionTextColor}
-                />
-              }
+              instructionEditorProps={{
+                content: questionAdapter.content,
+                onChange: (updatedContent) => {
+                  onUpdateTile(tile.id, {
+                    content: questionAdapter.applyChanges(updatedContent)
+                  });
+                },
+                onFinish: onFinishTextEditing,
+                onEditorReady,
+                textColor: questionTextColor
+              }}
             />
           );
         } else {
@@ -637,53 +521,47 @@ export const TileRenderer: React.FC<TileRendererProps> = ({
         const accentColor = sequencingTile.content.backgroundColor || computedBackground;
         const textColor = getReadableTextColor(accentColor);
 
-        const renderSequencingContent = (instructionContent?: React.ReactNode, isPreviewMode = false) => (
+        const renderSequencingContent = (
+          instructionEditorProps?: RichTextEditorProps,
+          isPreviewMode = false
+        ) => (
           <SequencingInteractive
             tile={sequencingTile}
             isTestingMode={isTestingMode}
-            instructionContent={instructionContent}
+            instructionEditorProps={instructionEditorProps}
             isPreview={isPreviewMode}
             onRequestTextEditing={isPreviewMode ? undefined : onDoubleClick}
           />
         );
 
         if (isEditingText && isSelected) {
-          const questionEditorTile = {
-            ...tile,
-            type: 'text',
-            content: {
-              text: sequencingTile.content.question,
-              richText: sequencingTile.content.richQuestion,
-              fontFamily: sequencingTile.content.fontFamily,
-              fontSize: sequencingTile.content.fontSize,
-              verticalAlign: sequencingTile.content.verticalAlign,
+          const instructionAdapter = createRichTextAdapter({
+            source: sequencingTile.content,
+            fields: {
+              text: 'question',
+              richText: 'richQuestion',
+              fontFamily: 'fontFamily',
+              fontSize: 'fontSize',
+              verticalAlign: 'verticalAlign'
+            },
+            defaults: {
               backgroundColor: sequencingTile.content.backgroundColor,
               showBorder: sequencingTile.content.showBorder
             }
-          } as TextTile;
+          });
 
           contentToRender = renderSequencingContent(
-            <RichTextEditor
-              textTile={questionEditorTile}
-              tileId={tile.id}
-              textColor={textColor}
-              onUpdateTile={(tileId, updates) => {
-                if (!updates.content) return;
-
-                onUpdateTile(tileId, {
-                  content: {
-                    ...sequencingTile.content,
-                    question: updates.content.text ?? sequencingTile.content.question,
-                    richQuestion: updates.content.richText ?? sequencingTile.content.richQuestion,
-                    fontFamily: updates.content.fontFamily ?? sequencingTile.content.fontFamily,
-                    fontSize: updates.content.fontSize ?? sequencingTile.content.fontSize,
-                    verticalAlign: updates.content.verticalAlign ?? sequencingTile.content.verticalAlign
-                  }
+            {
+              content: instructionAdapter.content,
+              onChange: (updatedContent) => {
+                onUpdateTile(tile.id, {
+                  content: instructionAdapter.applyChanges(updatedContent)
                 });
-              }}
-              onFinishTextEditing={onFinishTextEditing}
-              onEditorReady={onEditorReady}
-            />,
+              },
+              onFinish: onFinishTextEditing,
+              onEditorReady,
+              textColor
+            },
             true
           );
         } else {
@@ -697,50 +575,47 @@ export const TileRenderer: React.FC<TileRendererProps> = ({
         const accentColor = matchPairsTile.content.backgroundColor || computedBackground;
         const textColor = getReadableTextColor(accentColor);
 
-        const renderMatchPairs = (instructionContent?: React.ReactNode, isPreviewMode = false) => (
+        const renderMatchPairs = (
+          instructionEditorProps?: RichTextEditorProps,
+          isPreviewMode = false
+        ) => (
           <MatchPairsInteractive
             tile={matchPairsTile}
             isTestingMode={isTestingMode}
-            instructionContent={instructionContent}
+            instructionEditorProps={instructionEditorProps}
             isPreview={isPreviewMode}
             onRequestTextEditing={isPreviewMode ? undefined : onDoubleClick}
           />
         );
 
         if (isEditingText && isSelected) {
-          const instructionEditorTile = {
-            ...tile,
-            type: 'text',
-            content: {
-              text: matchPairsTile.content.instruction,
-              richText: matchPairsTile.content.richInstruction,
+          const instructionAdapter = createRichTextAdapter({
+            source: matchPairsTile.content,
+            fields: {
+              text: 'instruction',
+              richText: 'richInstruction'
+            },
+            defaults: {
               fontFamily: 'Inter, system-ui, sans-serif',
               fontSize: 16,
               verticalAlign: 'top',
               backgroundColor: matchPairsTile.content.backgroundColor,
               showBorder: true
             }
-          } as TextTile;
+          });
 
           contentToRender = renderMatchPairs(
-            <RichTextEditor
-              textTile={instructionEditorTile}
-              tileId={tile.id}
-              textColor={textColor}
-              onUpdateTile={(tileId, updates) => {
-                if (!updates.content) return;
-
-                onUpdateTile(tileId, {
-                  content: {
-                    ...matchPairsTile.content,
-                    instruction: updates.content.text ?? matchPairsTile.content.instruction,
-                    richInstruction: updates.content.richText ?? matchPairsTile.content.richInstruction
-                  }
+            {
+              content: instructionAdapter.content,
+              onChange: (updatedContent) => {
+                onUpdateTile(tile.id, {
+                  content: instructionAdapter.applyChanges(updatedContent)
                 });
-              }}
-              onFinishTextEditing={onFinishTextEditing}
-              onEditorReady={onEditorReady}
-            />,
+              },
+              onFinish: onFinishTextEditing,
+              onEditorReady,
+              textColor
+            },
             true
           );
         } else {

--- a/src/components/admin/common/RichTextEditor.tsx
+++ b/src/components/admin/common/RichTextEditor.tsx
@@ -1,0 +1,215 @@
+import React, { useEffect } from 'react';
+import { Editor, EditorContent, useEditor } from '@tiptap/react';
+import StarterKit from '@tiptap/starter-kit';
+import Underline from '@tiptap/extension-underline';
+import { TextStyle } from '@tiptap/extension-text-style';
+import Color from '@tiptap/extension-color';
+import FontFamily from '@tiptap/extension-font-family';
+import BulletList from '@tiptap/extension-bullet-list';
+import OrderedList from '@tiptap/extension-ordered-list';
+import ListItem from '@tiptap/extension-list-item';
+import FontSize from '../../../extensions/FontSize';
+import TextAlignExtension from '../../../extensions/TextAlign';
+
+export interface RichTextContent {
+  text: string;
+  richText?: string;
+  fontFamily?: string;
+  fontSize?: number;
+  verticalAlign?: 'top' | 'center' | 'bottom';
+  backgroundColor?: string;
+  showBorder?: boolean;
+}
+
+export interface RichTextEditorProps {
+  content: RichTextContent;
+  onChange: (content: RichTextContent) => void;
+  onFinish: () => void;
+  onEditorReady?: (editor: Editor | null) => void;
+  textColor?: string;
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+export interface RichTextFieldMapping<T extends Record<string, any>> {
+  text: keyof T;
+  richText?: keyof T;
+  fontFamily?: keyof T;
+  fontSize?: keyof T;
+  verticalAlign?: keyof T;
+}
+
+export interface RichTextAdapterOptions<T extends Record<string, any>> {
+  source: T;
+  fields: RichTextFieldMapping<T>;
+  defaults?: Partial<Omit<RichTextContent, 'text' | 'richText'>>;
+}
+
+export interface RichTextAdapter<T extends Record<string, any>> {
+  content: RichTextContent;
+  applyChanges: (updated: RichTextContent) => T;
+}
+
+const defaultParagraph = (text: string) => `<p style="margin: 0;">${text || ''}</p>`;
+
+export const createRichTextAdapter = <T extends Record<string, any>>({
+  source,
+  fields,
+  defaults = {}
+}: RichTextAdapterOptions<T>): RichTextAdapter<T> => {
+  const content: RichTextContent = {
+    text: (source[fields.text] as string) ?? '',
+    richText: fields.richText ? ((source[fields.richText] as string | undefined) ?? undefined) : undefined,
+    fontFamily:
+      (fields.fontFamily ? (source[fields.fontFamily] as string | undefined) : undefined) ??
+      defaults.fontFamily ??
+      'Inter',
+    fontSize:
+      (fields.fontSize ? (source[fields.fontSize] as number | undefined) : undefined) ??
+      defaults.fontSize ??
+      16,
+    verticalAlign:
+      (fields.verticalAlign ? (source[fields.verticalAlign] as RichTextContent['verticalAlign'] | undefined) : undefined) ??
+      defaults.verticalAlign ??
+      'top',
+    backgroundColor: defaults.backgroundColor,
+    showBorder: defaults.showBorder
+  };
+
+  return {
+    content,
+    applyChanges: updated => ({
+      ...source,
+      [fields.text]: updated.text,
+      ...(fields.richText ? { [fields.richText]: updated.richText } : {}),
+      ...(fields.fontFamily ? { [fields.fontFamily]: updated.fontFamily } : {}),
+      ...(fields.fontSize ? { [fields.fontSize]: updated.fontSize } : {}),
+      ...(fields.verticalAlign ? { [fields.verticalAlign]: updated.verticalAlign } : {})
+    })
+  };
+};
+
+export const RichTextEditor: React.FC<RichTextEditorProps> = ({
+  content,
+  onChange,
+  onFinish,
+  onEditorReady,
+  textColor,
+  className,
+  style
+}) => {
+  const editor = useEditor({
+    extensions: [
+      StarterKit.configure({
+        bulletList: false,
+        orderedList: false,
+        listItem: false
+      }),
+      BulletList.configure({
+        HTMLAttributes: { class: 'bullet-list' },
+        keepMarks: true,
+        keepAttributes: true
+      }),
+      OrderedList.configure({
+        HTMLAttributes: { class: 'ordered-list' },
+        keepMarks: true,
+        keepAttributes: true
+      }),
+      ListItem,
+      Underline,
+      TextStyle,
+      Color.configure({ types: ['textStyle'] }),
+      FontFamily.configure({ types: ['textStyle'] }),
+      FontSize,
+      TextAlignExtension.configure({ types: ['paragraph'] })
+    ],
+    content: content.richText || defaultParagraph(content.text),
+    onUpdate: ({ editor: tiptap }) => {
+      const html = tiptap.getHTML();
+      const plain = tiptap.getText();
+      onChange({
+        ...content,
+        text: plain,
+        richText: html
+      });
+    },
+    autofocus: true
+  });
+
+  useEffect(() => {
+    if (!editor) return;
+    const nextContent = content.richText || defaultParagraph(content.text);
+    if (editor.getHTML() !== nextContent) {
+      editor.commands.setContent(nextContent, false);
+    }
+  }, [content.richText, content.text, editor]);
+
+  useEffect(() => {
+    if (!onEditorReady) return;
+
+    onEditorReady(editor);
+    return () => onEditorReady(null);
+  }, [editor, onEditorReady]);
+
+  if (!editor) {
+    return null;
+  }
+
+  const handleBlur = (event: React.FocusEvent) => {
+    const toolbar = document.querySelector('.top-toolbar');
+    if (toolbar && event.relatedTarget && toolbar.contains(event.relatedTarget as Node)) {
+      event.preventDefault();
+      editor.commands.focus();
+      return;
+    }
+
+    onFinish();
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent) => {
+    if (event.key === 'Tab') {
+      event.preventDefault();
+      if (editor.isActive('listItem')) {
+        if (event.shiftKey) {
+          editor.chain().focus().liftListItem('listItem').run();
+        } else {
+          editor.chain().focus().sinkListItem('listItem').run();
+        }
+      } else {
+        editor.chain().focus().insertContent('\t').run();
+      }
+    }
+  };
+
+  const combinedClassName = `w-full h-full p-3 overflow-hidden relative tile-text-content tiptap-editor${
+    className ? ` ${className}` : ''
+  }`;
+
+  const combinedStyle: React.CSSProperties = {
+    fontSize: content.fontSize ? `${content.fontSize}px` : undefined,
+    fontFamily: content.fontFamily,
+    color: textColor,
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent:
+      content.verticalAlign === 'center'
+        ? 'center'
+        : content.verticalAlign === 'bottom'
+        ? 'flex-end'
+        : 'flex-start',
+    ...style
+  };
+
+  return (
+    <div className={combinedClassName} style={combinedStyle}>
+      <EditorContent
+        editor={editor}
+        className="w-full focus:outline-none break-words rich-text-content tile-formatted-text"
+        onBlur={handleBlur}
+        onKeyDown={handleKeyDown}
+      />
+    </div>
+  );
+};
+
+export default RichTextEditor;


### PR DESCRIPTION
## Summary
- extract a reusable RichTextEditor component with helpers for mapping tile content
- update TileRenderer and programming tiles to rely on the shared editor instead of ad-hoc text tiles
- adjust quiz, sequencing, and match-pairs interactives to accept standardized editor props

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dafbd0cb608321be2658330e0799de