### PR TITLE
Add general matching pairs tile

### DIFF
--- a/src/components/admin/editor side/TilePalette.tsx
+++ b/src/components/admin/editor side/TilePalette.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Type, Image, Puzzle, Eye, HelpCircle, Plus, Code, ArrowUpDown } from 'lucide-react';
+import { Type, Image, Puzzle, Eye, HelpCircle, Plus, Code, ArrowUpDown, Link2 } from 'lucide-react';
 import { TilePaletteItem } from '../../../types/lessonEditor.ts';
 
 interface TilePaletteProps {
@@ -42,6 +42,11 @@ const TILE_TYPES: TilePaletteItem[] = [
     type: 'blanks',
     title: 'Uzupełnij luki',
     icon: 'Puzzle'
+  },
+  {
+    type: 'general',
+    title: 'Dopasuj pary',
+    icon: 'Link2'
   }
 ];
 
@@ -54,6 +59,7 @@ const getIcon = (iconName: string) => {
     case 'HelpCircle': return HelpCircle;
     case 'Code': return Code;
     case 'ArrowUpDown': return ArrowUpDown;
+    case 'Link2': return Link2;
     default: return Type;
   }
 };

--- a/src/components/admin/editor side/TileSideEditor.tsx
+++ b/src/components/admin/editor side/TileSideEditor.tsx
@@ -1,6 +1,15 @@
 import React from 'react';
-import { Plus, Trash2, Type, X, Image as ImageIcon, Eye, HelpCircle, Code, ArrowUpDown, Puzzle } from 'lucide-react';
-import { TextTile, ImageTile, LessonTile, ProgrammingTile, SequencingTile, QuizTile, BlanksTile } from '../../../types/lessonEditor.ts';
+import { Plus, Trash2, Type, X, Image as ImageIcon, Eye, HelpCircle, Code, ArrowUpDown, Puzzle, Link2 } from 'lucide-react';
+import {
+  TextTile,
+  ImageTile,
+  LessonTile,
+  ProgrammingTile,
+  SequencingTile,
+  QuizTile,
+  BlanksTile,
+  GeneralTile
+} from '../../../types/lessonEditor.ts';
 import { ImageUploadComponent } from './ImageUploadComponent.tsx';
 import { ImagePositionControl } from './ImagePositionControl.tsx';
 import { SequencingEditor } from './SequencingEditor.tsx';
@@ -90,11 +99,12 @@ export const TileSideEditor: React.FC<TileSideEditorProps> = ({
       case 'image': return ImageIcon;
       case 'visualization': return Eye;
       case 'quiz': return HelpCircle;
-      case 'programming': return Code;
-      case 'sequencing': return ArrowUpDown;
-      case 'blanks': return Puzzle;
-      default: return Type;
-    }
+    case 'programming': return Code;
+    case 'sequencing': return ArrowUpDown;
+    case 'blanks': return Puzzle;
+    case 'general': return Link2;
+    default: return Type;
+  }
   };
 
   const handleContentUpdate = (field: string, value: any) => {
@@ -263,6 +273,132 @@ export const TileSideEditor: React.FC<TileSideEditorProps> = ({
             isTesting={isTesting}
             onToggleTesting={onToggleTesting}
           />
+        );
+      }
+
+      case 'general': {
+        const generalTile = tile as GeneralTile;
+
+        const updateContent = (updates: Partial<GeneralTile['content']>) => {
+          onUpdateTile(tile.id, {
+            content: {
+              ...generalTile.content,
+              ...updates
+            },
+            updated_at: new Date().toISOString()
+          });
+        };
+
+        const handlePairChange = (
+          pairId: string,
+          side: 'left' | 'right',
+          value: string
+        ) => {
+          const pairs = generalTile.content.pairs.map(pair =>
+            pair.id === pairId ? { ...pair, [side]: value } : pair
+          );
+          updateContent({ pairs });
+        };
+
+        const handleAddPair = () => {
+          const newPairId = `pair-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
+          const newIndex = generalTile.content.pairs.length + 1;
+          updateContent({
+            pairs: [
+              ...generalTile.content.pairs,
+              {
+                id: newPairId,
+                left: `Lewy element ${newIndex}`,
+                right: `Prawy element ${newIndex}`
+              }
+            ]
+          });
+        };
+
+        const handleRemovePair = (pairId: string) => {
+          if (generalTile.content.pairs.length <= 1) return;
+          updateContent({
+            pairs: generalTile.content.pairs.filter(pair => pair.id !== pairId)
+          });
+        };
+
+        return (
+          <div className="space-y-6">
+            <div className="grid grid-cols-1 gap-4">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-3">Kolor akcentu</label>
+                <input
+                  type="color"
+                  value={generalTile.content.backgroundColor}
+                  onChange={(e) => updateContent({ backgroundColor: e.target.value })}
+                  className="w-full h-12 border border-gray-300 rounded-lg cursor-pointer"
+                />
+              </div>
+            </div>
+
+            <div className="space-y-4">
+              <div className="flex items-center justify-between">
+                <h4 className="text-sm font-semibold text-gray-900">Pary do dopasowania</h4>
+                <button
+                  type="button"
+                  onClick={handleAddPair}
+                  className="inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-blue-50 text-blue-600 text-sm font-medium hover:bg-blue-100 transition"
+                >
+                  <Plus className="w-4 h-4" />
+                  Dodaj parę
+                </button>
+              </div>
+
+              <div className="space-y-3">
+                {generalTile.content.pairs.map((pair, index) => (
+                  <div key={pair.id} className="rounded-xl border border-gray-200 bg-white p-4 space-y-3 shadow-sm">
+                    <div className="flex items-center justify-between">
+                      <span className="text-xs font-semibold uppercase tracking-[0.18em] text-gray-500">
+                        Para {index + 1}
+                      </span>
+                      {generalTile.content.pairs.length > 1 && (
+                        <button
+                          type="button"
+                          onClick={() => handleRemovePair(pair.id)}
+                          className="inline-flex items-center justify-center text-rose-600 hover:bg-rose-50 p-2 rounded-lg"
+                        >
+                          <Trash2 className="w-4 h-4" />
+                        </button>
+                      )}
+                    </div>
+
+                    <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+                      <div className="space-y-1">
+                        <label className="block text-xs font-semibold uppercase tracking-[0.16em] text-gray-600">
+                          Lewa kolumna
+                        </label>
+                        <input
+                          type="text"
+                          value={pair.left}
+                          onChange={(e) => handlePairChange(pair.id, 'left', e.target.value)}
+                          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm"
+                          placeholder="Treść elementu po lewej stronie"
+                        />
+                      </div>
+
+                      <div className="space-y-1">
+                        <label className="block text-xs font-semibold uppercase tracking-[0.16em] text-gray-600">
+                          Prawa kolumna
+                        </label>
+                        <input
+                          type="text"
+                          value={pair.right}
+                          onChange={(e) => handlePairChange(pair.id, 'right', e.target.value)}
+                          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm"
+                          placeholder="Treść elementu po prawej stronie"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
         );
       }
 

--- a/src/components/admin/editor top/TopToolbar.tsx
+++ b/src/components/admin/editor top/TopToolbar.tsx
@@ -5,14 +5,14 @@ import { FontSizeSelector } from './FontSizeSelector.tsx';
 import { TextColorPicker } from './TextColorPicker.tsx';
 import { FontSelector } from './FontSelector.tsx';
 import { AlignmentControls } from './AlignmentControls.tsx';
-import { LessonTile, ProgrammingTile, TextTile, SequencingTile } from '../../../types/lessonEditor.ts';
+import { LessonTile, ProgrammingTile, TextTile, SequencingTile, GeneralTile } from '../../../types/lessonEditor.ts';
 
 
 interface TopToolbarProps {
   isTextEditing: boolean;
   onFinishTextEditing?: () => void;
   editor?: Editor | null;
-  selectedTile?: TextTile | ProgrammingTile | SequencingTile | null;
+  selectedTile?: TextTile | ProgrammingTile | SequencingTile | GeneralTile | null;
   onUpdateTile?: (tileId: string, updates: Partial<LessonTile>) => void;
   currentPage?: number;
   totalPages?: number;
@@ -69,7 +69,7 @@ export const TopToolbar: React.FC<TopToolbarProps> = ({
   }, [editor]);
 
   useEffect(() => {
-    if (selectedTile?.type === 'text' || selectedTile?.type === 'sequencing') {
+    if (selectedTile?.type === 'text' || selectedTile?.type === 'sequencing' || selectedTile?.type === 'general') {
       setVerticalAlign(selectedTile.content.verticalAlign || 'top');
     }
   }, [selectedTile]);

--- a/src/components/admin/tiles/TileRenderer.tsx
+++ b/src/components/admin/tiles/TileRenderer.tsx
@@ -8,6 +8,7 @@ import { ImageTileRenderer } from './image';
 import { ProgrammingTileRenderer} from "./programming/Renderer.tsx";
 import { QuizTileRenderer } from './quiz';
 import { SequencingTileRenderer } from './sequencing';
+import { GeneralTileRenderer } from './general';
 import { TextTileRenderer} from "./text/Renderer.tsx";
 
 interface TileRendererProps {
@@ -35,6 +36,7 @@ const TILE_RENDERERS: Partial<Record<LessonTile['type'], React.ComponentType<any
   quiz: QuizTileRenderer,
   sequencing: SequencingTileRenderer,
   blanks: BlanksTileRenderer,
+  general: GeneralTileRenderer,
 };
 
 export const TileRenderer: React.FC<TileRendererProps> = ({
@@ -81,7 +83,9 @@ export const TileRenderer: React.FC<TileRendererProps> = ({
   };
 
   const handleDoubleClick =
-    tile.type === 'sequencing' || tile.type === 'blanks' ? undefined : onDoubleClick;
+    tile.type === 'sequencing' || tile.type === 'blanks' || tile.type === 'general'
+      ? undefined
+      : onDoubleClick;
 
 
   return (

--- a/src/components/admin/tiles/general/Interactive.tsx
+++ b/src/components/admin/tiles/general/Interactive.tsx
@@ -1,0 +1,252 @@
+import React, { useMemo } from 'react';
+import { Sparkles, Shuffle, Columns3 } from 'lucide-react';
+import { GeneralTile } from '../../../../types/lessonEditor';
+import { getReadableTextColor } from '../../../../utils/colorUtils';
+import { createSurfacePalette, createValidateButtonPalette } from '../../../../utils/surfacePalette.ts';
+import { TaskInstructionPanel } from '../TaskInstructionPanel.tsx';
+import { TaskTileSection } from '../TaskTileSection.tsx';
+import { RichTextEditor, type RichTextEditorProps } from '../RichTextEditor.tsx';
+import { ValidateButton, type ValidateButtonColors } from '../../../common/ValidateButton.tsx';
+
+type ShuffledItem = { id: string; text: string };
+
+type SeededShuffleFn = <T>(items: T[], seed: string) => T[];
+
+const createSeedFromString = (value: string): number => {
+  let seed = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    seed = (seed * 31 + value.charCodeAt(index)) & 0x7fffffff;
+  }
+  return seed;
+};
+
+const shuffleWithSeed: SeededShuffleFn = (items, seedValue) => {
+  const shuffled = [...items];
+  if (shuffled.length <= 1) {
+    return shuffled;
+  }
+
+  let seed = createSeedFromString(seedValue) || 1;
+
+  for (let i = shuffled.length - 1; i > 0; i -= 1) {
+    seed = (seed * 1664525 + 1013904223) % 4294967296;
+    const random = seed / 4294967296;
+    const j = Math.floor(random * (i + 1));
+    [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+  }
+
+  return shuffled;
+};
+
+interface GeneralInteractiveProps {
+  tile: GeneralTile;
+  isPreview?: boolean;
+  isTestingMode?: boolean;
+  onRequestTextEditing?: () => void;
+  instructionEditorProps?: RichTextEditorProps;
+}
+
+export const GeneralInteractive: React.FC<GeneralInteractiveProps> = ({
+  tile,
+  isPreview = false,
+  isTestingMode = false,
+  onRequestTextEditing,
+  instructionEditorProps
+}) => {
+  const accentColor = tile.content.backgroundColor || '#0f172a';
+  const textColor = useMemo(() => getReadableTextColor(accentColor), [accentColor]);
+
+  const {
+    panelBackground,
+    panelBorder,
+    iconBackground,
+    sectionBackground,
+    sectionBorder,
+    headerBorder,
+    columnBackground,
+    columnBorder,
+    itemBackground,
+    itemBorder
+  } = useMemo(
+    () =>
+      createSurfacePalette(accentColor, textColor, {
+        panelBackground: { lighten: 0.64, darken: 0.45 },
+        panelBorder: { lighten: 0.52, darken: 0.56 },
+        iconBackground: { lighten: 0.56, darken: 0.48 },
+        sectionBackground: { lighten: 0.62, darken: 0.42 },
+        sectionBorder: { lighten: 0.52, darken: 0.54 },
+        headerBorder: { lighten: 0.5, darken: 0.58 },
+        columnBackground: { lighten: 0.68, darken: 0.36 },
+        columnBorder: { lighten: 0.54, darken: 0.52 },
+        itemBackground: { lighten: 0.72, darken: 0.3 },
+        itemBorder: { lighten: 0.58, darken: 0.46 }
+      }),
+    [accentColor, textColor]
+  );
+
+  const validateButtonColors = useMemo<ValidateButtonColors>(
+    () => createValidateButtonPalette(accentColor, textColor),
+    [accentColor, textColor]
+  );
+
+  const leftItems = useMemo<ShuffledItem[]>(
+    () =>
+      shuffleWithSeed(
+        tile.content.pairs.map(pair => ({ id: `${pair.id}-left`, text: pair.left })),
+        `${tile.id}-left`
+      ),
+    [tile.content.pairs, tile.id]
+  );
+
+  const rightItems = useMemo<ShuffledItem[]>(
+    () =>
+      shuffleWithSeed(
+        tile.content.pairs.map(pair => ({ id: `${pair.id}-right`, text: pair.right })),
+        `${tile.id}-right`
+      ),
+    [tile.content.pairs, tile.id]
+  );
+
+  const mutedLabelColor = textColor === '#0f172a' ? '#475569' : '#cbd5f5';
+
+  const handleTileDoubleClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (isPreview || isTestingMode) return;
+    event.preventDefault();
+    event.stopPropagation();
+    onRequestTextEditing?.();
+  };
+
+  const renderColumnItems = (items: ShuffledItem[]) => {
+    if (items.length === 0) {
+      return (
+        <div className="flex-1 flex items-center justify-center text-sm text-center px-3" style={{ color: mutedLabelColor }}>
+          Dodaj pary w panelu edycji, aby wyświetlić je tutaj.
+        </div>
+      );
+    }
+
+    return items.map(item => (
+      <div
+        key={item.id}
+        className="rounded-xl border px-4 py-3 text-sm font-medium shadow-sm"
+        style={{
+          backgroundColor: itemBackground,
+          borderColor: itemBorder,
+          color: textColor
+        }}
+      >
+        {item.text}
+      </div>
+    ));
+  };
+
+  return (
+    <div className="relative w-full h-full" onDoubleClick={handleTileDoubleClick}>
+      <div
+        className="w-full h-full flex flex-col gap-6 p-6 transition-all duration-300 rounded-[inherit]"
+        style={{
+          background: 'transparent',
+          color: textColor
+        }}
+      >
+        <TaskInstructionPanel
+          icon={<Sparkles className="w-4 h-4" />}
+          label="Zadanie"
+          className="border"
+          style={{
+            backgroundColor: panelBackground,
+            borderColor: panelBorder,
+            color: textColor
+          }}
+          iconWrapperClassName="w-9 h-9 rounded-xl flex items-center justify-center shadow-sm"
+          iconWrapperStyle={{
+            backgroundColor: iconBackground,
+            color: textColor
+          }}
+          labelStyle={{ color: mutedLabelColor }}
+        >
+          {instructionEditorProps ? (
+            <RichTextEditor {...instructionEditorProps} />
+          ) : (
+            <div
+              className="text-base leading-relaxed"
+              style={{ fontFamily: tile.content.fontFamily, fontSize: tile.content.fontSize }}
+              dangerouslySetInnerHTML={{
+                __html: tile.content.richInstruction || `<p>${tile.content.instruction}</p>`
+              }}
+            />
+          )}
+        </TaskInstructionPanel>
+
+        <div className="flex-1 min-h-0 flex flex-col">
+          <TaskTileSection
+            className="flex-1 min-h-0 shadow-sm"
+            style={{
+              backgroundColor: sectionBackground,
+              borderColor: sectionBorder,
+              color: textColor
+            }}
+            icon={<Shuffle className="w-4 h-4" />}
+            title={<span className="uppercase tracking-[0.24em]">dopasuj pary</span>}
+            headerClassName="px-6 py-5 border-b"
+            headerStyle={{ borderColor: headerBorder, color: mutedLabelColor }}
+            contentClassName="flex-1 min-h-0 px-6 py-5"
+          >
+            <div className="grid h-full grid-cols-1 gap-6 lg:grid-cols-2">
+              <div
+                className="flex h-full min-h-0 flex-col gap-4 rounded-xl border p-4"
+                style={{ backgroundColor: columnBackground, borderColor: columnBorder }}
+              >
+                <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.18em]" style={{ color: mutedLabelColor }}>
+                  <Columns3 className="w-4 h-4" />
+                  <span>Lewa kolumna</span>
+                </div>
+                <div
+                  className="flex-1 min-h-0 overflow-y-auto pr-1 flex flex-col gap-3"
+                  style={{ scrollbarColor: `${itemBorder} transparent` }}
+                >
+                  {renderColumnItems(leftItems)}
+                </div>
+              </div>
+
+              <div
+                className="flex h-full min-h-0 flex-col gap-4 rounded-xl border p-4"
+                style={{ backgroundColor: columnBackground, borderColor: columnBorder }}
+              >
+                <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.18em]" style={{ color: mutedLabelColor }}>
+                  <Columns3 className="w-4 h-4" />
+                  <span>Prawa kolumna</span>
+                </div>
+                <div
+                  className="flex-1 min-h-0 overflow-y-auto pr-1 flex flex-col gap-3"
+                  style={{ scrollbarColor: `${itemBorder} transparent` }}
+                >
+                  {renderColumnItems(rightItems)}
+                </div>
+              </div>
+            </div>
+          </TaskTileSection>
+        </div>
+
+        <div className="flex justify-center pt-2">
+          <ValidateButton
+            state="idle"
+            onClick={() => {}}
+            disabled
+            colors={validateButtonColors}
+            labels={{
+              idle: (
+                <>
+                  <Shuffle className="h-5 w-5" aria-hidden="true" />
+                  <span>Sprawdź pary</span>
+                </>
+              )
+            }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default GeneralInteractive;

--- a/src/components/admin/tiles/general/Renderer.tsx
+++ b/src/components/admin/tiles/general/Renderer.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { GeneralTile } from '../../../../types/lessonEditor';
+import { createRichTextAdapter, type RichTextEditorProps } from '../RichTextEditor.tsx';
+import { BaseTileRendererProps, getReadableTextColor } from '../shared';
+import { GeneralInteractive } from './Interactive';
+
+export const GeneralTileRenderer: React.FC<BaseTileRendererProps<GeneralTile>> = ({
+  tile,
+  isSelected,
+  isEditingText,
+  isTestingMode,
+  onUpdateTile,
+  onFinishTextEditing,
+  onEditorReady,
+  onDoubleClick,
+  backgroundColor,
+  showBorder,
+}) => {
+  const generalTile = tile;
+  const textColor = getReadableTextColor(generalTile.content.backgroundColor || backgroundColor);
+
+  const wrapperStyle: React.CSSProperties = {
+    borderRadius: 'inherit',
+    backgroundColor,
+    border: showBorder ? '1px solid rgba(0, 0, 0, 0.08)' : 'none',
+  };
+
+  const renderGeneralTile = (
+    instructionEditorProps?: RichTextEditorProps,
+    isPreviewMode = false,
+  ) => (
+    <GeneralInteractive
+      tile={generalTile}
+      isTestingMode={isTestingMode}
+      instructionEditorProps={instructionEditorProps}
+      isPreview={isPreviewMode}
+      onRequestTextEditing={isPreviewMode ? undefined : onDoubleClick}
+    />
+  );
+
+  if (isEditingText && isSelected) {
+    const instructionAdapter = createRichTextAdapter({
+      source: generalTile.content,
+      fields: {
+        text: 'instruction',
+        richText: 'richInstruction',
+        fontFamily: 'fontFamily',
+        fontSize: 'fontSize',
+        verticalAlign: 'verticalAlign',
+      },
+      defaults: {
+        backgroundColor: generalTile.content.backgroundColor,
+        showBorder: generalTile.content.showBorder,
+      },
+    });
+
+    return (
+      <div className="w-full h-full overflow-hidden" style={wrapperStyle}>
+        {renderGeneralTile(
+          {
+            content: instructionAdapter.content,
+            onChange: (updatedContent) => {
+              onUpdateTile(tile.id, {
+                content: instructionAdapter.applyChanges(updatedContent),
+              });
+            },
+            onFinish: onFinishTextEditing,
+            onEditorReady,
+            textColor,
+          },
+          true,
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full h-full overflow-hidden" style={wrapperStyle}>
+      {renderGeneralTile()}
+    </div>
+  );
+};
+
+export default GeneralTileRenderer;

--- a/src/components/admin/tiles/general/index.ts
+++ b/src/components/admin/tiles/general/index.ts
@@ -1,0 +1,1 @@
+export { GeneralTileRenderer } from './Renderer';

--- a/src/hooks/useLessonContentManager.ts
+++ b/src/hooks/useLessonContentManager.ts
@@ -5,7 +5,8 @@ import {
   LessonTile,
   ProgrammingTile,
   SequencingTile,
-  TextTile
+  TextTile,
+  GeneralTile
 } from '../types/lessonEditor';
 import { GridUtils } from '../utils/gridUtils';
 import { logger } from '../utils/logger';
@@ -21,15 +22,20 @@ const tileFactoryMap: Record<LessonTile['type'], TileFactory> = {
   quiz: (position, page) => LessonContentService.createQuizTile(position, page),
   programming: (position, page) => LessonContentService.createProgrammingTile(position, page),
   sequencing: (position, page) => LessonContentService.createSequencingTile(position, page),
-  blanks: (position, page) => LessonContentService.createBlanksTile(position, page)
+  blanks: (position, page) => LessonContentService.createBlanksTile(position, page),
+  general: (position, page) => LessonContentService.createGeneralTile(position, page)
 };
 
 const isRichTextTile = (
   tile: LessonTile | null
-): tile is TextTile | ProgrammingTile | SequencingTile | BlanksTile => {
+): tile is TextTile | ProgrammingTile | SequencingTile | BlanksTile | GeneralTile => {
   return (
     !!tile &&
-    (tile.type === 'text' || tile.type === 'programming' || tile.type === 'sequencing' || tile.type === 'blanks')
+    (tile.type === 'text' ||
+      tile.type === 'programming' ||
+      tile.type === 'sequencing' ||
+      tile.type === 'blanks' ||
+      tile.type === 'general')
   );
 };
 
@@ -254,7 +260,13 @@ export const useLessonContentManager = ({
           };
 
           if (
-            (tile.type === 'text' || tile.type === 'programming' || tile.type === 'sequencing' || tile.type === 'blanks') &&
+            (
+              tile.type === 'text' ||
+              tile.type === 'programming' ||
+              tile.type === 'sequencing' ||
+              tile.type === 'blanks' ||
+              tile.type === 'general'
+            ) &&
             updates.content
           ) {
             updatedTile.content = {

--- a/src/hooks/useTileInteractions.ts
+++ b/src/hooks/useTileInteractions.ts
@@ -1,5 +1,13 @@
 import { useState, useEffect, RefObject } from 'react';
-import { LessonContent, LessonTile, GridPosition, EditorState, TextTile, ImageTile, SequencingTile } from '../types/lessonEditor';
+import {
+  LessonContent,
+  LessonTile,
+  GridPosition,
+  EditorState,
+  TextTile,
+  ImageTile,
+  SequencingTile
+} from '../types/lessonEditor';
 import { EditorAction } from '../state/editorReducer';
 import { GridUtils } from '../utils/gridUtils';
 import { logger } from '../utils/logger';
@@ -33,7 +41,8 @@ export const useTileInteractions = ({
       tile.type === 'text' ||
       tile.type === 'programming' ||
       tile.type === 'sequencing' ||
-      tile.type === 'quiz'
+      tile.type === 'quiz' ||
+      tile.type === 'general'
     ) {
       dispatch({ type: 'startTextEditing', tileId: tile.id });
     } else if (tile.type === 'image') {

--- a/src/services/lessonContentService.ts
+++ b/src/services/lessonContentService.ts
@@ -5,6 +5,7 @@ import {
   ProgrammingTile,
   SequencingTile,
   BlanksTile,
+  GeneralTile,
   CanvasSettings,
   GridPosition
 } from '../types/lessonEditor';
@@ -230,6 +231,32 @@ export class LessonContentService {
           { id: 'auto-warszawa-1', text: 'Warszawa', isAuto: true },
           { id: 'auto-bialo-czerwona-flaga-2', text: 'biało-czerwona flaga', isAuto: true },
           { id: 'distractor-wisla', text: 'Wisła', isAuto: false }
+        ]
+      }
+    };
+  }
+
+  /**
+   * Create a new general matching pairs tile
+   */
+  static createGeneralTile(position: { x: number; y: number }, page = 1): GeneralTile {
+    const base = this.initializeTileBase('general', position, page, { colSpan: 4, rowSpan: 4 });
+
+    return {
+      ...base,
+      content: {
+        instruction: 'Przeczytaj polecenie i dopasuj elementy z lewej kolumny do właściwych odpowiedzi po prawej stronie.',
+        richInstruction:
+          '<p style="margin: 0;">Przeczytaj polecenie i dopasuj elementy z lewej kolumny do właściwych odpowiedzi po prawej stronie.</p>',
+        fontFamily: 'Inter, system-ui, sans-serif',
+        fontSize: 16,
+        verticalAlign: 'top',
+        backgroundColor: '#d4d4d4',
+        showBorder: true,
+        pairs: [
+          { id: 'pair-1', left: 'Francja', right: 'Paryż' },
+          { id: 'pair-2', left: 'Hiszpania', right: 'Madryt' },
+          { id: 'pair-3', left: 'Włochy', right: 'Rzym' }
         ]
       }
     };

--- a/src/types/lessonEditor.ts
+++ b/src/types/lessonEditor.ts
@@ -17,7 +17,15 @@ export interface GridPosition {
 
 export interface LessonTile {
   id: string;
-  type: 'text' | 'image' | 'visualization' | 'quiz' | 'programming' | 'sequencing' | 'blanks';
+  type:
+    | 'text'
+    | 'image'
+    | 'visualization'
+    | 'quiz'
+    | 'programming'
+    | 'sequencing'
+    | 'blanks'
+    | 'general';
   position: Position;
   size: Size;
   gridPosition: GridPosition;
@@ -143,6 +151,24 @@ export interface BlanksTile extends LessonTile {
       id: string;
       text: string;
       isAuto?: boolean;
+    }>;
+  };
+}
+
+export interface GeneralTile extends LessonTile {
+  type: 'general';
+  content: {
+    instruction: string;
+    richInstruction?: string;
+    fontFamily: string;
+    fontSize: number;
+    verticalAlign: 'top' | 'center' | 'bottom';
+    backgroundColor: string;
+    showBorder: boolean;
+    pairs: Array<{
+      id: string;
+      left: string;
+      right: string;
     }>;
   };
 }


### PR DESCRIPTION
## Summary
- add a general matching pairs task tile with dedicated renderer and interactive layout
- wire the new tile into the palette, lesson manager, and canvas interactions
- extend the side editor controls to manage tile background and configurable pairs

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68debf857f748321984edd798ff88b38