### PR TITLE
Add reusable validation button for task tiles

### DIFF
--- a/src/components/admin/tiles/blanks/Interactive.tsx
+++ b/src/components/admin/tiles/blanks/Interactive.tsx
@@ -1,11 +1,16 @@
 import React, { useEffect, useMemo, useState, useCallback } from 'react';
-import { CheckCircle, XCircle, RefreshCw, Sparkles, Puzzle, RotateCcw } from 'lucide-react';
+import { RefreshCw, Sparkles, Puzzle, RotateCcw } from 'lucide-react';
 import { BlanksTile } from '../../../../types/lessonEditor';
 import { createBlankId, createPlaceholderRegex } from '../../../../utils/blanks.ts';
-import { getReadableTextColor, surfaceColor } from '../../../../utils/colorUtils';
+import { getReadableTextColor, surfaceColor, lightenColor, darkenColor } from '../../../../utils/colorUtils';
 import { TaskInstructionPanel } from '../TaskInstructionPanel.tsx';
 import { TaskTileSection } from '../TaskTileSection.tsx';
 import { RichTextEditor, RichTextEditorProps } from '../RichTextEditor.tsx';
+import {
+  ValidateButton,
+  ValidateButtonColors,
+  ValidateButtonState
+} from '../../../common/ValidateButton.tsx';
 
 interface BlanksInteractiveProps {
   tile: BlanksTile;
@@ -19,7 +24,7 @@ type Segment =
   | { type: 'text'; value: string }
   | { type: 'blank'; id: string };
 
-type EvaluationState = 'idle' | 'success' | 'error';
+type EvaluationState = ValidateButtonState;
 
 interface DragPayload {
   optionId: string;
@@ -67,9 +72,6 @@ const mapTextToNodes = (text: string): React.ReactNode =>
     part === '\n' ? <br key={`br-${index}`} /> : <span key={`segment-${index}`}>{part}</span>
   );
 
-const DEFAULT_SUCCESS_FEEDBACK = 'Brawo! Wszystkie odpowiedzi są poprawne.';
-const DEFAULT_FAILURE_FEEDBACK = 'Sprawdź jeszcze raz – część luk zawiera błędne odpowiedzi.';
-
 export const BlanksInteractive: React.FC<BlanksInteractiveProps> = ({
   tile,
   isPreview = false,
@@ -98,6 +100,52 @@ export const BlanksInteractive: React.FC<BlanksInteractiveProps> = ({
   const testingCaptionColor = useMemo(() => surfaceColor(accentColor, textColor, 0.42, 0.4), [accentColor, textColor]);
   const evaluationSuccessBackground = '#dcfce7';
   const evaluationErrorBackground = '#fee2e2';
+  const evaluationSuccessBorder = '#bbf7d0';
+  const evaluationErrorBorder = '#fecaca';
+  const evaluationSuccessText = '#166534';
+  const evaluationErrorText = '#b91c1c';
+  const primaryButtonBackground = useMemo(
+    () => (textColor === '#0f172a' ? darkenColor(accentColor, 0.2) : lightenColor(accentColor, 0.24)),
+    [accentColor, textColor]
+  );
+  const primaryButtonTextColor = useMemo(() => (textColor === '#0f172a' ? '#f8fafc' : '#0f172a'), [textColor]);
+  const validateButtonColors = useMemo<ValidateButtonColors>(
+    () => ({
+      idle: {
+        background: primaryButtonBackground,
+        color: primaryButtonTextColor,
+        border: 'transparent'
+      },
+      success: {
+        background: evaluationSuccessBackground,
+        color: evaluationSuccessText,
+        border: evaluationSuccessBorder
+      },
+      error: {
+        background: evaluationErrorBackground,
+        color: evaluationErrorText,
+        border: evaluationErrorBorder
+      }
+    }),
+    [
+      primaryButtonBackground,
+      primaryButtonTextColor,
+      evaluationSuccessBackground,
+      evaluationSuccessBorder,
+      evaluationSuccessText,
+      evaluationErrorBackground,
+      evaluationErrorBorder,
+      evaluationErrorText
+    ]
+  );
+  const validateButtonLabels = useMemo(
+    () => ({
+      idle: 'Sprawdź odpowiedzi',
+      success: 'Dobra robota!',
+      error: 'Spróbuj ponownie'
+    }),
+    []
+  );
 
   const segments = useMemo(() => parseTemplate(tile.content.textTemplate), [tile.content.textTemplate]);
 
@@ -124,6 +172,11 @@ export const BlanksInteractive: React.FC<BlanksInteractiveProps> = ({
   }, [placements, tile.content.options]);
 
   const isInteractionEnabled = !isPreview;
+  const isComplete = useMemo(
+    () => tile.content.blanks.every(blank => placements[blank.id]),
+    [placements, tile.content.blanks]
+  );
+  const validationState: ValidateButtonState = evaluation;
 
   const handleDragStartFromBank = (event: React.DragEvent<HTMLButtonElement>, optionId: string) => {
     if (!isInteractionEnabled) return;
@@ -216,8 +269,8 @@ export const BlanksInteractive: React.FC<BlanksInteractiveProps> = ({
   };
 
   const handleCheck = () => {
+    if (!isInteractionEnabled) return;
     setAttempts(prev => prev + 1);
-    const isComplete = tile.content.blanks.every(blank => placements[blank.id]);
     if (!isComplete) {
       setEvaluation('error');
       return;
@@ -225,27 +278,6 @@ export const BlanksInteractive: React.FC<BlanksInteractiveProps> = ({
 
     const isCorrect = tile.content.blanks.every(blank => placements[blank.id] === blank.correctOptionId);
     setEvaluation(isCorrect ? 'success' : 'error');
-  };
-
-  const handleReset = () => {
-    resetPlacements();
-  };
-
-  const renderEvaluationMessage = () => {
-    if (evaluation === 'idle') return null;
-
-    const isSuccess = evaluation === 'success';
-    const backgroundColor = isSuccess ? evaluationSuccessBackground : evaluationErrorBackground;
-    const textColorClass = isSuccess ? 'text-emerald-700' : 'text-rose-700';
-    const Icon = isSuccess ? CheckCircle : XCircle;
-    const message = isSuccess ? DEFAULT_SUCCESS_FEEDBACK : DEFAULT_FAILURE_FEEDBACK;
-
-    return (
-      <div className={`flex items-center gap-2 px-4 py-3 rounded-xl text-sm font-medium ${textColorClass}`} style={{ backgroundColor }}>
-        <Icon className="w-5 h-5" />
-        <span>{message}</span>
-      </div>
-    );
   };
 
   const handleTileDoubleClick = (event: React.MouseEvent<HTMLDivElement>) => {
@@ -433,28 +465,15 @@ export const BlanksInteractive: React.FC<BlanksInteractiveProps> = ({
 
         {isInteractionEnabled && (
           <div className="flex flex-wrap items-center gap-3 pt-2">
-            <button
-              type="button"
+            <ValidateButton
               onClick={handleCheck}
-              className="px-4 py-2 rounded-lg text-sm font-semibold shadow-sm transition-colors duration-200 bg-white/90 hover:bg-white"
-              style={{ color: accentColor }}
-            >
-              Sprawdź odpowiedzi
-            </button>
-            <button
-              type="button"
-              onClick={handleReset}
-              className="px-3 py-2 rounded-lg text-sm font-medium flex items-center gap-2 text-slate-100/90 hover:text-white"
-              style={{ backgroundColor: 'transparent' }}
-            >
-              <RotateCcw className="w-4 h-4" />
-              Wyczyść wybór
-            </button>
-            {renderEvaluationMessage()}
+              disabled={!isComplete || evaluation === 'success'}
+              state={validationState}
+              colors={validateButtonColors}
+              labels={validateButtonLabels}
+            />
           </div>
         )}
-
-        {!isInteractionEnabled && renderEvaluationMessage()}
       </div>
     </div>
   );

--- a/src/components/common/ValidateButton.tsx
+++ b/src/components/common/ValidateButton.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+
+export type ValidateButtonState = 'idle' | 'success' | 'error';
+
+export interface ValidateButtonColorConfig {
+  background: string;
+  color: string;
+  border?: string;
+}
+
+export type ValidateButtonColors = Partial<
+  Record<ValidateButtonState, Partial<ValidateButtonColorConfig>>
+>;
+
+export type ValidateButtonLabels = Partial<Record<ValidateButtonState, string>>;
+
+interface ValidateButtonProps {
+  state: ValidateButtonState;
+  onClick: () => void;
+  disabled?: boolean;
+  className?: string;
+  style?: React.CSSProperties;
+  colors?: ValidateButtonColors;
+  labels?: ValidateButtonLabels;
+  type?: 'button' | 'submit' | 'reset';
+}
+
+const DEFAULT_LABELS: Record<ValidateButtonState, string> = {
+  idle: 'Check answer',
+  success: 'Correct!',
+  error: 'Try again'
+};
+
+const DEFAULT_COLORS: Record<ValidateButtonState, ValidateButtonColorConfig> = {
+  idle: {
+    background: '#0f172a',
+    color: '#f8fafc',
+    border: 'transparent'
+  },
+  success: {
+    background: '#dcfce7',
+    color: '#166534',
+    border: '#86efac'
+  },
+  error: {
+    background: '#fee2e2',
+    color: '#b91c1c',
+    border: '#fca5a5'
+  }
+};
+
+const mergeColorConfig = (
+  state: ValidateButtonState,
+  overrides?: ValidateButtonColors
+): ValidateButtonColorConfig => {
+  const base = DEFAULT_COLORS[state];
+  if (!overrides || !overrides[state]) {
+    return base;
+  }
+
+  const override = overrides[state]!;
+  return {
+    background: override.background ?? base.background,
+    color: override.color ?? base.color,
+    border: override.border ?? base.border
+  };
+};
+
+export const ValidateButton: React.FC<ValidateButtonProps> = ({
+  state,
+  onClick,
+  disabled = false,
+  className = '',
+  style,
+  colors,
+  labels,
+  type = 'button'
+}) => {
+  const label = labels?.[state] ?? DEFAULT_LABELS[state];
+  const { background, color, border } = mergeColorConfig(state, colors);
+
+  const buttonStyle: React.CSSProperties = {
+    backgroundColor: background,
+    color,
+    borderColor: border ?? 'transparent',
+    boxShadow: '0 16px 32px rgba(15, 23, 42, 0.18)',
+    ...style
+  };
+
+  return (
+    <button
+      type={type}
+      onClick={onClick}
+      disabled={disabled}
+      className={`inline-flex h-11 w-[192px] items-center justify-center rounded-xl border font-semibold text-sm transition-transform duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-slate-900/20 disabled:cursor-not-allowed disabled:opacity-60 hover:-translate-y-0.5 active:translate-y-0 ${className}`.trim()}
+      style={buttonStyle}
+      data-state={state}
+    >
+      {label}
+    </button>
+  );
+};
+
+export default ValidateButton;


### PR DESCRIPTION
## Summary
- add a shared `ValidateButton` component that supports idle, success, and error states
- replace bespoke validation controls in sequencing and blanks tiles with the shared button and remove inline feedback banners
- simplify blanks interactions by dropping the reset control and routing feedback through the new button states

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dd04ec73148321984a241613d6dac6