### PR TITLE
Refactor admin tile shared color helpers

### DIFF
--- a/src/components/admin/tiles/shared.ts
+++ b/src/components/admin/tiles/shared.ts
@@ -19,69 +19,9 @@ export interface BaseTileRendererProps<T extends LessonTile = LessonTile> {
   onImageMouseDown?: (e: React.MouseEvent, tile?: ImageTile) => void;
 }
 
-interface RGBColor {
-  r: number;
-  g: number;
-  b: number;
-}
-
-const hexToRgb = (hex: string): RGBColor | null => {
-  if (!hex) return null;
-
-  let normalized = hex.replace('#', '').trim();
-  if (normalized.length === 3) {
-    normalized = normalized.split('').map((char) => `${char}${char}`).join('');
-  }
-
-  if (normalized.length !== 6) return null;
-
-  const intValue = Number.parseInt(normalized, 16);
-  if (Number.isNaN(intValue)) return null;
-
-  return {
-    r: (intValue >> 16) & 255,
-    g: (intValue >> 8) & 255,
-    b: intValue & 255,
-  };
-};
-
-const channelToLinear = (value: number): number => {
-  const scaled = value / 255;
-  return scaled <= 0.03928 ? scaled / 12.92 : Math.pow((scaled + 0.055) / 1.055, 2.4);
-};
-
-export const getReadableTextColor = (hex: string): string => {
-  const rgb = hexToRgb(hex);
-  if (!rgb) return '#0f172a';
-
-  const luminance = (0.2126 * channelToLinear(rgb.r)) +
-    (0.7152 * channelToLinear(rgb.g)) +
-    (0.0722 * channelToLinear(rgb.b));
-
-  return luminance > 0.6 ? '#0f172a' : '#f8fafc';
-};
-
-export const lightenColor = (hex: string, amount: number): string => {
-  const rgb = hexToRgb(hex);
-  if (!rgb) return hex;
-
-  const lightenChannel = (channel: number) => Math.round(channel + (255 - channel) * amount);
-  return `rgb(${lightenChannel(rgb.r)}, ${lightenChannel(rgb.g)}, ${lightenChannel(rgb.b)})`;
-};
-
-export const darkenColor = (hex: string, amount: number): string => {
-  const rgb = hexToRgb(hex);
-  if (!rgb) return hex;
-
-  const darkenChannel = (channel: number) => Math.round(channel * (1 - amount));
-  return `rgb(${darkenChannel(rgb.r)}, ${darkenChannel(rgb.g)}, ${darkenChannel(rgb.b)})`;
-};
-
-export const surfaceColor = (
-  accent: string,
-  textColor: string,
-  lightenAmount: number,
-  darkenAmount: number
-): string => (
-  textColor === '#0f172a' ? lightenColor(accent, lightenAmount) : darkenColor(accent, darkenAmount)
-);
+export {
+  getReadableTextColor,
+  lightenColor,
+  darkenColor,
+  surfaceColor,
+} from '../../../utils/colorUtils';


### PR DESCRIPTION
## Summary
- import and re-export shared tile color helpers from the central color utilities module
- remove the duplicated color helper implementations in the admin tile shared module

## Testing
- npm test -- colorUtils

------
https://chatgpt.com/codex/tasks/task_e_68de67980e688321b610c1666d353cf5