### PR TITLE
Fix retry handling on validation button

### DIFF
--- a/src/components/admin/tiles/blanks/Interactive.tsx
+++ b/src/components/admin/tiles/blanks/Interactive.tsx
@@ -295,6 +295,10 @@ export const BlanksInteractive: React.FC<BlanksInteractiveProps> = ({
     setEvaluation(isCorrect ? 'success' : 'error');
   };
 
+  const handleRetry = () => {
+    setEvaluation('idle');
+  };
+
   const handleTileDoubleClick = (event: React.MouseEvent<HTMLDivElement>) => {
     if (isPreview || isTestingMode) return;
     event.preventDefault();
@@ -482,6 +486,7 @@ export const BlanksInteractive: React.FC<BlanksInteractiveProps> = ({
           <div className="flex flex-wrap items-center gap-3 pt-2">
             <ValidateButton
               onClick={handleCheck}
+              onRetry={handleRetry}
               disabled={!isComplete || evaluation === 'success'}
               state={validationState}
               colors={validateButtonColors}

--- a/src/components/admin/tiles/sequencing/Interactive.tsx
+++ b/src/components/admin/tiles/sequencing/Interactive.tsx
@@ -688,6 +688,7 @@ export const SequencingInteractive: React.FC<SequencingInteractiveProps> = ({
             <div className="flex items-center gap-3">
               <ValidateButton
                 onClick={checkSequence}
+                onRetry={resetCheckState}
                 disabled={!sequenceComplete || (isChecked && isCorrect)}
                 state={validationState}
                 colors={validateButtonColors}

--- a/src/components/common/ValidateButton.tsx
+++ b/src/components/common/ValidateButton.tsx
@@ -17,6 +17,7 @@ export type ValidateButtonLabels = Partial<Record<ValidateButtonState, React.Rea
 interface ValidateButtonProps {
   state: ValidateButtonState;
   onClick: () => void;
+  onRetry?: () => void;
   disabled?: boolean;
   className?: string;
   style?: React.CSSProperties;
@@ -69,6 +70,7 @@ const mergeColorConfig = (
 export const ValidateButton: React.FC<ValidateButtonProps> = ({
   state,
   onClick,
+  onRetry,
   disabled = false,
   className = '',
   style,
@@ -78,6 +80,17 @@ export const ValidateButton: React.FC<ValidateButtonProps> = ({
 }) => {
   const label = labels?.[state] ?? DEFAULT_LABELS[state];
   const { background, color, border } = mergeColorConfig(state, colors);
+
+  const handleClick = React.useCallback(() => {
+    if (disabled) return;
+
+    if (state === 'error' && onRetry) {
+      onRetry();
+      return;
+    }
+
+    onClick();
+  }, [disabled, state, onRetry, onClick]);
 
   const buttonStyle: React.CSSProperties = {
     backgroundColor: background,
@@ -91,7 +104,7 @@ export const ValidateButton: React.FC<ValidateButtonProps> = ({
   return (
     <button
       type={type}
-      onClick={onClick}
+      onClick={handleClick}
       disabled={disabled}
       className={`inline-flex h-11 min-w-[220px] w-full max-w-[360px] sm:w-[60%] items-center justify-center gap-2 rounded-xl border font-semibold text-sm transition-transform duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-slate-900/20 disabled:cursor-not-allowed disabled:opacity-60 hover:-translate-y-0.5 active:translate-y-0 ${className}`.trim()}
       style={buttonStyle}


### PR DESCRIPTION
## Summary
- allow the validation button to trigger an optional retry handler when clicked in the error state
- reset the blanks tile evaluation state when retrying so error feedback clears
- reset the sequencing tile check state when retrying so editors can adjust their answers

## Testing
- npm run lint *(fails: pre-existing lint warnings/errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dd45f4966c83218abb38e6b91188f2