### PR TITLE
Add reusable validate button for task tiles

### DIFF
--- a/src/components/admin/tiles/ValidateButton.tsx
+++ b/src/components/admin/tiles/ValidateButton.tsx
@@ -1,0 +1,84 @@
+import React, { useMemo } from 'react';
+
+export type ValidateButtonStatus = 'idle' | 'success' | 'error';
+
+interface StatusColorConfig {
+  background: string;
+  text: string;
+}
+
+interface ValidateButtonProps extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'children'> {
+  status?: ValidateButtonStatus;
+  accentColor?: string;
+  idleTextColor?: string;
+  statusColors?: Partial<Record<ValidateButtonStatus, StatusColorConfig>>;
+}
+
+const DEFAULT_SUCCESS_COLOR = '#16a34a';
+const DEFAULT_SUCCESS_TEXT = '#ecfdf5';
+const DEFAULT_ERROR_COLOR = '#dc2626';
+const DEFAULT_ERROR_TEXT = '#fee2e2';
+const DEFAULT_IDLE_COLOR = '#2563eb';
+const DEFAULT_IDLE_TEXT = '#f8fafc';
+
+export const ValidateButton: React.FC<ValidateButtonProps> = ({
+  status = 'idle',
+  accentColor = DEFAULT_IDLE_COLOR,
+  idleTextColor,
+  statusColors,
+  disabled,
+  className = '',
+  style,
+  onClick,
+  ...buttonProps
+}) => {
+  const { label, background, text } = useMemo(() => {
+    const overrides = statusColors?.[status];
+
+    if (status === 'success') {
+      return {
+        label: 'Correct!',
+        background: overrides?.background ?? DEFAULT_SUCCESS_COLOR,
+        text: overrides?.text ?? DEFAULT_SUCCESS_TEXT
+      };
+    }
+
+    if (status === 'error') {
+      return {
+        label: 'Try again',
+        background: overrides?.background ?? DEFAULT_ERROR_COLOR,
+        text: overrides?.text ?? DEFAULT_ERROR_TEXT
+      };
+    }
+
+    return {
+      label: 'Check answer',
+      background: overrides?.background ?? accentColor ?? DEFAULT_IDLE_COLOR,
+      text: overrides?.text ?? idleTextColor ?? DEFAULT_IDLE_TEXT
+    };
+  }, [status, statusColors, accentColor, idleTextColor]);
+
+  const baseClasses =
+    'inline-flex items-center justify-center px-6 py-2 rounded-xl font-semibold shadow-lg transition-all duration-200 min-w-[168px] disabled:opacity-60 disabled:cursor-not-allowed hover:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent';
+
+  return (
+    <button
+      type="button"
+      {...buttonProps}
+      onClick={disabled ? undefined : onClick}
+      disabled={disabled}
+      className={`${baseClasses} ${className}`.trim()}
+      style={{
+        backgroundColor: background,
+        color: text,
+        boxShadow: '0 16px 32px rgba(15, 23, 42, 0.22)',
+        ...style
+      }}
+      data-validation-status={status}
+    >
+      {label}
+    </button>
+  );
+};
+
+export default ValidateButton;

--- a/src/components/admin/tiles/sequencing/Interactive.tsx
+++ b/src/components/admin/tiles/sequencing/Interactive.tsx
@@ -10,6 +10,7 @@ import {
 import { TaskInstructionPanel } from '../TaskInstructionPanel.tsx';
 import { TaskTileSection } from '../TaskTileSection.tsx';
 import { RichTextEditor, RichTextEditorProps } from '../RichTextEditor.tsx';
+import { ValidateButton, ValidateButtonStatus } from '../ValidateButton.tsx';
 
 interface SequencingInteractiveProps {
   tile: SequencingTile;
@@ -165,16 +166,25 @@ export const SequencingInteractive: React.FC<SequencingInteractiveProps> = ({
     [accentColor, textColor]
   );
   const successIconColor = textColor === '#0f172a' ? darkenColor(accentColor, 0.2) : lightenColor(accentColor, 0.32);
-  const successFeedbackBackground = surfaceColor(accentColor, textColor, 0.7, 0.34);
-  const successFeedbackBorder = surfaceColor(accentColor, textColor, 0.6, 0.44);
-  const failureFeedbackBackground = '#fee2e2';
-  const failureFeedbackBorder = '#fca5a5';
   const primaryButtonBackground = textColor === '#0f172a' ? darkenColor(accentColor, 0.25) : lightenColor(accentColor, 0.28);
   const primaryButtonTextColor = textColor === '#0f172a' ? '#f8fafc' : '#0f172a';
   const secondaryButtonBackground = surfaceColor(accentColor, textColor, 0.52, 0.5);
   const secondaryButtonBorder = surfaceColor(accentColor, textColor, 0.46, 0.58);
   const showBorder = tile.content.showBorder !== false;
   const isEmbedded = variant === 'embedded';
+
+  const validateButtonStatusColors = useMemo(
+    () => ({ idle: { background: primaryButtonBackground, text: primaryButtonTextColor } }),
+    [primaryButtonBackground, primaryButtonTextColor]
+  );
+
+  const validationStatus: ValidateButtonStatus = useMemo(() => {
+    if (isChecked && isCorrect) return 'success';
+    if (isChecked && isCorrect === false) return 'error';
+    return 'idle';
+  }, [isChecked, isCorrect]);
+
+  const isValidateDisabled = !sequenceComplete || (isChecked && isCorrect);
 
   const correctOrderIds = useMemo(
     () =>
@@ -633,47 +643,17 @@ export const SequencingInteractive: React.FC<SequencingInteractiveProps> = ({
           </TaskTileSection>
         </div>
 
-        {isChecked && isCorrect !== null && (
-          <div
-            className="rounded-2xl border px-6 py-4 flex items-center justify-between"
-            style={{
-              backgroundColor: isCorrect ? successFeedbackBackground : failureFeedbackBackground,
-              borderColor: isCorrect ? successFeedbackBorder : failureFeedbackBorder,
-              color: isCorrect ? textColor : '#7f1d1d'
-            }}
-          >
-            <div className="flex items-center gap-3 text-sm font-medium">
-              {isCorrect ? (
-                <CheckCircle className="w-5 h-5" style={{ color: successIconColor }} />
-              ) : (
-                <XCircle className="w-5 h-5 text-rose-300" />
-              )}
-              <span>{isCorrect ? tile.content.correctFeedback : tile.content.incorrectFeedback}</span>
-            </div>
-
-            {!isCorrect && (
-              <div className="text-xs" style={{ color: '#7f1d1d' }}>
-                Spróbuj ponownie, przenosząc elementy.
-              </div>
-            )}
-          </div>
-        )}
-
         {!isPreview && (
           <div className="flex flex-wrap items-center justify-between gap-4">
             <div className="flex items-center gap-3">
-              <button
+              <ValidateButton
                 onClick={checkSequence}
-                disabled={!sequenceComplete || (isChecked && isCorrect)}
-                className="px-6 py-2 rounded-xl font-semibold shadow-lg transition-transform duration-200 disabled:opacity-40 disabled:cursor-not-allowed hover:-translate-y-0.5"
-                style={{
-                  backgroundColor: primaryButtonBackground,
-                  color: primaryButtonTextColor,
-                  boxShadow: '0 16px 32px rgba(15, 23, 42, 0.22)'
-                }}
-              >
-                {isChecked && isCorrect ? 'Sekwencja sprawdzona' : 'Sprawdź kolejność'}
-              </button>
+                disabled={isValidateDisabled}
+                status={validationStatus}
+                accentColor={primaryButtonBackground}
+                idleTextColor={primaryButtonTextColor}
+                statusColors={validateButtonStatusColors}
+              />
 
               {isChecked && !isCorrect && (
                 <button


### PR DESCRIPTION
## Summary
- add a reusable ValidateButton component that standardizes validation labels and colors
- switch the blanks and sequencing tiles to the shared button and remove inline feedback popups

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd04ec73148321984a241613d6dac6