### PR TITLE
Add general matching tile

### DIFF
--- a/src/components/admin/editor side/GeneralEditor.tsx
+++ b/src/components/admin/editor side/GeneralEditor.tsx
@@ -1,0 +1,126 @@
+import React from 'react';
+import { Plus, Trash2 } from 'lucide-react';
+import { GeneralTile, LessonTile } from '../../../types/lessonEditor.ts';
+
+interface GeneralEditorProps {
+  tile: GeneralTile;
+  onUpdateTile: (tileId: string, updates: Partial<LessonTile>) => void;
+}
+
+const createPairId = () => `pair-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
+
+export const GeneralEditor: React.FC<GeneralEditorProps> = ({ tile, onUpdateTile }) => {
+  const handleContentUpdate = (updates: Partial<GeneralTile['content']>) => {
+    onUpdateTile(tile.id, {
+      content: {
+        ...tile.content,
+        ...updates
+      },
+      updated_at: new Date().toISOString()
+    });
+  };
+
+  const handlePairChange = (pairId: string, field: 'left' | 'right', value: string) => {
+    const pairs = tile.content.pairs.map(pair =>
+      pair.id === pairId ? { ...pair, [field]: value } : pair
+    );
+    handleContentUpdate({ pairs });
+  };
+
+  const handleAddPair = () => {
+    const newPair = {
+      id: createPairId(),
+      left: `Lewy element ${tile.content.pairs.length + 1}`,
+      right: `Prawy element ${tile.content.pairs.length + 1}`
+    };
+    handleContentUpdate({ pairs: [...tile.content.pairs, newPair] });
+  };
+
+  const handleRemovePair = (pairId: string) => {
+    const pairs = tile.content.pairs.filter(pair => pair.id !== pairId);
+    handleContentUpdate({ pairs });
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-3">Kolor tła kafelka</label>
+        <input
+          type="color"
+          value={tile.content.backgroundColor}
+          onChange={(event) => handleContentUpdate({ backgroundColor: event.target.value })}
+          className="w-full h-12 border border-gray-300 rounded-lg cursor-pointer"
+        />
+      </div>
+
+      <div>
+        <div className="flex items-center justify-between mb-3">
+          <label className="block text-sm font-medium text-gray-700">
+            Pary ({tile.content.pairs.length})
+          </label>
+          <button
+            type="button"
+            onClick={handleAddPair}
+            className="inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-blue-50 text-blue-600 text-sm font-medium hover:bg-blue-100 transition"
+          >
+            <Plus className="w-4 h-4" />
+            Dodaj parę
+          </button>
+        </div>
+
+        {tile.content.pairs.length === 0 ? (
+          <p className="text-sm text-gray-600">
+            Dodaj przynajmniej jedną parę, aby wyświetlić elementy w kafelku.
+          </p>
+        ) : (
+          <div className="space-y-3 max-h-80 overflow-y-auto pr-1">
+            {tile.content.pairs.map((pair, index) => (
+              <div
+                key={pair.id}
+                className="border border-gray-200 rounded-xl bg-white shadow-sm p-4 space-y-4"
+              >
+                <div className="flex items-center justify-between">
+                  <span className="text-sm font-semibold text-gray-900">Para {index + 1}</span>
+                  <button
+                    type="button"
+                    onClick={() => handleRemovePair(pair.id)}
+                    className="inline-flex items-center gap-1 text-xs text-red-500 hover:text-red-600"
+                    title="Usuń parę"
+                  >
+                    <Trash2 className="w-3 h-3" />
+                    Usuń
+                  </button>
+                </div>
+
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                  <div>
+                    <label className="block text-xs font-medium text-gray-600 mb-2">Lewa kolumna</label>
+                    <input
+                      type="text"
+                      value={pair.left}
+                      onChange={(event) => handlePairChange(pair.id, 'left', event.target.value)}
+                      className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm"
+                      placeholder="Tekst elementu po lewej"
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-xs font-medium text-gray-600 mb-2">Prawa kolumna</label>
+                    <input
+                      type="text"
+                      value={pair.right}
+                      onChange={(event) => handlePairChange(pair.id, 'right', event.target.value)}
+                      className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm"
+                      placeholder="Tekst elementu po prawej"
+                    />
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default GeneralEditor;

--- a/src/components/admin/editor side/TilePalette.tsx
+++ b/src/components/admin/editor side/TilePalette.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Type, Image, Puzzle, Eye, HelpCircle, Plus, Code, ArrowUpDown } from 'lucide-react';
+import { Type, Image, Puzzle, Eye, HelpCircle, Plus, Code, ArrowUpDown, Link } from 'lucide-react';
 import { TilePaletteItem } from '../../../types/lessonEditor.ts';
 
 interface TilePaletteProps {
@@ -39,6 +39,11 @@ const TILE_TYPES: TilePaletteItem[] = [
     icon: 'ArrowUpDown'
   },
   {
+    type: 'general',
+    title: 'Dopasuj pary',
+    icon: 'Link'
+  },
+  {
     type: 'blanks',
     title: 'Uzupełnij luki',
     icon: 'Puzzle'
@@ -54,6 +59,7 @@ const getIcon = (iconName: string) => {
     case 'HelpCircle': return HelpCircle;
     case 'Code': return Code;
     case 'ArrowUpDown': return ArrowUpDown;
+    case 'Link': return Link;
     default: return Type;
   }
 };

--- a/src/components/admin/editor side/TileSideEditor.tsx
+++ b/src/components/admin/editor side/TileSideEditor.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
-import { Plus, Trash2, Type, X, Image as ImageIcon, Eye, HelpCircle, Code, ArrowUpDown, Puzzle } from 'lucide-react';
-import { TextTile, ImageTile, LessonTile, ProgrammingTile, SequencingTile, QuizTile, BlanksTile } from '../../../types/lessonEditor.ts';
+import { Plus, Trash2, Type, X, Image as ImageIcon, Eye, HelpCircle, Code, ArrowUpDown, Puzzle, Link } from 'lucide-react';
+import { TextTile, ImageTile, LessonTile, ProgrammingTile, SequencingTile, QuizTile, BlanksTile, GeneralTile } from '../../../types/lessonEditor.ts';
 import { ImageUploadComponent } from './ImageUploadComponent.tsx';
 import { ImagePositionControl } from './ImagePositionControl.tsx';
 import { SequencingEditor } from './SequencingEditor.tsx';
+import { GeneralEditor } from './GeneralEditor.tsx';
 import { extractPlaceholdersFromTemplate } from '../../../utils/blanks.ts';
 
 interface TileSideEditorProps {
@@ -92,6 +93,7 @@ export const TileSideEditor: React.FC<TileSideEditorProps> = ({
       case 'quiz': return HelpCircle;
       case 'programming': return Code;
       case 'sequencing': return ArrowUpDown;
+      case 'general': return Link;
       case 'blanks': return Puzzle;
       default: return Type;
     }
@@ -262,6 +264,16 @@ export const TileSideEditor: React.FC<TileSideEditorProps> = ({
             onUpdateTile={onUpdateTile}
             isTesting={isTesting}
             onToggleTesting={onToggleTesting}
+          />
+        );
+      }
+
+      case 'general': {
+        const generalTile = tile as GeneralTile;
+        return (
+          <GeneralEditor
+            tile={generalTile}
+            onUpdateTile={onUpdateTile}
           />
         );
       }

--- a/src/components/admin/editor top/TopToolbar.tsx
+++ b/src/components/admin/editor top/TopToolbar.tsx
@@ -5,14 +5,14 @@ import { FontSizeSelector } from './FontSizeSelector.tsx';
 import { TextColorPicker } from './TextColorPicker.tsx';
 import { FontSelector } from './FontSelector.tsx';
 import { AlignmentControls } from './AlignmentControls.tsx';
-import { LessonTile, ProgrammingTile, TextTile, SequencingTile } from '../../../types/lessonEditor.ts';
+import { LessonTile, ProgrammingTile, TextTile, SequencingTile, GeneralTile } from '../../../types/lessonEditor.ts';
 
 
 interface TopToolbarProps {
   isTextEditing: boolean;
   onFinishTextEditing?: () => void;
   editor?: Editor | null;
-  selectedTile?: TextTile | ProgrammingTile | SequencingTile | null;
+  selectedTile?: TextTile | ProgrammingTile | SequencingTile | GeneralTile | null;
   onUpdateTile?: (tileId: string, updates: Partial<LessonTile>) => void;
   currentPage?: number;
   totalPages?: number;
@@ -69,7 +69,11 @@ export const TopToolbar: React.FC<TopToolbarProps> = ({
   }, [editor]);
 
   useEffect(() => {
-    if (selectedTile?.type === 'text' || selectedTile?.type === 'sequencing') {
+    if (
+      selectedTile?.type === 'text' ||
+      selectedTile?.type === 'sequencing' ||
+      selectedTile?.type === 'general'
+    ) {
       setVerticalAlign(selectedTile.content.verticalAlign || 'top');
     }
   }, [selectedTile]);

--- a/src/components/admin/tiles/TileRenderer.tsx
+++ b/src/components/admin/tiles/TileRenderer.tsx
@@ -9,6 +9,7 @@ import { ProgrammingTileRenderer} from "./programming/Renderer.tsx";
 import { QuizTileRenderer } from './quiz';
 import { SequencingTileRenderer } from './sequencing';
 import { TextTileRenderer} from "./text/Renderer.tsx";
+import { GeneralTileRenderer } from './general';
 
 interface TileRendererProps {
   tile: LessonTile;
@@ -35,6 +36,7 @@ const TILE_RENDERERS: Partial<Record<LessonTile['type'], React.ComponentType<any
   quiz: QuizTileRenderer,
   sequencing: SequencingTileRenderer,
   blanks: BlanksTileRenderer,
+  general: GeneralTileRenderer,
 };
 
 export const TileRenderer: React.FC<TileRendererProps> = ({
@@ -81,7 +83,7 @@ export const TileRenderer: React.FC<TileRendererProps> = ({
   };
 
   const handleDoubleClick =
-    tile.type === 'sequencing' || tile.type === 'blanks' ? undefined : onDoubleClick;
+    tile.type === 'sequencing' || tile.type === 'blanks' || tile.type === 'general' ? undefined : onDoubleClick;
 
 
   return (

--- a/src/components/admin/tiles/general/Interactive.tsx
+++ b/src/components/admin/tiles/general/Interactive.tsx
@@ -1,0 +1,233 @@
+import React, { useMemo, useCallback } from 'react';
+import { Link as LinkIcon, Sparkles } from 'lucide-react';
+import { GeneralTile } from '../../../../types/lessonEditor';
+import { getReadableTextColor, surfaceColor } from '../../../../utils/colorUtils';
+import { createValidateButtonPalette } from '../../../../utils/surfacePalette.ts';
+import { TaskInstructionPanel } from '../TaskInstructionPanel.tsx';
+import { TaskTileSection } from '../TaskTileSection.tsx';
+import { RichTextEditor, RichTextEditorProps } from '../RichTextEditor.tsx';
+import { ValidateButton, ValidateButtonColors, ValidateButtonState } from '../../../common/ValidateButton.tsx';
+
+interface GeneralInteractiveProps {
+  tile: GeneralTile;
+  isPreview?: boolean;
+  isTestingMode?: boolean;
+  onRequestTextEditing?: () => void;
+  instructionEditorProps?: RichTextEditorProps;
+}
+
+interface ColumnItem {
+  id: string;
+  text: string;
+}
+
+const createSeedFromString = (value: string): number => {
+  let hash = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    hash = (hash * 31 + value.charCodeAt(index)) % 2147483647;
+  }
+  return hash || 1;
+};
+
+const shuffleWithSeed = <T,>(items: T[], seedKey: string): T[] => {
+  const result = [...items];
+  let seed = createSeedFromString(seedKey);
+  for (let index = result.length - 1; index > 0; index -= 1) {
+    seed = (seed * 16807) % 2147483647;
+    const random = (seed - 1) / 2147483646;
+    const swapIndex = Math.floor(random * (index + 1));
+    [result[index], result[swapIndex]] = [result[swapIndex], result[index]];
+  }
+  return result;
+};
+
+export const GeneralInteractive: React.FC<GeneralInteractiveProps> = ({
+  tile,
+  isPreview = false,
+  isTestingMode = false,
+  onRequestTextEditing,
+  instructionEditorProps
+}) => {
+  const accentColor = tile.content.backgroundColor || '#0f172a';
+  const textColor = useMemo(() => getReadableTextColor(accentColor), [accentColor]);
+  const sectionBackground = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.66, 0.38),
+    [accentColor, textColor]
+  );
+  const sectionBorder = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.54, 0.5),
+    [accentColor, textColor]
+  );
+  const columnBackground = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.72, 0.32),
+    [accentColor, textColor]
+  );
+  const columnBorder = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.58, 0.46),
+    [accentColor, textColor]
+  );
+  const badgeBackground = useMemo(
+    () => surfaceColor(accentColor, textColor, 0.52, 0.48),
+    [accentColor, textColor]
+  );
+  const mutedLabelColor = textColor === '#0f172a' ? '#475569' : '#dbeafe';
+  const badgeTextColor = textColor === '#0f172a' ? '#1f2937' : '#f8fafc';
+  const validateButtonColors = useMemo<ValidateButtonColors>(
+    () => createValidateButtonPalette(accentColor, textColor),
+    [accentColor, textColor]
+  );
+  const validationState: ValidateButtonState = 'idle';
+
+  const leftItems = useMemo<ColumnItem[]>(
+    () =>
+      shuffleWithSeed(
+        tile.content.pairs.map(pair => ({ id: pair.id, text: pair.left })),
+        `${tile.id}-left`
+      ),
+    [tile.content.pairs, tile.id]
+  );
+
+  const rightItems = useMemo<ColumnItem[]>(
+    () =>
+      shuffleWithSeed(
+        tile.content.pairs.map(pair => ({ id: pair.id, text: pair.right })),
+        `${tile.id}-right`
+      ),
+    [tile.content.pairs, tile.id]
+  );
+
+  const handleTileDoubleClick = useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      if (isPreview || isTestingMode) {
+        return;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      onRequestTextEditing?.();
+    },
+    [isPreview, isTestingMode, onRequestTextEditing]
+  );
+
+  const renderColumn = (label: string, items: ColumnItem[], position: 'left' | 'right') => (
+    <div className={`flex flex-col gap-2 min-h-0 ${position === 'left' ? 'pr-1 md:pr-3' : 'pl-1 md:pl-3'}`}>
+      <span className="text-xs uppercase tracking-[0.24em]" style={{ color: mutedLabelColor }}>
+        {label}
+      </span>
+      <div className="flex-1 min-h-0 overflow-auto space-y-3">
+        {items.length === 0 ? (
+          <div className="flex items-center justify-center text-sm h-full" style={{ color: mutedLabelColor }}>
+            Dodaj pary w panelu edycji
+          </div>
+        ) : (
+          items.map((item, index) => (
+            <div
+              key={item.id}
+              className="flex items-center gap-3 rounded-xl border px-4 py-3 text-sm font-medium shadow-sm"
+              style={{
+                backgroundColor: columnBackground,
+                borderColor: columnBorder,
+                color: textColor
+              }}
+            >
+              <span
+                className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-xs font-semibold"
+                style={{ backgroundColor: badgeBackground, color: badgeTextColor }}
+              >
+                {index + 1}
+              </span>
+              <span className="leading-snug">{item.text}</span>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+
+  return (
+    <div className="relative w-full h-full" onDoubleClick={handleTileDoubleClick}>
+      <div
+        className="w-full h-full flex flex-col gap-6 transition-all duration-300 p-6 rounded-[inherit]"
+        style={{
+          background: 'transparent',
+          color: textColor
+        }}
+      >
+        <TaskInstructionPanel
+          icon={<Sparkles className="w-4 h-4" />}
+          label="Zadanie"
+          className="border"
+          style={{
+            backgroundColor: surfaceColor(accentColor, textColor, 0.62, 0.42),
+            borderColor: surfaceColor(accentColor, textColor, 0.5, 0.52),
+            color: textColor
+          }}
+          iconWrapperClassName="w-9 h-9 rounded-xl flex items-center justify-center shadow-sm"
+          iconWrapperStyle={{
+            backgroundColor: surfaceColor(accentColor, textColor, 0.54, 0.48),
+            color: textColor
+          }}
+          labelStyle={{ color: mutedLabelColor }}
+        >
+          {instructionEditorProps ? (
+            <RichTextEditor {...instructionEditorProps} />
+          ) : (
+            <div
+              className="text-base leading-relaxed"
+              style={{ fontFamily: tile.content.fontFamily, fontSize: tile.content.fontSize }}
+              dangerouslySetInnerHTML={{
+                __html: tile.content.richInstruction || `<p>${tile.content.instruction}</p>`
+              }}
+            />
+          )}
+        </TaskInstructionPanel>
+
+        {isTestingMode && (
+          <div className="text-[11px] uppercase tracking-[0.32em]" style={{ color: mutedLabelColor }}>
+            Tryb testowania
+          </div>
+        )}
+
+        <div className="flex-1 min-h-0">
+          <TaskTileSection
+            className="h-full shadow-sm min-h-0"
+            style={{
+              backgroundColor: sectionBackground,
+              borderColor: sectionBorder,
+              color: textColor
+            }}
+            icon={<LinkIcon className="w-4 h-4" />}
+            title="dopasuj pary"
+            headerClassName="px-6 py-5 border-b"
+            headerStyle={{ borderColor: sectionBorder, color: mutedLabelColor }}
+            titleStyle={{ color: mutedLabelColor }}
+            rightContent={
+              <span className="text-xs" style={{ color: mutedLabelColor }}>
+                {tile.content.pairs.length} elementów
+              </span>
+            }
+            contentClassName="flex-1 overflow-hidden px-6 py-5 flex flex-col gap-5"
+          >
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6 flex-1 min-h-0">
+              {renderColumn('Lewy zestaw', leftItems, 'left')}
+              {renderColumn('Prawy zestaw', rightItems, 'right')}
+            </div>
+            <div className="rounded-xl border px-4 py-3 text-xs leading-relaxed" style={{ borderColor: columnBorder, color: mutedLabelColor }}>
+              Łączenie par będzie dostępne w widoku ucznia. Ta wersja kafelka prezentuje jedynie treści do dopasowania.
+            </div>
+          </TaskTileSection>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-3 pt-2">
+          <ValidateButton
+            onClick={() => undefined}
+            state={validationState}
+            colors={validateButtonColors}
+            disabled
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default GeneralInteractive;

--- a/src/components/admin/tiles/general/Renderer.tsx
+++ b/src/components/admin/tiles/general/Renderer.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { GeneralTile } from '../../../../types/lessonEditor';
+import { createRichTextAdapter, type RichTextEditorProps } from '../RichTextEditor.tsx';
+import { BaseTileRendererProps, getReadableTextColor } from '../shared';
+import { GeneralInteractive } from './Interactive';
+
+export const GeneralTileRenderer: React.FC<BaseTileRendererProps<GeneralTile>> = ({
+  tile,
+  isSelected,
+  isEditingText,
+  isTestingMode,
+  onUpdateTile,
+  onFinishTextEditing,
+  onEditorReady,
+  onDoubleClick,
+  backgroundColor,
+  showBorder,
+}) => {
+  const generalTile = tile;
+  const textColor = getReadableTextColor(generalTile.content.backgroundColor || backgroundColor);
+
+  const wrapperStyle: React.CSSProperties = {
+    borderRadius: 'inherit',
+    backgroundColor,
+    border: showBorder ? '1px solid rgba(0, 0, 0, 0.08)' : 'none',
+  };
+
+  const renderGeneral = (
+    instructionEditorProps?: RichTextEditorProps,
+    isPreviewMode = false,
+  ) => (
+    <GeneralInteractive
+      tile={generalTile}
+      isTestingMode={isTestingMode}
+      instructionEditorProps={instructionEditorProps}
+      isPreview={isPreviewMode}
+      onRequestTextEditing={isPreviewMode ? undefined : onDoubleClick}
+    />
+  );
+
+  if (isEditingText && isSelected) {
+    const instructionAdapter = createRichTextAdapter({
+      source: generalTile.content,
+      fields: {
+        text: 'instruction',
+        richText: 'richInstruction',
+        fontFamily: 'fontFamily',
+        fontSize: 'fontSize',
+        verticalAlign: 'verticalAlign',
+      },
+      defaults: {
+        backgroundColor: generalTile.content.backgroundColor,
+        showBorder: generalTile.content.showBorder,
+      },
+    });
+
+    return (
+      <div className="w-full h-full overflow-hidden" style={wrapperStyle}>
+        {renderGeneral(
+          {
+            content: instructionAdapter.content,
+            onChange: (updatedContent) => {
+              onUpdateTile(tile.id, {
+                content: instructionAdapter.applyChanges(updatedContent),
+              });
+            },
+            onFinish: onFinishTextEditing,
+            onEditorReady,
+            textColor,
+          },
+          true,
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full h-full overflow-hidden" style={wrapperStyle}>
+      {renderGeneral()}
+    </div>
+  );
+};
+
+export default GeneralTileRenderer;

--- a/src/components/admin/tiles/general/index.ts
+++ b/src/components/admin/tiles/general/index.ts
@@ -1,0 +1,2 @@
+export { GeneralTileRenderer } from './Renderer';
+export { GeneralInteractive } from './Interactive';

--- a/src/hooks/useLessonContentManager.ts
+++ b/src/hooks/useLessonContentManager.ts
@@ -5,11 +5,13 @@ import {
   LessonTile,
   ProgrammingTile,
   SequencingTile,
-  TextTile
+  TextTile,
+  GeneralTile,
+  EditorState,
+  BlanksTile
 } from '../types/lessonEditor';
 import { GridUtils } from '../utils/gridUtils';
 import { logger } from '../utils/logger';
-import { EditorState, BlanksTile } from '../types/lessonEditor';
 import { EditorAction } from '../state/editorReducer';
 
 type TileFactory = (position: { x: number; y: number }, page: number) => LessonTile;
@@ -21,15 +23,22 @@ const tileFactoryMap: Record<LessonTile['type'], TileFactory> = {
   quiz: (position, page) => LessonContentService.createQuizTile(position, page),
   programming: (position, page) => LessonContentService.createProgrammingTile(position, page),
   sequencing: (position, page) => LessonContentService.createSequencingTile(position, page),
-  blanks: (position, page) => LessonContentService.createBlanksTile(position, page)
+  blanks: (position, page) => LessonContentService.createBlanksTile(position, page),
+  general: (position, page) => LessonContentService.createGeneralTile(position, page)
 };
 
 const isRichTextTile = (
   tile: LessonTile | null
-): tile is TextTile | ProgrammingTile | SequencingTile | BlanksTile => {
+): tile is TextTile | ProgrammingTile | SequencingTile | BlanksTile | GeneralTile => {
   return (
     !!tile &&
-    (tile.type === 'text' || tile.type === 'programming' || tile.type === 'sequencing' || tile.type === 'blanks')
+    (
+      tile.type === 'text' ||
+      tile.type === 'programming' ||
+      tile.type === 'sequencing' ||
+      tile.type === 'blanks' ||
+      tile.type === 'general'
+    )
   );
 };
 
@@ -254,7 +263,13 @@ export const useLessonContentManager = ({
           };
 
           if (
-            (tile.type === 'text' || tile.type === 'programming' || tile.type === 'sequencing' || tile.type === 'blanks') &&
+            (
+              tile.type === 'text' ||
+              tile.type === 'programming' ||
+              tile.type === 'sequencing' ||
+              tile.type === 'blanks' ||
+              tile.type === 'general'
+            ) &&
             updates.content
           ) {
             updatedTile.content = {

--- a/src/hooks/useTileInteractions.ts
+++ b/src/hooks/useTileInteractions.ts
@@ -33,7 +33,8 @@ export const useTileInteractions = ({
       tile.type === 'text' ||
       tile.type === 'programming' ||
       tile.type === 'sequencing' ||
-      tile.type === 'quiz'
+      tile.type === 'quiz' ||
+      tile.type === 'general'
     ) {
       dispatch({ type: 'startTextEditing', tileId: tile.id });
     } else if (tile.type === 'image') {

--- a/src/services/lessonContentService.ts
+++ b/src/services/lessonContentService.ts
@@ -5,6 +5,7 @@ import {
   ProgrammingTile,
   SequencingTile,
   BlanksTile,
+  GeneralTile,
   CanvasSettings,
   GridPosition
 } from '../types/lessonEditor';
@@ -205,6 +206,32 @@ export class LessonContentService {
         ],
         correctFeedback: 'Świetnie! Prawidłowa kolejność.',
         incorrectFeedback: 'Spróbuj ponownie. Sprawdź kolejność elementów.'
+      }
+    };
+  }
+
+  /**
+   * Create a new general matching tile
+   */
+  static createGeneralTile(position: { x: number; y: number }, page = 1): GeneralTile {
+    const base = this.initializeTileBase('general', position, page, { colSpan: 4, rowSpan: 4 });
+
+    return {
+      ...base,
+      content: {
+        instruction: 'Połącz elementy z lewej i prawej kolumny w pasujące pary.',
+        richInstruction:
+          '<p style="margin: 0;">Połącz elementy z lewej i prawej kolumny w pasujące pary.</p>',
+        fontFamily: 'Inter, system-ui, sans-serif',
+        fontSize: 16,
+        verticalAlign: 'top',
+        backgroundColor: '#d4d4d4',
+        showBorder: true,
+        pairs: [
+          { id: 'pair-1', left: 'Fotosynteza', right: 'Proces powstawania energii w roślinach' },
+          { id: 'pair-2', left: 'Chromosom', right: 'Nośnik informacji genetycznej' },
+          { id: 'pair-3', left: 'Komórka', right: 'Podstawowa jednostka budowy organizmów' }
+        ]
       }
     };
   }

--- a/src/types/lessonEditor.ts
+++ b/src/types/lessonEditor.ts
@@ -17,7 +17,7 @@ export interface GridPosition {
 
 export interface LessonTile {
   id: string;
-  type: 'text' | 'image' | 'visualization' | 'quiz' | 'programming' | 'sequencing' | 'blanks';
+  type: 'text' | 'image' | 'visualization' | 'quiz' | 'programming' | 'sequencing' | 'blanks' | 'general';
   position: Position;
   size: Size;
   gridPosition: GridPosition;
@@ -125,6 +125,24 @@ export interface SequencingTile extends LessonTile {
     }>;
     correctFeedback: string;
     incorrectFeedback: string;
+  };
+}
+
+export interface GeneralTile extends LessonTile {
+  type: 'general';
+  content: {
+    instruction: string;
+    richInstruction?: string;
+    fontFamily: string;
+    fontSize: number;
+    verticalAlign: 'top' | 'center' | 'bottom';
+    backgroundColor: string;
+    showBorder: boolean;
+    pairs: Array<{
+      id: string;
+      left: string;
+      right: string;
+    }>;
   };
 }
 


### PR DESCRIPTION
## Summary
- add a general matching tile renderer with instruction editing, shuffled two-column display, and validate button placeholder
- integrate the new tile into palette, lesson content service, toolbar, and side editor with background color and pair management support

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68debf857f748321984edd798ff88b38