### PR TITLE
feat: add reusable validate button for task tiles

### DIFF
--- a/src/components/admin/tiles/ValidateButton.tsx
+++ b/src/components/admin/tiles/ValidateButton.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { getReadableTextColor } from '../../../utils/colorUtils';
+
+export type ValidateButtonStatus = 'idle' | 'correct' | 'incorrect';
+
+const STATUS_LABELS: Record<ValidateButtonStatus, string> = {
+  idle: 'Check answer',
+  correct: 'Correct!',
+  incorrect: 'Try again'
+};
+
+const SUCCESS_COLOR = '#22c55e';
+const ERROR_COLOR = '#ef4444';
+const DEFAULT_ACCENT = '#0f172a';
+
+export interface ValidateButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  status?: ValidateButtonStatus;
+  accentColor?: string;
+  textColor?: string;
+}
+
+export const ValidateButton: React.FC<ValidateButtonProps> = ({
+  status = 'idle',
+  accentColor = DEFAULT_ACCENT,
+  textColor,
+  disabled,
+  className = '',
+  style,
+  children,
+  ...props
+}) => {
+  const baseTextColor = textColor ?? getReadableTextColor(accentColor);
+  const stylesByStatus: Record<ValidateButtonStatus, React.CSSProperties> = {
+    idle: {
+      backgroundColor: accentColor,
+      color: baseTextColor
+    },
+    correct: {
+      backgroundColor: SUCCESS_COLOR,
+      color: getReadableTextColor(SUCCESS_COLOR)
+    },
+    incorrect: {
+      backgroundColor: ERROR_COLOR,
+      color: getReadableTextColor(ERROR_COLOR)
+    }
+  };
+
+  const statusLabel = STATUS_LABELS[status];
+
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      className={`inline-flex h-11 w-44 items-center justify-center rounded-xl text-sm font-semibold shadow-lg transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-black/20 disabled:opacity-40 disabled:cursor-not-allowed ${className}`}
+      style={{
+        ...stylesByStatus[status],
+        ...style
+      }}
+      {...props}
+    >
+      {children ?? statusLabel}
+    </button>
+  );
+};
+
+export default ValidateButton;

--- a/src/components/admin/tiles/blanks/Interactive.tsx
+++ b/src/components/admin/tiles/blanks/Interactive.tsx
@@ -1,11 +1,12 @@
 import React, { useEffect, useMemo, useState, useCallback } from 'react';
-import { CheckCircle, XCircle, RefreshCw, Sparkles, Puzzle, RotateCcw } from 'lucide-react';
+import { RefreshCw, Sparkles, Puzzle, RotateCcw } from 'lucide-react';
 import { BlanksTile } from '../../../../types/lessonEditor';
 import { createBlankId, createPlaceholderRegex } from '../../../../utils/blanks.ts';
 import { getReadableTextColor, surfaceColor } from '../../../../utils/colorUtils';
 import { TaskInstructionPanel } from '../TaskInstructionPanel.tsx';
 import { TaskTileSection } from '../TaskTileSection.tsx';
 import { RichTextEditor, RichTextEditorProps } from '../RichTextEditor.tsx';
+import { ValidateButton, ValidateButtonStatus } from '../ValidateButton.tsx';
 
 interface BlanksInteractiveProps {
   tile: BlanksTile;
@@ -67,9 +68,6 @@ const mapTextToNodes = (text: string): React.ReactNode =>
     part === '\n' ? <br key={`br-${index}`} /> : <span key={`segment-${index}`}>{part}</span>
   );
 
-const DEFAULT_SUCCESS_FEEDBACK = 'Brawo! Wszystkie odpowiedzi są poprawne.';
-const DEFAULT_FAILURE_FEEDBACK = 'Sprawdź jeszcze raz – część luk zawiera błędne odpowiedzi.';
-
 export const BlanksInteractive: React.FC<BlanksInteractiveProps> = ({
   tile,
   isPreview = false,
@@ -96,9 +94,20 @@ export const BlanksInteractive: React.FC<BlanksInteractiveProps> = ({
   const optionBackground = useMemo(() => surfaceColor(accentColor, textColor, 0.52, 0.46), [accentColor, textColor]);
   const optionBorder = useMemo(() => surfaceColor(accentColor, textColor, 0.44, 0.56), [accentColor, textColor]);
   const testingCaptionColor = useMemo(() => surfaceColor(accentColor, textColor, 0.42, 0.4), [accentColor, textColor]);
-  const evaluationSuccessBackground = '#dcfce7';
-  const evaluationErrorBackground = '#fee2e2';
+  const validateButtonBackground = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.52, 0.46),
+    [accentColor, textColor]
+  );
+  const validateButtonTextColor = useMemo(
+    () => getReadableTextColor(validateButtonBackground),
+    [validateButtonBackground]
+  );
 
+  const validationStatus: ValidateButtonStatus = evaluation === 'idle'
+    ? 'idle'
+    : evaluation === 'success'
+      ? 'correct'
+      : 'incorrect';
   const segments = useMemo(() => parseTemplate(tile.content.textTemplate), [tile.content.textTemplate]);
 
   const resetPlacements = useCallback(() => {
@@ -225,27 +234,6 @@ export const BlanksInteractive: React.FC<BlanksInteractiveProps> = ({
 
     const isCorrect = tile.content.blanks.every(blank => placements[blank.id] === blank.correctOptionId);
     setEvaluation(isCorrect ? 'success' : 'error');
-  };
-
-  const handleReset = () => {
-    resetPlacements();
-  };
-
-  const renderEvaluationMessage = () => {
-    if (evaluation === 'idle') return null;
-
-    const isSuccess = evaluation === 'success';
-    const backgroundColor = isSuccess ? evaluationSuccessBackground : evaluationErrorBackground;
-    const textColorClass = isSuccess ? 'text-emerald-700' : 'text-rose-700';
-    const Icon = isSuccess ? CheckCircle : XCircle;
-    const message = isSuccess ? DEFAULT_SUCCESS_FEEDBACK : DEFAULT_FAILURE_FEEDBACK;
-
-    return (
-      <div className={`flex items-center gap-2 px-4 py-3 rounded-xl text-sm font-medium ${textColorClass}`} style={{ backgroundColor }}>
-        <Icon className="w-5 h-5" />
-        <span>{message}</span>
-      </div>
-    );
   };
 
   const handleTileDoubleClick = (event: React.MouseEvent<HTMLDivElement>) => {
@@ -433,28 +421,15 @@ export const BlanksInteractive: React.FC<BlanksInteractiveProps> = ({
 
         {isInteractionEnabled && (
           <div className="flex flex-wrap items-center gap-3 pt-2">
-            <button
-              type="button"
+            <ValidateButton
               onClick={handleCheck}
-              className="px-4 py-2 rounded-lg text-sm font-semibold shadow-sm transition-colors duration-200 bg-white/90 hover:bg-white"
-              style={{ color: accentColor }}
-            >
-              Sprawdź odpowiedzi
-            </button>
-            <button
-              type="button"
-              onClick={handleReset}
-              className="px-3 py-2 rounded-lg text-sm font-medium flex items-center gap-2 text-slate-100/90 hover:text-white"
-              style={{ backgroundColor: 'transparent' }}
-            >
-              <RotateCcw className="w-4 h-4" />
-              Wyczyść wybór
-            </button>
-            {renderEvaluationMessage()}
+              disabled={evaluation === 'success'}
+              accentColor={validateButtonBackground}
+              textColor={validateButtonTextColor}
+              status={validationStatus}
+            />
           </div>
         )}
-
-        {!isInteractionEnabled && renderEvaluationMessage()}
       </div>
     </div>
   );

--- a/src/components/admin/tiles/sequencing/Interactive.tsx
+++ b/src/components/admin/tiles/sequencing/Interactive.tsx
@@ -10,6 +10,7 @@ import {
 import { TaskInstructionPanel } from '../TaskInstructionPanel.tsx';
 import { TaskTileSection } from '../TaskTileSection.tsx';
 import { RichTextEditor, RichTextEditorProps } from '../RichTextEditor.tsx';
+import { ValidateButton, ValidateButtonStatus } from '../ValidateButton.tsx';
 
 interface SequencingInteractiveProps {
   tile: SequencingTile;
@@ -46,7 +47,6 @@ export const SequencingInteractive: React.FC<SequencingInteractiveProps> = ({
   const [placedItems, setPlacedItems] = useState<(DraggedItem | null)[]>([]);
   const [isChecked, setIsChecked] = useState(false);
   const [isCorrect, setIsCorrect] = useState<boolean | null>(null);
-  const [attempts, setAttempts] = useState(0);
   const [dragState, setDragState] = useState<DragState | null>(null);
   const [dragOverSlot, setDragOverSlot] = useState<number | null>(null);
   const [isPoolHighlighted, setIsPoolHighlighted] = useState(false);
@@ -75,10 +75,6 @@ export const SequencingInteractive: React.FC<SequencingInteractiveProps> = ({
   );
   const mutedLabelColor = textColor === '#0f172a' ? '#475569' : '#dbeafe';
   const subtleCaptionColor = textColor === '#0f172a' ? '#64748b' : '#e2e8f0';
-  const testingCaptionColor = useMemo(
-    () => surfaceColor(accentColor, textColor, 0.42, 0.4),
-    [accentColor, textColor]
-  );
   const poolBackground = useMemo(
     () => surfaceColor(accentColor, textColor, 0.6, 0.4),
     [accentColor, textColor]
@@ -165,16 +161,16 @@ export const SequencingInteractive: React.FC<SequencingInteractiveProps> = ({
     [accentColor, textColor]
   );
   const successIconColor = textColor === '#0f172a' ? darkenColor(accentColor, 0.2) : lightenColor(accentColor, 0.32);
-  const successFeedbackBackground = surfaceColor(accentColor, textColor, 0.7, 0.34);
-  const successFeedbackBorder = surfaceColor(accentColor, textColor, 0.6, 0.44);
-  const failureFeedbackBackground = '#fee2e2';
-  const failureFeedbackBorder = '#fca5a5';
   const primaryButtonBackground = textColor === '#0f172a' ? darkenColor(accentColor, 0.25) : lightenColor(accentColor, 0.28);
   const primaryButtonTextColor = textColor === '#0f172a' ? '#f8fafc' : '#0f172a';
   const secondaryButtonBackground = surfaceColor(accentColor, textColor, 0.52, 0.5);
   const secondaryButtonBorder = surfaceColor(accentColor, textColor, 0.46, 0.58);
   const showBorder = tile.content.showBorder !== false;
   const isEmbedded = variant === 'embedded';
+
+  const validationStatus: ValidateButtonStatus = isChecked && isCorrect !== null
+    ? (isCorrect ? 'correct' : 'incorrect')
+    : 'idle';
 
   const correctOrderIds = useMemo(
     () =>
@@ -224,7 +220,6 @@ export const SequencingInteractive: React.FC<SequencingInteractiveProps> = ({
     setPlacedItems(new Array(shuffledItems.length).fill(null));
     setIsChecked(false);
     setIsCorrect(null);
-    setAttempts(0);
   }, [buildInitialPool]);
 
   useEffect(() => {
@@ -383,7 +378,6 @@ export const SequencingInteractive: React.FC<SequencingInteractiveProps> = ({
 
     setIsCorrect(isSequenceCorrect);
     setIsChecked(true);
-    setAttempts(prev => prev + 1);
   };
 
   const resetSequence = () => {
@@ -633,47 +627,17 @@ export const SequencingInteractive: React.FC<SequencingInteractiveProps> = ({
           </TaskTileSection>
         </div>
 
-        {isChecked && isCorrect !== null && (
-          <div
-            className="rounded-2xl border px-6 py-4 flex items-center justify-between"
-            style={{
-              backgroundColor: isCorrect ? successFeedbackBackground : failureFeedbackBackground,
-              borderColor: isCorrect ? successFeedbackBorder : failureFeedbackBorder,
-              color: isCorrect ? textColor : '#7f1d1d'
-            }}
-          >
-            <div className="flex items-center gap-3 text-sm font-medium">
-              {isCorrect ? (
-                <CheckCircle className="w-5 h-5" style={{ color: successIconColor }} />
-              ) : (
-                <XCircle className="w-5 h-5 text-rose-300" />
-              )}
-              <span>{isCorrect ? tile.content.correctFeedback : tile.content.incorrectFeedback}</span>
-            </div>
-
-            {!isCorrect && (
-              <div className="text-xs" style={{ color: '#7f1d1d' }}>
-                Spróbuj ponownie, przenosząc elementy.
-              </div>
-            )}
-          </div>
-        )}
-
         {!isPreview && (
           <div className="flex flex-wrap items-center justify-between gap-4">
             <div className="flex items-center gap-3">
-              <button
+              <ValidateButton
                 onClick={checkSequence}
                 disabled={!sequenceComplete || (isChecked && isCorrect)}
-                className="px-6 py-2 rounded-xl font-semibold shadow-lg transition-transform duration-200 disabled:opacity-40 disabled:cursor-not-allowed hover:-translate-y-0.5"
-                style={{
-                  backgroundColor: primaryButtonBackground,
-                  color: primaryButtonTextColor,
-                  boxShadow: '0 16px 32px rgba(15, 23, 42, 0.22)'
-                }}
-              >
-                {isChecked && isCorrect ? 'Sekwencja sprawdzona' : 'Sprawdź kolejność'}
-              </button>
+                accentColor={primaryButtonBackground}
+                textColor={primaryButtonTextColor}
+                status={validationStatus}
+                className="hover:-translate-y-0.5"
+              />
 
               {isChecked && !isCorrect && (
                 <button


### PR DESCRIPTION
## Summary
- add a reusable ValidateButton component that reports validation status and holds a fixed width
- integrate the shared validation button into sequencing and blanks tiles while removing in-tile feedback popovers
- simplify the blanks tile controls by relying on the new status-aware validation button

## Testing
- npm run lint *(fails: existing lint errors in legacy files)*

------
https://chatgpt.com/codex/tasks/task_e_68dd04ec73148321984a241613d6dac6