### PR TITLE
Extract color utilities into shared module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ lerna-debug.log*
 
 node_modules
 dist
+dist-tests
 dist-ssr
 *.local
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "tsc --project tsconfig.test.json && node --experimental-specifier-resolution=node dist-tests/utils/colorUtils.test.js"
   },
   "dependencies": {
     "@tiptap/core": "^3.4.2",

--- a/src/components/admin/MatchPairsInteractive.tsx
+++ b/src/components/admin/MatchPairsInteractive.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useState, useCallback } from 'react';
 import { CheckCircle, XCircle, RefreshCw, Sparkles, Puzzle, RotateCcw } from 'lucide-react';
 import { MatchPairsTile } from '../../types/lessonEditor';
 import { createBlankId, createPlaceholderRegex } from '../../utils/matchPairs';
+import { getReadableTextColor, surfaceColor } from '../../utils/colorUtils';
 import { TaskInstructionPanel } from './common/TaskInstructionPanel';
 import { RichTextEditor, RichTextEditorProps } from './common/RichTextEditor';
 
@@ -23,62 +24,6 @@ interface DragPayload {
   optionId: string;
   sourceBlankId?: string;
 }
-
-const hexToRgb = (hex: string): { r: number; g: number; b: number } | null => {
-  if (!hex) return null;
-
-  let normalized = hex.replace('#', '').trim();
-  if (normalized.length === 3) {
-    normalized = normalized.split('').map(char => `${char}${char}`).join('');
-  }
-
-  if (normalized.length !== 6) return null;
-
-  const intValue = Number.parseInt(normalized, 16);
-  if (Number.isNaN(intValue)) return null;
-
-  return {
-    r: (intValue >> 16) & 255,
-    g: (intValue >> 8) & 255,
-    b: intValue & 255
-  };
-};
-
-const channelToLinear = (value: number): number => {
-  const scaled = value / 255;
-  return scaled <= 0.03928 ? scaled / 12.92 : Math.pow((scaled + 0.055) / 1.055, 2.4);
-};
-
-const getReadableTextColor = (hex: string): string => {
-  const rgb = hexToRgb(hex);
-  if (!rgb) return '#0f172a';
-
-  const luminance =
-    0.2126 * channelToLinear(rgb.r) +
-    0.7152 * channelToLinear(rgb.g) +
-    0.0722 * channelToLinear(rgb.b);
-
-  return luminance > 0.6 ? '#0f172a' : '#f8fafc';
-};
-
-const lightenColor = (hex: string, amount: number): string => {
-  const rgb = hexToRgb(hex);
-  if (!rgb) return hex;
-
-  const lightenChannel = (channel: number) => Math.round(channel + (255 - channel) * amount);
-  return `rgb(${lightenChannel(rgb.r)}, ${lightenChannel(rgb.g)}, ${lightenChannel(rgb.b)})`;
-};
-
-const darkenColor = (hex: string, amount: number): string => {
-  const rgb = hexToRgb(hex);
-  if (!rgb) return hex;
-
-  const darkenChannel = (channel: number) => Math.round(channel * (1 - amount));
-  return `rgb(${darkenChannel(rgb.r)}, ${darkenChannel(rgb.g)}, ${darkenChannel(rgb.b)})`;
-};
-
-const surfaceColor = (accent: string, textColor: string, lightenAmount: number, darkenAmount: number): string =>
-  textColor === '#0f172a' ? lightenColor(accent, lightenAmount) : darkenColor(accent, darkenAmount);
 
 const parseTemplate = (template: string): Segment[] => {
   const regex = createPlaceholderRegex();

--- a/src/components/admin/QuizInteractive.tsx
+++ b/src/components/admin/QuizInteractive.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { CheckCircle2, Circle, HelpCircle, RotateCcw, XCircle } from 'lucide-react';
 import { QuizTile } from '../../types/lessonEditor';
+import { getReadableTextColor, surfaceColor } from '../../utils/colorUtils';
 import { TaskInstructionPanel } from './common/TaskInstructionPanel';
 import { RichTextEditor, RichTextEditorProps } from './common/RichTextEditor';
 
@@ -13,65 +14,6 @@ interface QuizInteractiveProps {
 }
 
 type EvaluationState = 'idle' | 'correct' | 'incorrect';
-
-const hexToRgb = (hex: string): { r: number; g: number; b: number } | null => {
-  if (!hex) return null;
-
-  let normalized = hex.replace('#', '').trim();
-  if (normalized.length === 3) {
-    normalized = normalized
-      .split('')
-      .map(char => `${char}${char}`)
-      .join('');
-  }
-
-  if (normalized.length !== 6) return null;
-
-  const intValue = Number.parseInt(normalized, 16);
-  if (Number.isNaN(intValue)) return null;
-
-  return {
-    r: (intValue >> 16) & 255,
-    g: (intValue >> 8) & 255,
-    b: intValue & 255
-  };
-};
-
-const channelToLinear = (value: number): number => {
-  const scaled = value / 255;
-  return scaled <= 0.03928 ? scaled / 12.92 : Math.pow((scaled + 0.055) / 1.055, 2.4);
-};
-
-const getReadableTextColor = (hex: string): string => {
-  const rgb = hexToRgb(hex);
-  if (!rgb) return '#0f172a';
-
-  const luminance =
-    0.2126 * channelToLinear(rgb.r) +
-    0.7152 * channelToLinear(rgb.g) +
-    0.0722 * channelToLinear(rgb.b);
-
-  return luminance > 0.6 ? '#0f172a' : '#f8fafc';
-};
-
-const lightenColor = (hex: string, amount: number): string => {
-  const rgb = hexToRgb(hex);
-  if (!rgb) return hex;
-
-  const lightenChannel = (channel: number) => Math.round(channel + (255 - channel) * amount);
-  return `rgb(${lightenChannel(rgb.r)}, ${lightenChannel(rgb.g)}, ${lightenChannel(rgb.b)})`;
-};
-
-const darkenColor = (hex: string, amount: number): string => {
-  const rgb = hexToRgb(hex);
-  if (!rgb) return hex;
-
-  const darkenChannel = (channel: number) => Math.round(channel * (1 - amount));
-  return `rgb(${darkenChannel(rgb.r)}, ${darkenChannel(rgb.g)}, ${darkenChannel(rgb.b)})`;
-};
-
-const surfaceColor = (accent: string, textColor: string, lightenAmount: number, darkenAmount: number): string =>
-  textColor === '#0f172a' ? lightenColor(accent, lightenAmount) : darkenColor(accent, darkenAmount);
 
 export const QuizInteractive: React.FC<QuizInteractiveProps> = ({
   tile,

--- a/src/components/admin/SequencingInteractive.tsx
+++ b/src/components/admin/SequencingInteractive.tsx
@@ -1,6 +1,12 @@
 import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import { CheckCircle, XCircle, RotateCcw, Sparkles, GripVertical, Shuffle, ArrowLeftRight } from 'lucide-react';
 import { SequencingTile } from '../../types/lessonEditor';
+import {
+  getReadableTextColor,
+  lightenColor,
+  darkenColor,
+  surfaceColor,
+} from '../../utils/colorUtils';
 import { TaskInstructionPanel } from './common/TaskInstructionPanel';
 import { RichTextEditor, RichTextEditorProps } from './common/RichTextEditor';
 
@@ -26,65 +32,6 @@ interface DragState {
   source: DragSource;
   index?: number;
 }
-
-const hexToRgb = (hex: string): { r: number; g: number; b: number } | null => {
-  if (!hex) return null;
-
-  let normalized = hex.replace('#', '').trim();
-  if (normalized.length === 3) {
-    normalized = normalized
-      .split('')
-      .map(char => `${char}${char}`)
-      .join('');
-  }
-
-  if (normalized.length !== 6) return null;
-
-  const intValue = Number.parseInt(normalized, 16);
-  if (Number.isNaN(intValue)) return null;
-
-  return {
-    r: (intValue >> 16) & 255,
-    g: (intValue >> 8) & 255,
-    b: intValue & 255
-  };
-};
-
-const channelToLinear = (value: number): number => {
-  const scaled = value / 255;
-  return scaled <= 0.03928 ? scaled / 12.92 : Math.pow((scaled + 0.055) / 1.055, 2.4);
-};
-
-const getReadableTextColor = (hex: string): string => {
-  const rgb = hexToRgb(hex);
-  if (!rgb) return '#f8fafc';
-
-  const luminance =
-    0.2126 * channelToLinear(rgb.r) +
-    0.7152 * channelToLinear(rgb.g) +
-    0.0722 * channelToLinear(rgb.b);
-
-  return luminance > 0.6 ? '#0f172a' : '#f8fafc';
-};
-
-const lightenColor = (hex: string, amount: number): string => {
-  const rgb = hexToRgb(hex);
-  if (!rgb) return hex;
-
-  const lightenChannel = (channel: number) => Math.round(channel + (255 - channel) * amount);
-  return `rgb(${lightenChannel(rgb.r)}, ${lightenChannel(rgb.g)}, ${lightenChannel(rgb.b)})`;
-};
-
-const darkenColor = (hex: string, amount: number): string => {
-  const rgb = hexToRgb(hex);
-  if (!rgb) return hex;
-
-  const darkenChannel = (channel: number) => Math.round(channel * (1 - amount));
-  return `rgb(${darkenChannel(rgb.r)}, ${darkenChannel(rgb.g)}, ${darkenChannel(rgb.b)})`;
-};
-
-const surfaceColor = (accent: string, textColor: string, lightenAmount: number, darkenAmount: number): string =>
-  textColor === '#0f172a' ? lightenColor(accent, lightenAmount) : darkenColor(accent, darkenAmount);
 
 export const SequencingInteractive: React.FC<SequencingInteractiveProps> = ({
   tile,

--- a/src/components/admin/TileRenderer.tsx
+++ b/src/components/admin/TileRenderer.tsx
@@ -1,6 +1,11 @@
 import React, { useState, useEffect } from 'react';
 import { Play, Code2 } from 'lucide-react';
 import { GridUtils } from '../../utils/gridUtils';
+import {
+  getReadableTextColor,
+  darkenColor,
+  surfaceColor,
+} from '../../utils/colorUtils';
 import { Editor } from '@tiptap/react';
 import { LessonTile, TextTile, ImageTile, QuizTile, ProgrammingTile, SequencingTile, MatchPairsTile } from '../../types/lessonEditor';
 import { SequencingInteractive } from './SequencingInteractive';
@@ -9,61 +14,6 @@ import { TaskInstructionPanel } from './common/TaskInstructionPanel';
 import { QuizInteractive } from './QuizInteractive';
 import { RichTextEditor, createRichTextAdapter, RichTextEditorProps } from './common/RichTextEditor';
 import { TileFrame } from './tiles/TileFrame';
-
-const hexToRgb = (hex: string): { r: number; g: number; b: number } | null => {
-  if (!hex) return null;
-
-  let normalized = hex.replace('#', '').trim();
-  if (normalized.length === 3) {
-    normalized = normalized.split('').map((char) => `${char}${char}`).join('');
-  }
-
-  if (normalized.length !== 6) return null;
-
-  const intValue = Number.parseInt(normalized, 16);
-  if (Number.isNaN(intValue)) return null;
-
-  return {
-    r: (intValue >> 16) & 255,
-    g: (intValue >> 8) & 255,
-    b: intValue & 255,
-  };
-};
-
-const channelToLinear = (value: number): number => {
-  const scaled = value / 255;
-  return scaled <= 0.03928 ? scaled / 12.92 : Math.pow((scaled + 0.055) / 1.055, 2.4);
-};
-
-const getReadableTextColor = (hex: string): string => {
-  const rgb = hexToRgb(hex);
-  if (!rgb) return '#0f172a';
-
-  const luminance = (0.2126 * channelToLinear(rgb.r)) +
-    (0.7152 * channelToLinear(rgb.g)) +
-    (0.0722 * channelToLinear(rgb.b));
-
-  return luminance > 0.6 ? '#0f172a' : '#f8fafc';
-};
-
-const lightenColor = (hex: string, amount: number): string => {
-  const rgb = hexToRgb(hex);
-  if (!rgb) return hex;
-
-  const lightenChannel = (channel: number) => Math.round(channel + (255 - channel) * amount);
-  return `rgb(${lightenChannel(rgb.r)}, ${lightenChannel(rgb.g)}, ${lightenChannel(rgb.b)})`;
-};
-
-const darkenColor = (hex: string, amount: number): string => {
-  const rgb = hexToRgb(hex);
-  if (!rgb) return hex;
-
-  const darkenChannel = (channel: number) => Math.round(channel * (1 - amount));
-  return `rgb(${darkenChannel(rgb.r)}, ${darkenChannel(rgb.g)}, ${darkenChannel(rgb.b)})`;
-};
-
-const surfaceColor = (accent: string, textColor: string, lightenAmount: number, darkenAmount: number): string =>
-  textColor === '#0f172a' ? lightenColor(accent, lightenAmount) : darkenColor(accent, darkenAmount);
 
 interface TileRendererProps {
   tile: LessonTile;

--- a/src/utils/colorUtils.test.ts
+++ b/src/utils/colorUtils.test.ts
@@ -1,0 +1,140 @@
+import {
+  hexToRgb,
+  channelToLinear,
+  getReadableTextColor,
+  lightenColor,
+  darkenColor,
+  surfaceColor,
+} from './colorUtils.js';
+
+type TestFn = () => void;
+interface TestCase {
+  name: string;
+  fn: TestFn;
+}
+
+const tests: TestCase[] = [];
+
+const test = (name: string, fn: TestFn) => {
+  tests.push({ name, fn });
+};
+
+const isNumber = (value: unknown): value is number => typeof value === 'number';
+
+const deepEqual = (a: unknown, b: unknown): boolean => {
+  if (a === b) return true;
+  if (typeof a !== typeof b) return false;
+  if (a && b && typeof a === 'object' && typeof b === 'object') {
+    const aKeys = Object.keys(a as Record<string, unknown>);
+    const bKeys = Object.keys(b as Record<string, unknown>);
+    if (aKeys.length !== bKeys.length) return false;
+    return aKeys.every(key => deepEqual((a as Record<string, unknown>)[key], (b as Record<string, unknown>)[key]));
+  }
+  return false;
+};
+
+const expect = (actual: unknown) => ({
+  toEqual(expected: unknown) {
+    if (!deepEqual(actual, expected)) {
+      throw new Error(`Expected ${JSON.stringify(actual)} to equal ${JSON.stringify(expected)}`);
+    }
+  },
+  toBe(expected: unknown) {
+    if (actual !== expected) {
+      throw new Error(`Expected ${JSON.stringify(actual)} to be ${JSON.stringify(expected)}`);
+    }
+  },
+  toBeNull() {
+    if (actual !== null) {
+      throw new Error(`Expected ${JSON.stringify(actual)} to be null`);
+    }
+  },
+  toBeCloseTo(expected: number, epsilon = 1e-6) {
+    if (!isNumber(actual)) {
+      throw new Error(`Expected a number but received ${JSON.stringify(actual)}`);
+    }
+    if (Math.abs(actual - expected) > epsilon) {
+      throw new Error(`Expected ${actual} to be within ${epsilon} of ${expected}`);
+    }
+  },
+});
+
+test('hexToRgb converts six digit hex colors to rgb values', () => {
+  expect(hexToRgb('#336699')).toEqual({ r: 51, g: 102, b: 153 });
+});
+
+test('hexToRgb expands shorthand hex colors', () => {
+  expect(hexToRgb('#0af')).toEqual({ r: 0, g: 170, b: 255 });
+});
+
+test('hexToRgb returns null for invalid input', () => {
+  expect(hexToRgb('#zzzzzz')).toBeNull();
+  expect(hexToRgb('')).toBeNull();
+});
+
+test('channelToLinear converts low values using the linear segment', () => {
+  expect(channelToLinear(5)).toBeCloseTo(5 / (255 * 12.92));
+});
+
+test('channelToLinear converts higher values using the exponential segment', () => {
+  const expected = Math.pow(((200 / 255) + 0.055) / 1.055, 2.4);
+  expect(channelToLinear(200)).toBeCloseTo(expected);
+});
+
+test('getReadableTextColor returns dark text for light backgrounds', () => {
+  expect(getReadableTextColor('#ffffff')).toBe('#0f172a');
+});
+
+test('getReadableTextColor returns light text for dark backgrounds', () => {
+  expect(getReadableTextColor('#000000')).toBe('#f8fafc');
+});
+
+test('getReadableTextColor falls back to dark text when hex is invalid', () => {
+  expect(getReadableTextColor('#xyzxyz')).toBe('#0f172a');
+});
+
+test('lightenColor lightens rgb channels towards white', () => {
+  expect(lightenColor('#000000', 0.5)).toBe('rgb(128, 128, 128)');
+  expect(lightenColor('#123456', 1)).toBe('rgb(255, 255, 255)');
+});
+
+test('lightenColor returns original string when conversion fails', () => {
+  expect(lightenColor('invalid', 0.3)).toBe('invalid');
+});
+
+test('darkenColor darkens rgb channels towards black', () => {
+  expect(darkenColor('#ffffff', 0.5)).toBe('rgb(128, 128, 128)');
+  expect(darkenColor('#123456', 1)).toBe('rgb(0, 0, 0)');
+});
+
+test('darkenColor returns original string when conversion fails', () => {
+  expect(darkenColor('invalid', 0.3)).toBe('invalid');
+});
+
+test('surfaceColor uses lightenColor when text is dark', () => {
+  expect(surfaceColor('#000000', '#0f172a', 0.25, 0.5)).toBe('rgb(64, 64, 64)');
+});
+
+test('surfaceColor uses darkenColor when text is light', () => {
+  expect(surfaceColor('#ffffff', '#f8fafc', 0.25, 0.5)).toBe('rgb(128, 128, 128)');
+});
+
+let failures = 0;
+
+tests.forEach(({ name, fn }) => {
+  try {
+    fn();
+    console.log(`✓ ${name}`);
+  } catch (error) {
+    failures += 1;
+    console.error(`✗ ${name}`);
+    console.error(error instanceof Error ? error.message : error);
+  }
+});
+
+if (failures > 0) {
+  const globalProcess = (globalThis as { process?: { exitCode?: number } }).process;
+  if (globalProcess) {
+    globalProcess.exitCode = 1;
+  }
+}

--- a/src/utils/colorUtils.ts
+++ b/src/utils/colorUtils.ts
@@ -1,0 +1,54 @@
+export const hexToRgb = (hex: string): { r: number; g: number; b: number } | null => {
+  if (!hex) return null;
+
+  let normalized = hex.replace('#', '').trim();
+  if (normalized.length === 3) {
+    normalized = normalized.split('').map((char) => `${char}${char}`).join('');
+  }
+
+  if (normalized.length !== 6) return null;
+
+  const intValue = Number.parseInt(normalized, 16);
+  if (Number.isNaN(intValue)) return null;
+
+  return {
+    r: (intValue >> 16) & 255,
+    g: (intValue >> 8) & 255,
+    b: intValue & 255,
+  };
+};
+
+export const channelToLinear = (value: number): number => {
+  const scaled = value / 255;
+  return scaled <= 0.03928 ? scaled / 12.92 : Math.pow((scaled + 0.055) / 1.055, 2.4);
+};
+
+export const getReadableTextColor = (hex: string): string => {
+  const rgb = hexToRgb(hex);
+  if (!rgb) return '#0f172a';
+
+  const luminance = (0.2126 * channelToLinear(rgb.r)) +
+    (0.7152 * channelToLinear(rgb.g)) +
+    (0.0722 * channelToLinear(rgb.b));
+
+  return luminance > 0.6 ? '#0f172a' : '#f8fafc';
+};
+
+export const lightenColor = (hex: string, amount: number): string => {
+  const rgb = hexToRgb(hex);
+  if (!rgb) return hex;
+
+  const lightenChannel = (channel: number) => Math.round(channel + (255 - channel) * amount);
+  return `rgb(${lightenChannel(rgb.r)}, ${lightenChannel(rgb.g)}, ${lightenChannel(rgb.b)})`;
+};
+
+export const darkenColor = (hex: string, amount: number): string => {
+  const rgb = hexToRgb(hex);
+  if (!rgb) return hex;
+
+  const darkenChannel = (channel: number) => Math.round(channel * (1 - amount));
+  return `rgb(${darkenChannel(rgb.r)}, ${darkenChannel(rgb.g)}, ${darkenChannel(rgb.b)})`;
+};
+
+export const surfaceColor = (accent: string, textColor: string, lightenAmount: number, darkenAmount: number): string =>
+  textColor === '#0f172a' ? lightenColor(accent, lightenAmount) : darkenColor(accent, darkenAmount);

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "outDir": "dist-tests",
+    "rootDir": "src"
+  },
+  "include": [
+    "src/utils/colorUtils.ts",
+    "src/utils/colorUtils.test.ts"
+  ]
+}


### PR DESCRIPTION
## Summary
- centralize color helper functions in `src/utils/colorUtils.ts`
- update admin tile renderer components to consume the shared helpers
- add a lightweight TypeScript test harness and script for the color utilities

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68db96cfaf0883219c12b3be51dce33d