### PR TITLE
Centralize tile accent palette helper

### DIFF
--- a/src/components/admin/MatchPairsInteractive.tsx
+++ b/src/components/admin/MatchPairsInteractive.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo, useState, useCallback } from 'react';
 import { CheckCircle, XCircle, RefreshCw, Sparkles, Puzzle, RotateCcw } from 'lucide-react';
 import { MatchPairsTile } from '../../types/lessonEditor';
 import { createBlankId, createPlaceholderRegex } from '../../utils/matchPairs';
-import { getReadableTextColor, surfaceColor } from '../../utils/colorUtils';
+import { useTileAccentPalette } from '../../utils/colorUtils';
 import { TaskInstructionPanel } from './common/TaskInstructionPanel';
 import { RichTextEditor, RichTextEditorProps } from './common/RichTextEditor';
 
@@ -83,18 +83,22 @@ export const MatchPairsInteractive: React.FC<MatchPairsInteractiveProps> = ({
   const [activeBlankId, setActiveBlankId] = useState<string | null>(null);
 
   const accentColor = tile.content.backgroundColor || '#0f172a';
-  const textColor = useMemo(() => getReadableTextColor(accentColor), [accentColor]);
-  const panelBackground = useMemo(() => surfaceColor(accentColor, textColor, 0.62, 0.45), [accentColor, textColor]);
-  const panelBorder = useMemo(() => surfaceColor(accentColor, textColor, 0.5, 0.55), [accentColor, textColor]);
-  const iconBackground = useMemo(() => surfaceColor(accentColor, textColor, 0.54, 0.48), [accentColor, textColor]);
+  const {
+    textColor,
+    shared: { testingCaptionColor },
+    matchPairs: {
+      panelBackground,
+      panelBorder,
+      iconBackground,
+      blankBackground,
+      blankBorder,
+      blankHoverBackground,
+      blankFilledBackground,
+      optionBackground,
+      optionBorder
+    }
+  } = useTileAccentPalette(accentColor);
   const mutedLabelColor = textColor === '#0f172a' ? '#475569' : '#d1d5db';
-  const blankBackground = useMemo(() => surfaceColor(accentColor, textColor, 0.65, 0.38), [accentColor, textColor]);
-  const blankBorder = useMemo(() => surfaceColor(accentColor, textColor, 0.54, 0.52), [accentColor, textColor]);
-  const blankHoverBackground = useMemo(() => surfaceColor(accentColor, textColor, 0.75, 0.32), [accentColor, textColor]);
-  const blankFilledBackground = useMemo(() => surfaceColor(accentColor, textColor, 0.52, 0.46), [accentColor, textColor]);
-  const optionBackground = useMemo(() => surfaceColor(accentColor, textColor, 0.52, 0.46), [accentColor, textColor]);
-  const optionBorder = useMemo(() => surfaceColor(accentColor, textColor, 0.44, 0.56), [accentColor, textColor]);
-  const testingCaptionColor = useMemo(() => surfaceColor(accentColor, textColor, 0.42, 0.4), [accentColor, textColor]);
   const evaluationSuccessBackground = '#dcfce7';
   const evaluationErrorBackground = '#fee2e2';
 

--- a/src/components/admin/QuizInteractive.tsx
+++ b/src/components/admin/QuizInteractive.tsx
@@ -1,7 +1,7 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { CheckCircle2, Circle, HelpCircle, RotateCcw, XCircle } from 'lucide-react';
 import { QuizTile } from '../../types/lessonEditor';
-import { getReadableTextColor, surfaceColor } from '../../utils/colorUtils';
+import { useTileAccentPalette } from '../../utils/colorUtils';
 import { TaskInstructionPanel } from './common/TaskInstructionPanel';
 import { RichTextEditor, RichTextEditorProps } from './common/RichTextEditor';
 
@@ -31,8 +31,19 @@ export const QuizInteractive: React.FC<QuizInteractiveProps> = ({
   }, [tile.content.answers, tile.content.multipleCorrect]);
 
   const accentColor = tile.content.backgroundColor || '#1d4ed8';
-  const textColor = useMemo(() => getReadableTextColor(accentColor), [accentColor]);
-  const mutedTextColor = textColor === '#0f172a' ? '#475569' : '#e2e8f0';
+  const {
+    textColor,
+    mutedTextColor,
+    quiz: {
+      panelBackground,
+      panelBorder,
+      iconBackground,
+      answerBackground,
+      answerBorder,
+      answerSelectedBackground,
+      answerSelectedBorder
+    }
+  } = useTileAccentPalette(accentColor);
   const isInteractionEnabled = !isPreview && isTestingMode;
 
   useEffect(() => {
@@ -41,35 +52,6 @@ export const QuizInteractive: React.FC<QuizInteractiveProps> = ({
       setEvaluationState('idle');
     }
   }, [isInteractionEnabled]);
-
-  const panelBackground = useMemo(
-    () => surfaceColor(accentColor, textColor, 0.66, 0.42),
-    [accentColor, textColor]
-  );
-  const panelBorder = useMemo(
-    () => surfaceColor(accentColor, textColor, 0.54, 0.52),
-    [accentColor, textColor]
-  );
-  const iconBackground = useMemo(
-    () => surfaceColor(accentColor, textColor, 0.58, 0.48),
-    [accentColor, textColor]
-  );
-  const answerBackground = useMemo(
-    () => surfaceColor(accentColor, textColor, 0.7, 0.38),
-    [accentColor, textColor]
-  );
-  const answerBorder = useMemo(
-    () => surfaceColor(accentColor, textColor, 0.58, 0.48),
-    [accentColor, textColor]
-  );
-  const answerSelectedBackground = useMemo(
-    () => surfaceColor(accentColor, textColor, 0.46, 0.56),
-    [accentColor, textColor]
-  );
-  const answerSelectedBorder = useMemo(
-    () => surfaceColor(accentColor, textColor, 0.38, 0.62),
-    [accentColor, textColor]
-  );
 
   const handleTileDoubleClick = useCallback(
     (event: React.MouseEvent) => {

--- a/src/components/admin/SequencingInteractive.tsx
+++ b/src/components/admin/SequencingInteractive.tsx
@@ -1,12 +1,7 @@
 import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import { CheckCircle, XCircle, RotateCcw, Sparkles, GripVertical, Shuffle, ArrowLeftRight } from 'lucide-react';
 import { SequencingTile } from '../../types/lessonEditor';
-import {
-  getReadableTextColor,
-  lightenColor,
-  darkenColor,
-  surfaceColor,
-} from '../../utils/colorUtils';
+import { useTileAccentPalette } from '../../utils/colorUtils';
 import { TaskInstructionPanel } from './common/TaskInstructionPanel';
 import { RichTextEditor, RichTextEditorProps } from './common/RichTextEditor';
 
@@ -53,125 +48,53 @@ export const SequencingInteractive: React.FC<SequencingInteractiveProps> = ({
   const sequenceComplete = placedItems.length > 0 && placedItems.every(item => item !== null);
 
   const accentColor = tile.content.backgroundColor || '#0f172a';
-  const textColor = useMemo(() => getReadableTextColor(accentColor), [accentColor]);
-  const gradientStart = useMemo(() => lightenColor(accentColor, 0.08), [accentColor]);
-  const gradientEnd = useMemo(() => darkenColor(accentColor, 0.08), [accentColor]);
-  const frameBorderColor = useMemo(
-    () => surfaceColor(accentColor, textColor, 0.52, 0.6),
-    [accentColor, textColor]
-  );
-  const panelBackground = useMemo(
-    () => surfaceColor(accentColor, textColor, 0.64, 0.45),
-    [accentColor, textColor]
-  );
-  const panelBorder = useMemo(
-    () => surfaceColor(accentColor, textColor, 0.5, 0.58),
-    [accentColor, textColor]
-  );
-  const iconBackground = useMemo(
-    () => surfaceColor(accentColor, textColor, 0.56, 0.5),
-    [accentColor, textColor]
-  );
+  const {
+    textColor,
+    shared: { testingCaptionColor },
+    buttons,
+    feedback,
+    sequencing: {
+      gradientStart,
+      gradientEnd,
+      frameBorderColor,
+      panelBackground,
+      panelBorder,
+      iconBackground,
+      poolBackground,
+      poolBorder,
+      poolHighlightBackground,
+      poolHighlightBorder,
+      itemBackground,
+      itemBorder,
+      gripBackground,
+      gripBorder,
+      sequenceBackground,
+      sequenceBorder,
+      sequenceHeaderBorder,
+      badgeBackground,
+      badgeBorder,
+      slotEmptyBackground,
+      slotEmptyBorder,
+      slotHoverBackground,
+      slotHoverBorder,
+      slotFilledBackground,
+      slotFilledBorder,
+      slotCorrectBackground,
+      slotCorrectBorder,
+      successIconColor,
+    },
+  } = useTileAccentPalette(accentColor);
   const mutedLabelColor = textColor === '#0f172a' ? '#475569' : '#dbeafe';
   const subtleCaptionColor = textColor === '#0f172a' ? '#64748b' : '#e2e8f0';
-  const testingCaptionColor = useMemo(
-    () => surfaceColor(accentColor, textColor, 0.42, 0.4),
-    [accentColor, textColor]
-  );
-  const poolBackground = useMemo(
-    () => surfaceColor(accentColor, textColor, 0.6, 0.4),
-    [accentColor, textColor]
-  );
-  const poolBorder = useMemo(
-    () => surfaceColor(accentColor, textColor, 0.5, 0.56),
-    [accentColor, textColor]
-  );
-  const poolHighlightBackground = useMemo(
-    () => surfaceColor(accentColor, textColor, 0.7, 0.3),
-    [accentColor, textColor]
-  );
-  const poolHighlightBorder = useMemo(
-    () => surfaceColor(accentColor, textColor, 0.6, 0.45),
-    [accentColor, textColor]
-  );
-  const itemBackground = useMemo(
-    () => surfaceColor(accentColor, textColor, 0.52, 0.46),
-    [accentColor, textColor]
-  );
-  const itemBorder = useMemo(
-    () => surfaceColor(accentColor, textColor, 0.42, 0.58),
-    [accentColor, textColor]
-  );
-  const gripBackground = useMemo(
-    () => surfaceColor(accentColor, textColor, 0.48, 0.52),
-    [accentColor, textColor]
-  );
-  const gripBorder = useMemo(
-    () => surfaceColor(accentColor, textColor, 0.42, 0.6),
-    [accentColor, textColor]
-  );
-  const sequenceBackground = useMemo(
-    () => surfaceColor(accentColor, textColor, 0.58, 0.42),
-    [accentColor, textColor]
-  );
-  const sequenceBorder = useMemo(
-    () => surfaceColor(accentColor, textColor, 0.48, 0.6),
-    [accentColor, textColor]
-  );
-  const sequenceHeaderBorder = useMemo(
-    () => surfaceColor(accentColor, textColor, 0.44, 0.64),
-    [accentColor, textColor]
-  );
-  const badgeBackground = useMemo(
-    () => surfaceColor(accentColor, textColor, 0.54, 0.48),
-    [accentColor, textColor]
-  );
-  const badgeBorder = useMemo(
-    () => surfaceColor(accentColor, textColor, 0.46, 0.58),
-    [accentColor, textColor]
-  );
   const badgeTextColor = textColor === '#0f172a' ? '#1f2937' : '#f8fafc';
-  const slotEmptyBackground = useMemo(
-    () => surfaceColor(accentColor, textColor, 0.58, 0.42),
-    [accentColor, textColor]
-  );
-  const slotEmptyBorder = useMemo(
-    () => surfaceColor(accentColor, textColor, 0.5, 0.58),
-    [accentColor, textColor]
-  );
-  const slotHoverBackground = useMemo(
-    () => surfaceColor(accentColor, textColor, 0.68, 0.32),
-    [accentColor, textColor]
-  );
-  const slotHoverBorder = useMemo(
-    () => surfaceColor(accentColor, textColor, 0.58, 0.5),
-    [accentColor, textColor]
-  );
-  const slotFilledBackground = useMemo(
-    () => surfaceColor(accentColor, textColor, 0.48, 0.5),
-    [accentColor, textColor]
-  );
-  const slotFilledBorder = useMemo(
-    () => surfaceColor(accentColor, textColor, 0.42, 0.6),
-    [accentColor, textColor]
-  );
-  const slotCorrectBackground = useMemo(
-    () => surfaceColor(accentColor, textColor, 0.72, 0.26),
-    [accentColor, textColor]
-  );
-  const slotCorrectBorder = useMemo(
-    () => surfaceColor(accentColor, textColor, 0.62, 0.36),
-    [accentColor, textColor]
-  );
-  const successIconColor = textColor === '#0f172a' ? darkenColor(accentColor, 0.2) : lightenColor(accentColor, 0.32);
-  const successFeedbackBackground = surfaceColor(accentColor, textColor, 0.7, 0.34);
-  const successFeedbackBorder = surfaceColor(accentColor, textColor, 0.6, 0.44);
-  const failureFeedbackBackground = '#fee2e2';
-  const failureFeedbackBorder = '#fca5a5';
-  const primaryButtonBackground = textColor === '#0f172a' ? darkenColor(accentColor, 0.25) : lightenColor(accentColor, 0.28);
-  const primaryButtonTextColor = textColor === '#0f172a' ? '#f8fafc' : '#0f172a';
-  const secondaryButtonBackground = surfaceColor(accentColor, textColor, 0.52, 0.5);
-  const secondaryButtonBorder = surfaceColor(accentColor, textColor, 0.46, 0.58);
+  const successFeedbackBackground = feedback.successBackground;
+  const successFeedbackBorder = feedback.successBorder;
+  const failureFeedbackBackground = feedback.failureBackground;
+  const failureFeedbackBorder = feedback.failureBorder;
+  const primaryButtonBackground = buttons.primary.background;
+  const primaryButtonTextColor = buttons.primary.text;
+  const secondaryButtonBackground = buttons.secondary.background;
+  const secondaryButtonBorder = buttons.secondary.border;
   const showBorder = tile.content.showBorder !== false;
   const isEmbedded = variant === 'embedded';
 

--- a/src/utils/colorUtils.ts
+++ b/src/utils/colorUtils.ts
@@ -1,3 +1,5 @@
+import { useMemo } from 'react';
+
 export const hexToRgb = (hex: string): { r: number; g: number; b: number } | null => {
   if (!hex) return null;
 
@@ -52,3 +54,187 @@ export const darkenColor = (hex: string, amount: number): string => {
 
 export const surfaceColor = (accent: string, textColor: string, lightenAmount: number, darkenAmount: number): string =>
   textColor === '#0f172a' ? lightenColor(accent, lightenAmount) : darkenColor(accent, darkenAmount);
+
+export interface SharedAccentPalette {
+  panelBackground: string;
+  panelBorder: string;
+  iconBackground: string;
+  testingCaptionColor: string;
+}
+
+export interface ButtonPalette {
+  primary: {
+    background: string;
+    text: string;
+  };
+  secondary: {
+    background: string;
+    border: string;
+  };
+}
+
+export interface FeedbackPalette {
+  successBackground: string;
+  successBorder: string;
+  failureBackground: string;
+  failureBorder: string;
+}
+
+export interface QuizAccentPalette {
+  panelBackground: string;
+  panelBorder: string;
+  iconBackground: string;
+  answerBackground: string;
+  answerBorder: string;
+  answerSelectedBackground: string;
+  answerSelectedBorder: string;
+}
+
+export interface SequencingAccentPalette {
+  gradientStart: string;
+  gradientEnd: string;
+  frameBorderColor: string;
+  panelBackground: string;
+  panelBorder: string;
+  iconBackground: string;
+  poolBackground: string;
+  poolBorder: string;
+  poolHighlightBackground: string;
+  poolHighlightBorder: string;
+  itemBackground: string;
+  itemBorder: string;
+  gripBackground: string;
+  gripBorder: string;
+  sequenceBackground: string;
+  sequenceBorder: string;
+  sequenceHeaderBorder: string;
+  badgeBackground: string;
+  badgeBorder: string;
+  slotEmptyBackground: string;
+  slotEmptyBorder: string;
+  slotHoverBackground: string;
+  slotHoverBorder: string;
+  slotFilledBackground: string;
+  slotFilledBorder: string;
+  slotCorrectBackground: string;
+  slotCorrectBorder: string;
+  successIconColor: string;
+}
+
+export interface MatchPairsAccentPalette {
+  panelBackground: string;
+  panelBorder: string;
+  iconBackground: string;
+  blankBackground: string;
+  blankBorder: string;
+  blankHoverBackground: string;
+  blankFilledBackground: string;
+  optionBackground: string;
+  optionBorder: string;
+}
+
+export interface AccentPalette {
+  accentColor: string;
+  textColor: string;
+  mutedTextColor: string;
+  shared: SharedAccentPalette;
+  buttons: ButtonPalette;
+  feedback: FeedbackPalette;
+  quiz: QuizAccentPalette;
+  sequencing: SequencingAccentPalette;
+  matchPairs: MatchPairsAccentPalette;
+}
+
+export const buildAccentPalette = (accentColor: string, providedTextColor?: string): AccentPalette => {
+  const textColor = providedTextColor ?? getReadableTextColor(accentColor);
+  const surface = (lightenAmount: number, darkenAmount: number) =>
+    surfaceColor(accentColor, textColor, lightenAmount, darkenAmount);
+  const lighten = (amount: number) => lightenColor(accentColor, amount);
+  const darken = (amount: number) => darkenColor(accentColor, amount);
+
+  const sharedPanelBackground = surface(0.62, 0.45);
+  const sharedPanelBorder = surface(0.5, 0.55);
+  const sharedIconBackground = surface(0.54, 0.48);
+  const testingCaptionColor = surface(0.42, 0.4);
+
+  return {
+    accentColor,
+    textColor,
+    mutedTextColor: textColor === '#0f172a' ? '#475569' : '#e2e8f0',
+    shared: {
+      panelBackground: sharedPanelBackground,
+      panelBorder: sharedPanelBorder,
+      iconBackground: sharedIconBackground,
+      testingCaptionColor,
+    },
+    buttons: {
+      primary: {
+        background: textColor === '#0f172a' ? darken(0.25) : lighten(0.28),
+        text: textColor === '#0f172a' ? '#f8fafc' : '#0f172a',
+      },
+      secondary: {
+        background: surface(0.52, 0.5),
+        border: surface(0.46, 0.58),
+      },
+    },
+    feedback: {
+      successBackground: surface(0.7, 0.34),
+      successBorder: surface(0.6, 0.44),
+      failureBackground: '#fee2e2',
+      failureBorder: '#fca5a5',
+    },
+    quiz: {
+      panelBackground: surface(0.66, 0.42),
+      panelBorder: surface(0.54, 0.52),
+      iconBackground: surface(0.58, 0.48),
+      answerBackground: surface(0.7, 0.38),
+      answerBorder: surface(0.58, 0.48),
+      answerSelectedBackground: surface(0.46, 0.56),
+      answerSelectedBorder: surface(0.38, 0.62),
+    },
+    sequencing: {
+      gradientStart: lighten(0.08),
+      gradientEnd: darken(0.08),
+      frameBorderColor: surface(0.52, 0.6),
+      panelBackground: surface(0.64, 0.45),
+      panelBorder: surface(0.5, 0.58),
+      iconBackground: surface(0.56, 0.5),
+      poolBackground: surface(0.6, 0.4),
+      poolBorder: surface(0.5, 0.56),
+      poolHighlightBackground: surface(0.7, 0.3),
+      poolHighlightBorder: surface(0.6, 0.45),
+      itemBackground: surface(0.52, 0.46),
+      itemBorder: surface(0.42, 0.58),
+      gripBackground: surface(0.48, 0.52),
+      gripBorder: surface(0.42, 0.6),
+      sequenceBackground: surface(0.58, 0.42),
+      sequenceBorder: surface(0.48, 0.6),
+      sequenceHeaderBorder: surface(0.44, 0.64),
+      badgeBackground: surface(0.54, 0.48),
+      badgeBorder: surface(0.46, 0.58),
+      slotEmptyBackground: surface(0.58, 0.42),
+      slotEmptyBorder: surface(0.5, 0.58),
+      slotHoverBackground: surface(0.68, 0.32),
+      slotHoverBorder: surface(0.58, 0.5),
+      slotFilledBackground: surface(0.48, 0.5),
+      slotFilledBorder: surface(0.42, 0.6),
+      slotCorrectBackground: surface(0.72, 0.26),
+      slotCorrectBorder: surface(0.62, 0.36),
+      successIconColor: textColor === '#0f172a' ? darken(0.2) : lighten(0.32),
+    },
+    matchPairs: {
+      panelBackground: sharedPanelBackground,
+      panelBorder: sharedPanelBorder,
+      iconBackground: sharedIconBackground,
+      blankBackground: surface(0.65, 0.38),
+      blankBorder: surface(0.54, 0.52),
+      blankHoverBackground: surface(0.75, 0.32),
+      blankFilledBackground: surface(0.52, 0.46),
+      optionBackground: surface(0.52, 0.46),
+      optionBorder: surface(0.44, 0.56),
+    },
+  };
+};
+
+export const useTileAccentPalette = (accentColor: string, providedTextColor?: string): AccentPalette =>
+  useMemo(() => buildAccentPalette(accentColor, providedTextColor), [accentColor, providedTextColor]);


### PR DESCRIPTION
## Summary
- add a reusable accent palette builder/hook that produces shared tile surfaces, button colors, and feedback defaults
- update Quiz, Sequencing, and Match Pairs interactives to consume the shared palette instead of local useMemo blocks

## Testing
- npm run lint *(fails: pre-existing lint errors around unused vars / any types)*

------
https://chatgpt.com/codex/tasks/task_e_68dba62d8a108321a0ef26f934271628