### PR TITLE
Create reusable task section component for task tiles

### DIFF
--- a/src/components/admin/tiles/TaskTileSection.tsx
+++ b/src/components/admin/tiles/TaskTileSection.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+
+export interface TaskTileSectionProps extends React.HTMLAttributes<HTMLDivElement> {
+  icon?: React.ReactNode;
+  title: React.ReactNode;
+  headerRight?: React.ReactNode;
+  backgroundColor: string;
+  borderColor: string;
+  headerBorderColor?: string;
+  headerTextColor?: string;
+  className?: string;
+  headerClassName?: string;
+  headerContentClassName?: string;
+  headerRightClassName?: string;
+  contentClassName?: string;
+  contentStyle?: React.CSSProperties;
+  contentProps?: React.HTMLAttributes<HTMLDivElement>;
+}
+
+export const TaskTileSection: React.FC<TaskTileSectionProps> = ({
+  icon,
+  title,
+  headerRight,
+  backgroundColor,
+  borderColor,
+  headerBorderColor,
+  headerTextColor,
+  className = '',
+  headerClassName = '',
+  headerContentClassName = '',
+  headerRightClassName = '',
+  contentClassName = '',
+  contentStyle,
+  contentProps,
+  style,
+  children,
+  ...rest
+}) => {
+  const headerTextStyles = headerTextColor ? { color: headerTextColor } : undefined;
+  const mergedStyle = {
+    backgroundColor,
+    borderColor,
+    ...(style ?? {})
+  } satisfies React.CSSProperties;
+
+  const {
+    className: contentClassNameProp = '',
+    style: contentStyleProp,
+    ...contentRest
+  } = contentProps ?? {};
+
+  const mergedContentClassName = [
+    'px-5 py-4',
+    contentClassName,
+    contentClassNameProp
+  ].filter(Boolean).join(' ');
+
+  const mergedContentStyle = {
+    ...(contentStyle ?? {}),
+    ...(contentStyleProp ?? {})
+  } as React.CSSProperties;
+
+  return (
+    <div
+      {...rest}
+      className={['flex flex-col rounded-2xl border', className].filter(Boolean).join(' ')}
+      style={mergedStyle}
+    >
+      <div
+        className={[
+          'flex items-center justify-between px-5 py-4 border-b',
+          headerClassName
+        ].filter(Boolean).join(' ')}
+        style={{ borderColor: headerBorderColor ?? borderColor, ...headerTextStyles }}
+      >
+        <div
+          className={['flex items-center gap-2 text-sm font-semibold', headerContentClassName].filter(Boolean).join(' ')}
+          style={headerTextStyles}
+        >
+          {icon ? <span className="flex items-center justify-center">{icon}</span> : null}
+          {typeof title === 'string' ? <span>{title}</span> : title}
+        </div>
+
+        {headerRight ? (
+          <div
+            className={['text-xs', headerRightClassName].filter(Boolean).join(' ')}
+            style={headerTextStyles}
+          >
+            {headerRight}
+          </div>
+        ) : null}
+      </div>
+
+      <div
+        {...contentRest}
+        className={mergedContentClassName}
+        style={mergedContentStyle}
+      >
+        {children}
+      </div>
+    </div>
+  );
+};
+
+export default TaskTileSection;

--- a/src/components/admin/tiles/blanks/Interactive.tsx
+++ b/src/components/admin/tiles/blanks/Interactive.tsx
@@ -4,6 +4,7 @@ import { BlanksTile } from '../../../../types/lessonEditor';
 import { createBlankId, createPlaceholderRegex } from '../../../../utils/blanks.ts';
 import { getReadableTextColor, surfaceColor } from '../../../../utils/colorUtils';
 import { TaskInstructionPanel } from '../TaskInstructionPanel.tsx';
+import { TaskTileSection } from '../TaskTileSection.tsx';
 import { RichTextEditor, RichTextEditorProps } from '../RichTextEditor.tsx';
 
 interface BlanksInteractiveProps {
@@ -95,6 +96,12 @@ export const BlanksInteractive: React.FC<BlanksInteractiveProps> = ({
   const optionBackground = useMemo(() => surfaceColor(accentColor, textColor, 0.52, 0.46), [accentColor, textColor]);
   const optionBorder = useMemo(() => surfaceColor(accentColor, textColor, 0.44, 0.56), [accentColor, textColor]);
   const testingCaptionColor = useMemo(() => surfaceColor(accentColor, textColor, 0.42, 0.4), [accentColor, textColor]);
+  const taskTextBackground = useMemo(() => surfaceColor(accentColor, textColor, 0.68, 0.42), [accentColor, textColor]);
+  const taskTextBorder = useMemo(() => surfaceColor(accentColor, textColor, 0.52, 0.54), [accentColor, textColor]);
+  const taskTextHeaderBorder = useMemo(() => surfaceColor(accentColor, textColor, 0.58, 0.5), [accentColor, textColor]);
+  const optionsSectionBackground = useMemo(() => surfaceColor(accentColor, textColor, 0.6, 0.4), [accentColor, textColor]);
+  const optionsSectionBorder = useMemo(() => surfaceColor(accentColor, textColor, 0.5, 0.52), [accentColor, textColor]);
+  const optionsSectionHeaderBorder = useMemo(() => surfaceColor(accentColor, textColor, 0.54, 0.5), [accentColor, textColor]);
   const evaluationSuccessBackground = '#dcfce7';
   const evaluationErrorBackground = '#fee2e2';
 
@@ -355,49 +362,37 @@ export const BlanksInteractive: React.FC<BlanksInteractiveProps> = ({
         )}
 
         <div className="flex-1 grid grid-cols-1 lg:grid-cols-5 gap-6">
-          <div
-            className="lg:col-span-3 rounded-2xl border px-6 py-5 space-y-4 shadow-sm"
-            style={{
-              backgroundColor: surfaceColor(accentColor, textColor, 0.68, 0.42),
-              borderColor: surfaceColor(accentColor, textColor, 0.52, 0.54),
-              color: textColor
-            }}
+          <TaskTileSection
+            className="lg:col-span-3 shadow-sm"
+            backgroundColor={taskTextBackground}
+            borderColor={taskTextBorder}
+            headerBorderColor={taskTextHeaderBorder}
+            headerTextColor={mutedLabelColor}
+            icon={<Puzzle className="w-4 h-4" style={{ color: mutedLabelColor }} />}
+            title="Tekst zadania"
+            contentClassName="text-base leading-relaxed space-y-3"
+            style={{ color: textColor }}
           >
-            <div className="flex items-center gap-3 text-sm font-semibold" style={{ color: mutedLabelColor }}>
-              <Puzzle className="w-4 h-4" />
-              <span>Tekst zadania</span>
-            </div>
-            <div
-              className="text-base leading-relaxed space-y-3"
-            >
-              {segments.map((segment, index) => (
-                segment.type === 'text'
-                  ? <React.Fragment key={`text-${index}`}>{mapTextToNodes(segment.value)}</React.Fragment>
-                  : <React.Fragment key={`blank-${segment.id}-${index}`}>{renderBlank(segment.id)}</React.Fragment>
-              ))}
-            </div>
-          </div>
+            {segments.map((segment, index) => (
+              segment.type === 'text'
+                ? <React.Fragment key={`text-${index}`}>{mapTextToNodes(segment.value)}</React.Fragment>
+                : <React.Fragment key={`blank-${segment.id}-${index}`}>{renderBlank(segment.id)}</React.Fragment>
+            ))}
+          </TaskTileSection>
 
-          <div
-            className="lg:col-span-2 rounded-2xl border px-6 py-5 flex flex-col gap-4"
-            style={{
-              backgroundColor: surfaceColor(accentColor, textColor, 0.6, 0.4),
-              borderColor: surfaceColor(accentColor, textColor, 0.5, 0.52),
-              color: textColor
-            }}
-            onDragOver={handleDragOverBank}
-            onDrop={handleDropToBank}
+          <TaskTileSection
+            className="lg:col-span-2"
+            backgroundColor={optionsSectionBackground}
+            borderColor={optionsSectionBorder}
+            headerBorderColor={optionsSectionHeaderBorder}
+            headerTextColor={mutedLabelColor}
+            icon={<RefreshCw className="w-4 h-4" style={{ color: mutedLabelColor }} />}
+            title="Pula odpowiedzi"
+            headerRight={`${availableOptions.length} / ${tile.content.options.length}`}
+            contentClassName="flex-1 flex flex-col gap-4"
+            contentProps={{ onDragOver: handleDragOverBank, onDrop: handleDropToBank }}
+            style={{ color: textColor }}
           >
-            <div className="flex items-center justify-between">
-              <div className="flex items-center gap-3 text-sm font-semibold" style={{ color: mutedLabelColor }}>
-                <RefreshCw className="w-4 h-4" />
-                <span>Pula odpowiedzi</span>
-              </div>
-              <span className="text-xs" style={{ color: mutedLabelColor }}>
-                {availableOptions.length} / {tile.content.options.length}
-              </span>
-            </div>
-
             <div className="flex flex-wrap gap-3">
               {availableOptions.length === 0 ? (
                 <div className="flex flex-col items-center justify-center text-sm text-center gap-2 py-8 w-full" style={{ color: mutedLabelColor }}>
@@ -428,7 +423,7 @@ export const BlanksInteractive: React.FC<BlanksInteractiveProps> = ({
                 ))
               )}
             </div>
-          </div>
+          </TaskTileSection>
         </div>
 
         {isInteractionEnabled && (

--- a/src/components/admin/tiles/sequencing/Interactive.tsx
+++ b/src/components/admin/tiles/sequencing/Interactive.tsx
@@ -8,6 +8,7 @@ import {
   surfaceColor,
 } from '../../../../utils/colorUtils';
 import { TaskInstructionPanel } from '../TaskInstructionPanel.tsx';
+import { TaskTileSection } from '../TaskTileSection.tsx';
 import { RichTextEditor, RichTextEditorProps } from '../RichTextEditor.tsx';
 
 interface SequencingInteractiveProps {
@@ -507,45 +508,93 @@ export const SequencingInteractive: React.FC<SequencingInteractiveProps> = ({
         </TaskInstructionPanel>
 
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 flex-1 min-h-0">
-          <div
-            className="flex flex-col rounded-2xl border transition-all duration-200"
+          <TaskTileSection
+            className="transition-all duration-200"
+            backgroundColor={isPoolHighlighted ? poolHighlightBackground : poolBackground}
+            borderColor={isPoolHighlighted ? poolHighlightBorder : poolBorder}
+            headerBorderColor={itemBorder}
+            headerTextColor={subtleCaptionColor}
+            icon={<Shuffle className="w-4 h-4" style={{ color: subtleCaptionColor }} />}
+            title="Pula elementów"
+            contentClassName="flex-1 overflow-auto space-y-3"
             style={{
-              backgroundColor: isPoolHighlighted ? poolHighlightBackground : poolBackground,
-              borderColor: isPoolHighlighted ? poolHighlightBorder : poolBorder,
               boxShadow: isPoolHighlighted ? '0 22px 44px rgba(15, 23, 42, 0.22)' : undefined
             }}
             onDragOver={handlePoolDragOver}
             onDragLeave={handlePoolDragLeave}
             onDrop={handleDropToPool}
           >
-            <div
-              className="flex items-center justify-between px-5 py-4 border-b"
-              style={{ borderColor: itemBorder, color: subtleCaptionColor }}
-            >
-              <div className="flex items-center gap-2 text-sm font-semibold" style={{ color: subtleCaptionColor }}>
-                <Shuffle className="w-4 h-4" />
-                <span>Pula elementów</span>
+            {availableItems.length === 0 ? (
+              <div
+                className="flex flex-col items-center justify-center gap-2 text-center text-sm py-10"
+                style={{ color: subtleCaptionColor }}
+              >
+                <ArrowLeftRight className="w-5 h-5" />
+                <span>Przeciągnij elementy na prawą stronę</span>
               </div>
-            </div>
-
-            <div className="flex-1 overflow-auto px-5 py-4 space-y-3">
-              {availableItems.length === 0 ? (
+            ) : (
+              availableItems.map(item => (
                 <div
-                  className="flex flex-col items-center justify-center gap-2 text-center text-sm py-10"
-                  style={{ color: subtleCaptionColor }}
+                  key={item.id}
+                  draggable={canInteract}
+                  onDragStart={e => handleDragStart(e, item.id, 'pool')}
+                  onDragEnd={handleDragEnd}
+                  className={getItemClasses(item.id)}
+                  style={{ backgroundColor: itemBackground, borderColor: itemBorder, color: textColor }}
                 >
-                  <ArrowLeftRight className="w-5 h-5" />
-                  <span>Przeciągnij elementy na prawą stronę</span>
+                  <div className="flex items-center gap-3">
+                    <div
+                      className="flex h-8 w-8 items-center justify-center rounded-lg border"
+                      style={{ backgroundColor: gripBackground, borderColor: gripBorder, color: mutedLabelColor }}
+                    >
+                      <GripVertical className="h-4 w-4" />
+                    </div>
+                    <span className="text-sm font-medium" style={{ color: textColor }}>
+                      {item.text}
+                    </span>
+                  </div>
                 </div>
-              ) : (
-                availableItems.map(item => (
+              ))
+            )}
+          </TaskTileSection>
+
+          <TaskTileSection
+            backgroundColor={sequenceBackground}
+            borderColor={sequenceBorder}
+            headerBorderColor={sequenceHeaderBorder}
+            headerTextColor={subtleCaptionColor}
+            icon={<CheckCircle className="w-4 h-4" style={{ color: subtleCaptionColor }} />}
+            title="Twoja sekwencja"
+            headerRight={`${placedItems.filter(Boolean).length} / ${tile.content.items.length}`}
+            contentClassName="flex-1 overflow-auto space-y-3"
+          >
+            {placedItems.map((item, index) => (
+              <div
+                key={index}
+                className={getSlotClasses(Boolean(item))}
+                style={getSlotStyles(index, Boolean(item))}
+                onDragOver={e => handleSlotDragOver(e, index)}
+                onDragLeave={handleSlotDragLeave}
+                onDrop={e => handleDropToSlot(e, index)}
+              >
+                <div
+                  className="flex items-center justify-center w-8 h-8 rounded-lg border text-sm font-semibold"
+                  style={{
+                    backgroundColor: badgeBackground,
+                    borderColor: badgeBorder,
+                    color: badgeTextColor
+                  }}
+                >
+                  {index + 1}
+                </div>
+                {item ? (
                   <div
-                    key={item.id}
+                    className={`flex-1 flex items-center justify-between gap-4 cursor-grab active:cursor-grabbing ${
+                      dragState?.id === item.id ? 'opacity-60 scale-[0.98]' : ''
+                    }`}
                     draggable={canInteract}
-                    onDragStart={e => handleDragStart(e, item.id, 'pool')}
+                    onDragStart={e => handleDragStart(e, item.id, 'sequence', index)}
                     onDragEnd={handleDragEnd}
-                    className={getItemClasses(item.id)}
-                    style={{ backgroundColor: itemBackground, borderColor: itemBorder, color: textColor }}
                   >
                     <div className="flex items-center gap-3">
                       <div
@@ -554,94 +603,30 @@ export const SequencingInteractive: React.FC<SequencingInteractiveProps> = ({
                       >
                         <GripVertical className="h-4 w-4" />
                       </div>
-                      <span className="text-sm font-medium" style={{ color: textColor }}>
+                      <span className="text-sm font-medium text-left break-words" style={{ color: textColor }}>
                         {item.text}
                       </span>
                     </div>
                   </div>
-                ))
-              )}
-            </div>
-          </div>
+                ) : (
+                  <span className="flex-1 text-sm italic" style={{ color: subtleCaptionColor }}>
+                    Upuść element w tym miejscu
+                  </span>
+                )}
 
-          <div
-            className="flex flex-col rounded-2xl border"
-            style={{ backgroundColor: sequenceBackground, borderColor: sequenceBorder }}
-          >
-            <div
-              className="flex items-center justify-between px-5 py-4 border-b"
-              style={{ borderColor: sequenceHeaderBorder, color: subtleCaptionColor }}
-            >
-              <div className="flex items-center gap-2 text-sm font-semibold" style={{ color: subtleCaptionColor }}>
-                <CheckCircle className="w-4 h-4" style={{ color: subtleCaptionColor }} />
-                <span>Twoja sekwencja</span>
-              </div>
-              <span className="text-xs" style={{ color: subtleCaptionColor }}>
-                {placedItems.filter(Boolean).length} / {tile.content.items.length}
-              </span>
-            </div>
+                {isChecked && isCorrect !== null && item && (() => {
+                  const originalItem = tile.content.items.find(original => original.id === item.id);
+                  const isInCorrectPosition = originalItem && originalItem.correctPosition === index;
 
-            <div className="flex-1 overflow-auto px-5 py-4 space-y-3">
-              {placedItems.map((item, index) => (
-                <div
-                  key={index}
-                  className={getSlotClasses(Boolean(item))}
-                  style={getSlotStyles(index, Boolean(item))}
-                  onDragOver={e => handleSlotDragOver(e, index)}
-                  onDragLeave={handleSlotDragLeave}
-                  onDrop={e => handleDropToSlot(e, index)}
-                >
-                  <div
-                    className="flex items-center justify-center w-8 h-8 rounded-lg border text-sm font-semibold"
-                    style={{
-                      backgroundColor: badgeBackground,
-                      borderColor: badgeBorder,
-                      color: badgeTextColor
-                    }}
-                  >
-                    {index + 1}
-                  </div>
-                  {item ? (
-                    <div
-                      className={`flex-1 flex items-center justify-between gap-4 cursor-grab active:cursor-grabbing ${
-                        dragState?.id === item.id ? 'opacity-60 scale-[0.98]' : ''
-                      }`}
-                      draggable={canInteract}
-                      onDragStart={e => handleDragStart(e, item.id, 'sequence', index)}
-                      onDragEnd={handleDragEnd}
-                    >
-                      <div className="flex items-center gap-3">
-                        <div
-                          className="flex h-8 w-8 items-center justify-center rounded-lg border"
-                          style={{ backgroundColor: gripBackground, borderColor: gripBorder, color: mutedLabelColor }}
-                        >
-                          <GripVertical className="h-4 w-4" />
-                        </div>
-                        <span className="text-sm font-medium text-left break-words" style={{ color: textColor }}>
-                          {item.text}
-                        </span>
-                      </div>
-                    </div>
+                  return isInCorrectPosition ? (
+                    <CheckCircle className="w-5 h-5" style={{ color: successIconColor }} />
                   ) : (
-                    <span className="flex-1 text-sm italic" style={{ color: subtleCaptionColor }}>
-                      Upuść element w tym miejscu
-                    </span>
-                  )}
-
-                  {isChecked && isCorrect !== null && item && (() => {
-                    const originalItem = tile.content.items.find(original => original.id === item.id);
-                    const isInCorrectPosition = originalItem && originalItem.correctPosition === index;
-
-                    return isInCorrectPosition ? (
-                      <CheckCircle className="w-5 h-5" style={{ color: successIconColor }} />
-                    ) : (
-                      <XCircle className="w-5 h-5 text-rose-400" />
-                    );
-                  })()}
-                </div>
-              ))}
-            </div>
-          </div>
+                    <XCircle className="w-5 h-5 text-rose-400" />
+                  );
+                })()}
+              </div>
+            ))}
+          </TaskTileSection>
         </div>
 
         {isChecked && isCorrect !== null && (


### PR DESCRIPTION
## Summary
- add a shared TaskTileSection component that encapsulates the common header and body layout for task tile sections
- refactor the sequencing tile to render pool and sequence panels through the new component while preserving behaviors
- update the blanks tile to use the shared section component and align section styling across tiles

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd004313108321adf74f2481378e66