### PR TITLE
Add general matching tile for lesson editor

### DIFF
--- a/src/components/admin/editor side/TilePalette.tsx
+++ b/src/components/admin/editor side/TilePalette.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Type, Image, Puzzle, Eye, HelpCircle, Plus, Code, ArrowUpDown } from 'lucide-react';
+import { Type, Image, Puzzle, Eye, HelpCircle, Plus, Code, ArrowUpDown, Link2 } from 'lucide-react';
 import { TilePaletteItem } from '../../../types/lessonEditor.ts';
 
 interface TilePaletteProps {
@@ -42,6 +42,11 @@ const TILE_TYPES: TilePaletteItem[] = [
     type: 'blanks',
     title: 'Uzupełnij luki',
     icon: 'Puzzle'
+  },
+  {
+    type: 'general',
+    title: 'Dopasuj pary',
+    icon: 'Link2'
   }
 ];
 
@@ -54,6 +59,7 @@ const getIcon = (iconName: string) => {
     case 'HelpCircle': return HelpCircle;
     case 'Code': return Code;
     case 'ArrowUpDown': return ArrowUpDown;
+    case 'Link2': return Link2;
     default: return Type;
   }
 };

--- a/src/components/admin/editor side/TileSideEditor.tsx
+++ b/src/components/admin/editor side/TileSideEditor.tsx
@@ -1,6 +1,27 @@
 import React from 'react';
-import { Plus, Trash2, Type, X, Image as ImageIcon, Eye, HelpCircle, Code, ArrowUpDown, Puzzle } from 'lucide-react';
-import { TextTile, ImageTile, LessonTile, ProgrammingTile, SequencingTile, QuizTile, BlanksTile } from '../../../types/lessonEditor.ts';
+import {
+  Plus,
+  Trash2,
+  Type,
+  X,
+  Image as ImageIcon,
+  Eye,
+  HelpCircle,
+  Code,
+  ArrowUpDown,
+  Puzzle,
+  Link2
+} from 'lucide-react';
+import {
+  TextTile,
+  ImageTile,
+  LessonTile,
+  ProgrammingTile,
+  SequencingTile,
+  QuizTile,
+  BlanksTile,
+  GeneralTile
+} from '../../../types/lessonEditor.ts';
 import { ImageUploadComponent } from './ImageUploadComponent.tsx';
 import { ImagePositionControl } from './ImagePositionControl.tsx';
 import { SequencingEditor } from './SequencingEditor.tsx';
@@ -93,6 +114,7 @@ export const TileSideEditor: React.FC<TileSideEditorProps> = ({
       case 'programming': return Code;
       case 'sequencing': return ArrowUpDown;
       case 'blanks': return Puzzle;
+      case 'general': return Link2;
       default: return Type;
     }
   };
@@ -418,6 +440,129 @@ export const TileSideEditor: React.FC<TileSideEditorProps> = ({
 
                 )}
               </div>
+            </div>
+          </div>
+        );
+      }
+
+      case 'general': {
+        const generalTile = tile as GeneralTile;
+
+        const updateContent = (updates: Partial<GeneralTile['content']>) => {
+          onUpdateTile(tile.id, {
+            content: {
+              ...generalTile.content,
+              ...updates
+            },
+            updated_at: new Date().toISOString()
+          });
+        };
+
+        const handlePairChange = (pairId: string, field: 'left' | 'right', value: string) => {
+          const pairs = generalTile.content.pairs.map(pair =>
+            pair.id === pairId ? { ...pair, [field]: value } : pair
+          );
+          updateContent({ pairs });
+        };
+
+        const handleAddPair = () => {
+          const newPairId = `pair-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
+          const pairs = [
+            ...generalTile.content.pairs,
+            {
+              id: newPairId,
+              left: `Lewy element ${generalTile.content.pairs.length + 1}`,
+              right: `Prawy element ${generalTile.content.pairs.length + 1}`
+            }
+          ];
+          updateContent({ pairs });
+        };
+
+        const handleRemovePair = (pairId: string) => {
+          const pairs = generalTile.content.pairs.filter(pair => pair.id !== pairId);
+          updateContent({ pairs });
+        };
+
+        return (
+          <div className="space-y-6">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-3">Kolor akcentu</label>
+              <input
+                type="color"
+                value={generalTile.content.backgroundColor}
+                onChange={(e) => updateContent({ backgroundColor: e.target.value })}
+                className="w-full h-12 border border-gray-300 rounded-lg cursor-pointer"
+              />
+            </div>
+
+            <div className="space-y-4">
+              <div className="flex items-center justify-between">
+                <h4 className="text-sm font-semibold text-gray-900">Pary do dopasowania</h4>
+                <button
+                  type="button"
+                  onClick={handleAddPair}
+                  className="inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-blue-50 text-blue-600 text-sm font-medium hover:bg-blue-100 transition"
+                >
+                  <Plus className="w-4 h-4" />
+                  Dodaj parę
+                </button>
+              </div>
+
+              {generalTile.content.pairs.length === 0 ? (
+                <p className="text-sm text-gray-600">
+                  Dodaj co najmniej jedną parę elementów, które uczniowie będą musieli połączyć.
+                </p>
+              ) : (
+                <div className="space-y-3">
+                  {generalTile.content.pairs.map((pair, index) => (
+                    <div
+                      key={pair.id}
+                      className="border border-gray-200 rounded-xl p-4 bg-gray-50 space-y-4"
+                    >
+                      <div className="flex items-center justify-between">
+                        <span className="text-xs font-semibold uppercase tracking-wider text-gray-500">
+                          Para {index + 1}
+                        </span>
+                        <button
+                          type="button"
+                          onClick={() => handleRemovePair(pair.id)}
+                          className="inline-flex items-center justify-center text-rose-600 hover:bg-rose-50 p-2 rounded-lg"
+                          aria-label={`Usuń parę ${index + 1}`}
+                        >
+                          <Trash2 className="w-4 h-4" />
+                        </button>
+                      </div>
+
+                      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                        <div className="space-y-2">
+                          <label className="text-xs font-medium text-gray-600 uppercase tracking-wide">
+                            Element z lewej kolumny
+                          </label>
+                          <input
+                            type="text"
+                            value={pair.left}
+                            onChange={(e) => handlePairChange(pair.id, 'left', e.target.value)}
+                            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm"
+                            placeholder="Treść z lewej kolumny"
+                          />
+                        </div>
+                        <div className="space-y-2">
+                          <label className="text-xs font-medium text-gray-600 uppercase tracking-wide">
+                            Dopasowanie w prawej kolumnie
+                          </label>
+                          <input
+                            type="text"
+                            value={pair.right}
+                            onChange={(e) => handlePairChange(pair.id, 'right', e.target.value)}
+                            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm"
+                            placeholder="Treść z prawej kolumny"
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
             </div>
           </div>
         );

--- a/src/components/admin/tiles/TileRenderer.tsx
+++ b/src/components/admin/tiles/TileRenderer.tsx
@@ -9,6 +9,7 @@ import { ProgrammingTileRenderer} from "./programming/Renderer.tsx";
 import { QuizTileRenderer } from './quiz';
 import { SequencingTileRenderer } from './sequencing';
 import { TextTileRenderer} from "./text/Renderer.tsx";
+import { GeneralTileRenderer } from './general';
 
 interface TileRendererProps {
   tile: LessonTile;
@@ -35,6 +36,7 @@ const TILE_RENDERERS: Partial<Record<LessonTile['type'], React.ComponentType<any
   quiz: QuizTileRenderer,
   sequencing: SequencingTileRenderer,
   blanks: BlanksTileRenderer,
+  general: GeneralTileRenderer,
 };
 
 export const TileRenderer: React.FC<TileRendererProps> = ({
@@ -81,7 +83,9 @@ export const TileRenderer: React.FC<TileRendererProps> = ({
   };
 
   const handleDoubleClick =
-    tile.type === 'sequencing' || tile.type === 'blanks' ? undefined : onDoubleClick;
+    tile.type === 'sequencing' || tile.type === 'blanks' || tile.type === 'general'
+      ? undefined
+      : onDoubleClick;
 
 
   return (

--- a/src/components/admin/tiles/general/Interactive.tsx
+++ b/src/components/admin/tiles/general/Interactive.tsx
@@ -1,0 +1,252 @@
+import React, { useMemo } from 'react';
+import { Link2, Shuffle, Sparkles } from 'lucide-react';
+import { GeneralTile } from '../../../../types/lessonEditor';
+import { getReadableTextColor } from '../../../../utils/colorUtils';
+import {
+  createSurfacePalette,
+  createValidateButtonPalette
+} from '../../../../utils/surfacePalette.ts';
+import { TaskInstructionPanel } from '../TaskInstructionPanel.tsx';
+import { TaskTileSection } from '../TaskTileSection.tsx';
+import { RichTextEditor, type RichTextEditorProps } from '../RichTextEditor.tsx';
+import { ValidateButton, type ValidateButtonColors } from '../../../common/ValidateButton.tsx';
+
+interface GeneralInteractiveProps {
+  tile: GeneralTile;
+  isPreview?: boolean;
+  isTestingMode?: boolean;
+  onRequestTextEditing?: () => void;
+  instructionEditorProps?: RichTextEditorProps;
+}
+
+interface ShuffledItem {
+  id: string;
+  text: string;
+}
+
+const hashString = (value: string): number => {
+  let hash = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    hash = Math.imul(31, hash) + value.charCodeAt(index);
+    hash |= 0;
+  }
+  return hash >>> 0;
+};
+
+const ensureDifferentOrder = (originalIds: string[], items: ShuffledItem[]): ShuffledItem[] => {
+  if (items.length <= 1) {
+    return items;
+  }
+
+  const isSameOrder = items.every((item, index) => item.id === originalIds[index]);
+  if (!isSameOrder) {
+    return items;
+  }
+
+  const [first, ...rest] = items;
+  return [...rest, first];
+};
+
+export const GeneralInteractive: React.FC<GeneralInteractiveProps> = ({
+  tile,
+  isPreview = false,
+  isTestingMode = false,
+  onRequestTextEditing,
+  instructionEditorProps
+}) => {
+  const accentColor = tile.content.backgroundColor || '#0f172a';
+  const textColor = useMemo(() => getReadableTextColor(accentColor), [accentColor]);
+  const {
+    panelBackground,
+    panelBorder,
+    iconBackground,
+    sectionBackground,
+    sectionBorder,
+    itemBackground,
+    itemBorder,
+    badgeBackground,
+    badgeBorder
+  } = useMemo(
+    () =>
+      createSurfacePalette(accentColor, textColor, {
+        panelBackground: { lighten: 0.62, darken: 0.45 },
+        panelBorder: { lighten: 0.5, darken: 0.55 },
+        iconBackground: { lighten: 0.54, darken: 0.48 },
+        sectionBackground: { lighten: 0.68, darken: 0.4 },
+        sectionBorder: { lighten: 0.52, darken: 0.54 },
+        itemBackground: { lighten: 0.58, darken: 0.44 },
+        itemBorder: { lighten: 0.48, darken: 0.56 },
+        badgeBackground: { lighten: 0.52, darken: 0.48 },
+        badgeBorder: { lighten: 0.44, darken: 0.58 }
+      }),
+    [accentColor, textColor]
+  );
+  const mutedLabelColor = textColor === '#0f172a' ? '#475569' : '#d1d5db';
+  const columnCaptionColor = textColor === '#0f172a' ? '#64748b' : '#e2e8f0';
+
+  const validateButtonColors = useMemo<ValidateButtonColors>(
+    () => createValidateButtonPalette(accentColor, textColor),
+    [accentColor, textColor]
+  );
+
+  const validateButtonLabels = useMemo(
+    () => ({
+      idle: (
+        <>
+          <Shuffle className="h-5 w-5" aria-hidden="true" />
+          <span>Sprawdź dopasowania</span>
+        </>
+      )
+    }),
+    []
+  );
+
+  const shuffledRightItems = useMemo(() => {
+    const originalIds = tile.content.pairs.map(pair => pair.id);
+    const items: ShuffledItem[] = tile.content.pairs.map(pair => ({
+      id: pair.id,
+      text: pair.right
+    }));
+
+    const seededItems = items
+      .map(item => ({
+        ...item,
+        sortKey: hashString(`${tile.id}-${item.id}-${item.text}`)
+      }))
+      .sort((a, b) => a.sortKey - b.sortKey)
+      .map(({ sortKey: _sortKey, ...rest }) => rest);
+
+    return ensureDifferentOrder(originalIds, seededItems);
+  }, [tile.content.pairs, tile.id]);
+
+  const handleTileDoubleClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (isPreview || isTestingMode) return;
+    event.preventDefault();
+    event.stopPropagation();
+    onRequestTextEditing?.();
+  };
+
+  return (
+    <div className="relative w-full h-full" onDoubleClick={handleTileDoubleClick}>
+      <div
+        className="w-full h-full flex flex-col gap-6 transition-all duration-300 p-6 rounded-[inherit]"
+        style={{
+          background: 'transparent',
+          color: textColor
+        }}
+      >
+        <TaskInstructionPanel
+          icon={<Sparkles className="w-4 h-4" />}
+          label="Zadanie"
+          className="border"
+          style={{
+            backgroundColor: panelBackground,
+            borderColor: panelBorder,
+            color: textColor
+          }}
+          iconWrapperClassName="w-9 h-9 rounded-xl flex items-center justify-center shadow-sm"
+          iconWrapperStyle={{
+            backgroundColor: iconBackground,
+            color: textColor
+          }}
+          labelStyle={{ color: mutedLabelColor }}
+        >
+          {instructionEditorProps ? (
+            <RichTextEditor {...instructionEditorProps} />
+          ) : (
+            <div
+              className="text-base leading-relaxed"
+              dangerouslySetInnerHTML={{
+                __html: tile.content.richInstruction || `<p>${tile.content.instruction}</p>`
+              }}
+            />
+          )}
+        </TaskInstructionPanel>
+
+        <TaskTileSection
+          className="flex-1 min-h-0 shadow-sm"
+          icon={<Link2 className="w-4 h-4" />}
+          title="dopasuj pary"
+          style={{
+            backgroundColor: sectionBackground,
+            borderColor: sectionBorder,
+            color: textColor
+          }}
+          headerClassName="px-5 py-4 border-b"
+          headerStyle={{ borderColor: sectionBorder, color: mutedLabelColor }}
+          titleClassName="uppercase tracking-[0.24em] text-xs"
+          contentClassName="flex-1 min-h-0 px-5 py-4 overflow-hidden"
+        >
+          {tile.content.pairs.length === 0 ? (
+            <div className="h-full flex items-center justify-center text-sm" style={{ color: columnCaptionColor }}>
+              Dodaj pary w panelu edycji, aby zobaczyć podgląd układu.
+            </div>
+          ) : (
+            <div className="h-full flex flex-col gap-5 lg:flex-row min-h-0">
+              <div className="flex-1 min-h-0 flex flex-col">
+                <span className="text-xs uppercase tracking-[0.32em]" style={{ color: columnCaptionColor }}>
+                  Lewa kolumna
+                </span>
+                <div className="mt-3 flex-1 min-h-0 overflow-y-auto space-y-3 pr-1">
+                  {tile.content.pairs.map((pair, index) => (
+                    <div
+                      key={pair.id}
+                      className="flex items-start gap-3 rounded-xl border px-4 py-3 shadow-sm"
+                      style={{ backgroundColor: itemBackground, borderColor: itemBorder, color: textColor }}
+                    >
+                      <span
+                        className="flex h-8 w-8 items-center justify-center rounded-lg border text-sm font-semibold"
+                        style={{ backgroundColor: badgeBackground, borderColor: badgeBorder, color: textColor }}
+                      >
+                        {index + 1}
+                      </span>
+                      <span className="text-sm font-medium leading-snug break-words" style={{ color: textColor }}>
+                        {pair.left}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              <div className="flex-1 min-h-0 flex flex-col">
+                <span className="text-xs uppercase tracking-[0.32em]" style={{ color: columnCaptionColor }}>
+                  Prawa kolumna
+                </span>
+                <div className="mt-3 flex-1 min-h-0 overflow-y-auto space-y-3 pr-1">
+                  {shuffledRightItems.map((item, index) => (
+                    <div
+                      key={item.id}
+                      className="flex items-start gap-3 rounded-xl border px-4 py-3 shadow-sm"
+                      style={{ backgroundColor: itemBackground, borderColor: itemBorder, color: textColor }}
+                    >
+                      <span
+                        className="flex h-8 w-8 items-center justify-center rounded-lg border text-sm font-semibold"
+                        style={{ backgroundColor: badgeBackground, borderColor: badgeBorder, color: textColor }}
+                      >
+                        {String.fromCharCode(65 + (index % 26))}
+                      </span>
+                      <span className="text-sm font-medium leading-snug break-words" style={{ color: textColor }}>
+                        {item.text}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          )}
+        </TaskTileSection>
+
+        {!isPreview && (
+          <div className="flex items-center justify-center pt-1">
+            <ValidateButton
+              state="idle"
+              onClick={() => {}}
+              colors={validateButtonColors}
+              labels={validateButtonLabels}
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/components/admin/tiles/general/Renderer.tsx
+++ b/src/components/admin/tiles/general/Renderer.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { GeneralTile } from '../../../../types/lessonEditor';
+import { createRichTextAdapter, type RichTextEditorProps } from '../RichTextEditor.tsx';
+import { BaseTileRendererProps, getReadableTextColor } from '../shared';
+import { GeneralInteractive } from './Interactive';
+
+export const GeneralTileRenderer: React.FC<BaseTileRendererProps<GeneralTile>> = ({
+  tile,
+  isSelected,
+  isEditingText,
+  isTestingMode,
+  onUpdateTile,
+  onFinishTextEditing,
+  onEditorReady,
+  onDoubleClick,
+  backgroundColor,
+  showBorder,
+}) => {
+  const generalTile = tile;
+  const textColor = getReadableTextColor(generalTile.content.backgroundColor || backgroundColor);
+
+  const wrapperStyle: React.CSSProperties = {
+    borderRadius: 'inherit',
+    backgroundColor,
+    border: showBorder ? '1px solid rgba(0, 0, 0, 0.08)' : 'none',
+  };
+
+  const renderGeneralContent = (
+    instructionEditorProps?: RichTextEditorProps,
+    isPreviewMode = false,
+  ) => (
+    <GeneralInteractive
+      tile={generalTile}
+      isTestingMode={isTestingMode}
+      instructionEditorProps={instructionEditorProps}
+      isPreview={isPreviewMode}
+      onRequestTextEditing={isPreviewMode ? undefined : onDoubleClick}
+    />
+  );
+
+  if (isEditingText && isSelected) {
+    const instructionAdapter = createRichTextAdapter({
+      source: generalTile.content,
+      fields: {
+        text: 'instruction',
+        richText: 'richInstruction',
+        fontFamily: 'fontFamily',
+        fontSize: 'fontSize',
+        verticalAlign: 'verticalAlign',
+      },
+      defaults: {
+        backgroundColor: generalTile.content.backgroundColor,
+        showBorder: true,
+      },
+    });
+
+    return (
+      <div className="w-full h-full overflow-hidden" style={wrapperStyle}>
+        {renderGeneralContent(
+          {
+            content: instructionAdapter.content,
+            onChange: (updatedContent) => {
+              onUpdateTile(tile.id, {
+                content: instructionAdapter.applyChanges(updatedContent),
+              });
+            },
+            onFinish: onFinishTextEditing,
+            onEditorReady,
+            textColor,
+          },
+          true,
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full h-full overflow-hidden" style={wrapperStyle}>
+      {renderGeneralContent()}
+    </div>
+  );
+};

--- a/src/components/admin/tiles/general/index.ts
+++ b/src/components/admin/tiles/general/index.ts
@@ -1,0 +1,2 @@
+export { GeneralTileRenderer } from './Renderer';
+export { GeneralInteractive } from './Interactive';

--- a/src/hooks/useLessonContentManager.ts
+++ b/src/hooks/useLessonContentManager.ts
@@ -5,7 +5,8 @@ import {
   LessonTile,
   ProgrammingTile,
   SequencingTile,
-  TextTile
+  TextTile,
+  GeneralTile
 } from '../types/lessonEditor';
 import { GridUtils } from '../utils/gridUtils';
 import { logger } from '../utils/logger';
@@ -21,15 +22,22 @@ const tileFactoryMap: Record<LessonTile['type'], TileFactory> = {
   quiz: (position, page) => LessonContentService.createQuizTile(position, page),
   programming: (position, page) => LessonContentService.createProgrammingTile(position, page),
   sequencing: (position, page) => LessonContentService.createSequencingTile(position, page),
-  blanks: (position, page) => LessonContentService.createBlanksTile(position, page)
+  blanks: (position, page) => LessonContentService.createBlanksTile(position, page),
+  general: (position, page) => LessonContentService.createGeneralTile(position, page)
 };
 
 const isRichTextTile = (
   tile: LessonTile | null
-): tile is TextTile | ProgrammingTile | SequencingTile | BlanksTile => {
+): tile is TextTile | ProgrammingTile | SequencingTile | BlanksTile | GeneralTile => {
   return (
     !!tile &&
-    (tile.type === 'text' || tile.type === 'programming' || tile.type === 'sequencing' || tile.type === 'blanks')
+    (
+      tile.type === 'text' ||
+      tile.type === 'programming' ||
+      tile.type === 'sequencing' ||
+      tile.type === 'blanks' ||
+      tile.type === 'general'
+    )
   );
 };
 
@@ -254,7 +262,13 @@ export const useLessonContentManager = ({
           };
 
           if (
-            (tile.type === 'text' || tile.type === 'programming' || tile.type === 'sequencing' || tile.type === 'blanks') &&
+            (
+              tile.type === 'text' ||
+              tile.type === 'programming' ||
+              tile.type === 'sequencing' ||
+              tile.type === 'blanks' ||
+              tile.type === 'general'
+            ) &&
             updates.content
           ) {
             updatedTile.content = {

--- a/src/hooks/useTileInteractions.ts
+++ b/src/hooks/useTileInteractions.ts
@@ -33,7 +33,8 @@ export const useTileInteractions = ({
       tile.type === 'text' ||
       tile.type === 'programming' ||
       tile.type === 'sequencing' ||
-      tile.type === 'quiz'
+      tile.type === 'quiz' ||
+      tile.type === 'general'
     ) {
       dispatch({ type: 'startTextEditing', tileId: tile.id });
     } else if (tile.type === 'image') {

--- a/src/services/lessonContentService.ts
+++ b/src/services/lessonContentService.ts
@@ -5,6 +5,7 @@ import {
   ProgrammingTile,
   SequencingTile,
   BlanksTile,
+  GeneralTile,
   CanvasSettings,
   GridPosition
 } from '../types/lessonEditor';
@@ -205,6 +206,31 @@ export class LessonContentService {
         ],
         correctFeedback: 'Świetnie! Prawidłowa kolejność.',
         incorrectFeedback: 'Spróbuj ponownie. Sprawdź kolejność elementów.'
+      }
+    };
+  }
+
+  /**
+   * Create a new general matching tile
+   */
+  static createGeneralTile(position: { x: number; y: number }, page = 1): GeneralTile {
+    const base = this.initializeTileBase('general', position, page, { colSpan: 4, rowSpan: 4 });
+
+    return {
+      ...base,
+      content: {
+        instruction: 'Dopasuj pasujące do siebie elementy z obu kolumn.',
+        richInstruction:
+          '<p style="margin: 0;">Dopasuj pasujące do siebie elementy z obu kolumn.</p>',
+        fontFamily: 'Inter, system-ui, sans-serif',
+        fontSize: 16,
+        verticalAlign: 'top',
+        backgroundColor: '#d4d4d4',
+        pairs: [
+          { id: 'pair-1', left: 'Element A', right: 'Odpowiednik A' },
+          { id: 'pair-2', left: 'Element B', right: 'Odpowiednik B' },
+          { id: 'pair-3', left: 'Element C', right: 'Odpowiednik C' }
+        ]
       }
     };
   }

--- a/src/types/lessonEditor.ts
+++ b/src/types/lessonEditor.ts
@@ -17,7 +17,15 @@ export interface GridPosition {
 
 export interface LessonTile {
   id: string;
-  type: 'text' | 'image' | 'visualization' | 'quiz' | 'programming' | 'sequencing' | 'blanks';
+  type:
+    | 'text'
+    | 'image'
+    | 'visualization'
+    | 'quiz'
+    | 'programming'
+    | 'sequencing'
+    | 'blanks'
+    | 'general';
   position: Position;
   size: Size;
   gridPosition: GridPosition;
@@ -143,6 +151,23 @@ export interface BlanksTile extends LessonTile {
       id: string;
       text: string;
       isAuto?: boolean;
+    }>;
+  };
+}
+
+export interface GeneralTile extends LessonTile {
+  type: 'general';
+  content: {
+    instruction: string;
+    richInstruction?: string;
+    fontFamily: string;
+    fontSize: number;
+    verticalAlign: 'top' | 'center' | 'bottom';
+    backgroundColor: string;
+    pairs: Array<{
+      id: string;
+      left: string;
+      right: string;
     }>;
   };
 }


### PR DESCRIPTION
## Summary
- add a new general matching tile type with default content
- expose the tile in the palette, renderer, editor interactions, and side editor controls
- implement the general tile renderer with task instruction panel, shuffled pair columns, and validate button layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68debf857f748321984edd798ff88b38