### PR TITLE
Add general matching tile

### DIFF
--- a/src/components/admin/editor side/TilePalette.tsx
+++ b/src/components/admin/editor side/TilePalette.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Type, Image, Puzzle, Eye, HelpCircle, Plus, Code, ArrowUpDown } from 'lucide-react';
+import { Type, Image, Puzzle, Eye, HelpCircle, Plus, Code, ArrowUpDown, Link2 } from 'lucide-react';
 import { TilePaletteItem } from '../../../types/lessonEditor.ts';
 
 interface TilePaletteProps {
@@ -42,6 +42,11 @@ const TILE_TYPES: TilePaletteItem[] = [
     type: 'blanks',
     title: 'Uzupełnij luki',
     icon: 'Puzzle'
+  },
+  {
+    type: 'general',
+    title: 'Dopasuj pary',
+    icon: 'Link2'
   }
 ];
 
@@ -54,6 +59,7 @@ const getIcon = (iconName: string) => {
     case 'HelpCircle': return HelpCircle;
     case 'Code': return Code;
     case 'ArrowUpDown': return ArrowUpDown;
+    case 'Link2': return Link2;
     default: return Type;
   }
 };

--- a/src/components/admin/editor side/TileSideEditor.tsx
+++ b/src/components/admin/editor side/TileSideEditor.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { Plus, Trash2, Type, X, Image as ImageIcon, Eye, HelpCircle, Code, ArrowUpDown, Puzzle } from 'lucide-react';
-import { TextTile, ImageTile, LessonTile, ProgrammingTile, SequencingTile, QuizTile, BlanksTile } from '../../../types/lessonEditor.ts';
+import { Plus, Trash2, Type, X, Image as ImageIcon, Eye, HelpCircle, Code, ArrowUpDown, Puzzle, Link2 } from 'lucide-react';
+import { TextTile, ImageTile, LessonTile, ProgrammingTile, SequencingTile, QuizTile, BlanksTile, GeneralTile } from '../../../types/lessonEditor.ts';
 import { ImageUploadComponent } from './ImageUploadComponent.tsx';
 import { ImagePositionControl } from './ImagePositionControl.tsx';
 import { SequencingEditor } from './SequencingEditor.tsx';
@@ -93,6 +93,7 @@ export const TileSideEditor: React.FC<TileSideEditorProps> = ({
       case 'programming': return Code;
       case 'sequencing': return ArrowUpDown;
       case 'blanks': return Puzzle;
+      case 'general': return Link2;
       default: return Type;
     }
   };
@@ -416,6 +417,125 @@ export const TileSideEditor: React.FC<TileSideEditorProps> = ({
                       ))}
                     </div>
 
+                )}
+              </div>
+            </div>
+          </div>
+        );
+      }
+
+      case 'general': {
+        const generalTile = tile as GeneralTile;
+
+        const updateContent = (updates: Partial<GeneralTile['content']>) => {
+          onUpdateTile(tile.id, {
+            content: {
+              ...generalTile.content,
+              ...updates
+            },
+            updated_at: new Date().toISOString()
+          });
+        };
+
+        const handlePairChange = (pairId: string, field: 'left' | 'right', value: string) => {
+          const pairs = generalTile.content.pairs.map(pair =>
+            pair.id === pairId ? { ...pair, [field]: value } : pair
+          );
+
+          updateContent({ pairs });
+        };
+
+        const handleAddPair = () => {
+          const newPair = {
+            id: `pair-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`,
+            left: `Lewy element ${generalTile.content.pairs.length + 1}`,
+            right: `Prawy element ${generalTile.content.pairs.length + 1}`
+          };
+
+          updateContent({ pairs: [...generalTile.content.pairs, newPair] });
+        };
+
+        const handleRemovePair = (pairId: string) => {
+          updateContent({
+            pairs: generalTile.content.pairs.filter(pair => pair.id !== pairId)
+          });
+        };
+
+        return (
+          <div className="space-y-6">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-3">Kolor tła kafelka</label>
+              <input
+                type="color"
+                value={generalTile.content.backgroundColor}
+                onChange={(e) => updateContent({ backgroundColor: e.target.value })}
+                className="w-full h-12 border border-gray-300 rounded-lg cursor-pointer"
+              />
+            </div>
+
+            <div>
+              <div className="flex items-center justify-between mb-3">
+                <label className="block text-sm font-medium text-gray-700">
+                  Pary ({generalTile.content.pairs.length})
+                </label>
+                <button
+                  onClick={handleAddPair}
+                  type="button"
+                  className="inline-flex items-center gap-2 px-3 py-1.5 bg-blue-600 text-white text-xs font-medium rounded-lg shadow-sm hover:bg-blue-500 transition-colors"
+                >
+                  <Plus className="w-4 h-4" />
+                  <span>Dodaj parę</span>
+                </button>
+              </div>
+
+              <div className="space-y-3 max-h-64 overflow-y-auto pr-1">
+                {generalTile.content.pairs.length === 0 ? (
+                  <div className="text-sm text-gray-500 bg-gray-50 border border-dashed border-gray-300 rounded-lg p-4 text-center">
+                    Dodaj co najmniej jedną parę, aby zbudować zadanie.
+                  </div>
+                ) : (
+                  generalTile.content.pairs.map((pair, index) => (
+                    <div
+                      key={pair.id}
+                      className="space-y-3 rounded-xl border border-gray-200 bg-white p-4 shadow-sm"
+                    >
+                      <div className="flex items-center justify-between">
+                        <span className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+                          Para {index + 1}
+                        </span>
+                        <button
+                          type="button"
+                          onClick={() => handleRemovePair(pair.id)}
+                          className="inline-flex items-center justify-center rounded-lg p-2 text-rose-500 hover:bg-rose-50 transition-colors"
+                        >
+                          <Trash2 className="w-4 h-4" />
+                        </button>
+                      </div>
+
+                      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                        <div>
+                          <label className="block text-xs font-medium text-gray-600 mb-1">Lewa kolumna</label>
+                          <input
+                            type="text"
+                            value={pair.left}
+                            onChange={(e) => handlePairChange(pair.id, 'left', e.target.value)}
+                            className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-transparent focus:ring-2 focus:ring-blue-500"
+                            placeholder="Tekst elementu"
+                          />
+                        </div>
+                        <div>
+                          <label className="block text-xs font-medium text-gray-600 mb-1">Prawa kolumna</label>
+                          <input
+                            type="text"
+                            value={pair.right}
+                            onChange={(e) => handlePairChange(pair.id, 'right', e.target.value)}
+                            className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-transparent focus:ring-2 focus:ring-blue-500"
+                            placeholder="Tekst dopasowania"
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  ))
                 )}
               </div>
             </div>

--- a/src/components/admin/tiles/TileRenderer.tsx
+++ b/src/components/admin/tiles/TileRenderer.tsx
@@ -9,6 +9,7 @@ import { ProgrammingTileRenderer} from "./programming/Renderer.tsx";
 import { QuizTileRenderer } from './quiz';
 import { SequencingTileRenderer } from './sequencing';
 import { TextTileRenderer} from "./text/Renderer.tsx";
+import { GeneralTileRenderer } from './general';
 
 interface TileRendererProps {
   tile: LessonTile;
@@ -35,6 +36,7 @@ const TILE_RENDERERS: Partial<Record<LessonTile['type'], React.ComponentType<any
   quiz: QuizTileRenderer,
   sequencing: SequencingTileRenderer,
   blanks: BlanksTileRenderer,
+  general: GeneralTileRenderer,
 };
 
 export const TileRenderer: React.FC<TileRendererProps> = ({
@@ -81,7 +83,9 @@ export const TileRenderer: React.FC<TileRendererProps> = ({
   };
 
   const handleDoubleClick =
-    tile.type === 'sequencing' || tile.type === 'blanks' ? undefined : onDoubleClick;
+    tile.type === 'sequencing' || tile.type === 'blanks' || tile.type === 'general'
+      ? undefined
+      : onDoubleClick;
 
 
   return (

--- a/src/components/admin/tiles/general/Interactive.tsx
+++ b/src/components/admin/tiles/general/Interactive.tsx
@@ -1,0 +1,272 @@
+import React, { useCallback, useMemo } from 'react';
+import { Link2, Shuffle, Sparkles } from 'lucide-react';
+import { GeneralTile } from '../../../../types/lessonEditor';
+import { getReadableTextColor } from '../../../../utils/colorUtils';
+import {
+  createSurfacePalette,
+  createValidateButtonPalette
+} from '../../../../utils/surfacePalette.ts';
+import { TaskInstructionPanel } from '../TaskInstructionPanel.tsx';
+import { TaskTileSection } from '../TaskTileSection.tsx';
+import { RichTextEditor, RichTextEditorProps } from '../RichTextEditor.tsx';
+import { ValidateButton, ValidateButtonColors, ValidateButtonLabels } from '../../../common/ValidateButton.tsx';
+
+interface GeneralInteractiveProps {
+  tile: GeneralTile;
+  isPreview?: boolean;
+  isTestingMode?: boolean;
+  onRequestTextEditing?: () => void;
+  instructionEditorProps?: RichTextEditorProps;
+}
+
+interface ShuffledItem {
+  id: string;
+  text: string;
+}
+
+const createSeedFromString = (value: string): number => {
+  let hash = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    hash = (hash << 5) - hash + value.charCodeAt(index);
+    hash |= 0; // Convert to 32bit integer
+  }
+
+  return hash || 1;
+};
+
+const shuffleWithSeed = <T,>(items: T[], seedValue: string): T[] => {
+  if (items.length <= 1) {
+    return [...items];
+  }
+
+  const array = [...items];
+  let seed = createSeedFromString(seedValue);
+
+  const random = () => {
+    const x = Math.sin(seed++) * 10000;
+    return x - Math.floor(x);
+  };
+
+  for (let i = array.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(random() * (i + 1));
+    [array[i], array[j]] = [array[j], array[i]];
+  }
+
+  return array;
+};
+
+export const GeneralInteractive: React.FC<GeneralInteractiveProps> = ({
+  tile,
+  isPreview = false,
+  isTestingMode = false,
+  onRequestTextEditing,
+  instructionEditorProps
+}) => {
+  const accentColor = tile.content.backgroundColor || '#0f172a';
+  const textColor = useMemo(() => getReadableTextColor(accentColor), [accentColor]);
+
+  const {
+    panelBackground,
+    panelBorder,
+    iconBackground,
+    sectionBackground,
+    sectionBorder,
+    pairBackground,
+    pairBorder,
+    badgeBackground
+  } = useMemo(
+    () =>
+      createSurfacePalette(accentColor, textColor, {
+        panelBackground: { lighten: 0.64, darken: 0.42 },
+        panelBorder: { lighten: 0.52, darken: 0.56 },
+        iconBackground: { lighten: 0.54, darken: 0.5 },
+        sectionBackground: { lighten: 0.6, darken: 0.4 },
+        sectionBorder: { lighten: 0.5, darken: 0.54 },
+        pairBackground: { lighten: 0.66, darken: 0.36 },
+        pairBorder: { lighten: 0.52, darken: 0.58 },
+        badgeBackground: { lighten: 0.48, darken: 0.6 }
+      }),
+    [accentColor, textColor]
+  );
+
+  const mutedLabelColor = textColor === '#0f172a' ? '#475569' : '#dbeafe';
+
+  const validateButtonColors = useMemo<ValidateButtonColors>(
+    () => createValidateButtonPalette(accentColor, textColor),
+    [accentColor, textColor]
+  );
+
+  const validateButtonLabels = useMemo<ValidateButtonLabels>(
+    () => ({
+      idle: (
+        <>
+          <Shuffle className="h-5 w-5" aria-hidden="true" />
+          <span>Sprawdź pary</span>
+        </>
+      )
+    }),
+    []
+  );
+
+  const leftItems = useMemo<ShuffledItem[]>(
+    () =>
+      shuffleWithSeed(
+        tile.content.pairs.map(pair => ({ id: pair.id, text: pair.left })),
+        `${tile.id}-left`
+      ),
+    [tile.content.pairs, tile.id]
+  );
+
+  const rightItems = useMemo<ShuffledItem[]>(
+    () =>
+      shuffleWithSeed(
+        tile.content.pairs.map(pair => ({ id: pair.id, text: pair.right })),
+        `${tile.id}-right`
+      ),
+    [tile.content.pairs, tile.id]
+  );
+
+  const handleTileDoubleClick = useCallback(() => {
+    if (isPreview || isTestingMode) {
+      return;
+    }
+
+    onRequestTextEditing?.();
+  }, [isPreview, isTestingMode, onRequestTextEditing]);
+
+  return (
+    <div className="relative w-full h-full" onDoubleClick={handleTileDoubleClick}>
+      <div
+        className="w-full h-full flex flex-col gap-6 transition-all duration-300 p-6 rounded-[inherit]"
+        style={{
+          background: 'transparent',
+          color: textColor
+        }}
+      >
+        <TaskInstructionPanel
+          icon={<Sparkles className="w-4 h-4" />}
+          label="Zadanie"
+          className="border"
+          style={{
+            backgroundColor: panelBackground,
+            borderColor: panelBorder,
+            color: textColor
+          }}
+          iconWrapperClassName="w-9 h-9 rounded-xl flex items-center justify-center shadow-sm"
+          iconWrapperStyle={{
+            backgroundColor: iconBackground,
+            color: textColor
+          }}
+          labelStyle={{ color: mutedLabelColor }}
+        >
+          {instructionEditorProps ? (
+            <RichTextEditor {...instructionEditorProps} />
+          ) : (
+            <div
+              className="text-base leading-relaxed"
+              dangerouslySetInnerHTML={{
+                __html: tile.content.richInstruction || `<p>${tile.content.instruction}</p>`
+              }}
+            />
+          )}
+        </TaskInstructionPanel>
+
+        <TaskTileSection
+          className="flex-1 min-h-0 shadow-sm"
+          style={{
+            backgroundColor: sectionBackground,
+            borderColor: sectionBorder,
+            color: textColor
+          }}
+          icon={<Link2 className="w-4 h-4" />}
+          title="dopasuj pary"
+          headerClassName="px-6 py-5 border-b"
+          headerStyle={{ borderColor: sectionBorder, color: mutedLabelColor }}
+          titleStyle={{ color: mutedLabelColor, textTransform: 'uppercase' }}
+          contentClassName="flex-1 overflow-hidden px-6 py-5"
+        >
+          {tile.content.pairs.length === 0 ? (
+            <div
+              className="flex h-full items-center justify-center text-center text-sm"
+              style={{ color: mutedLabelColor }}
+            >
+              Dodaj pary w panelu bocznym, aby przygotować zadanie.
+            </div>
+          ) : (
+            <div className="h-full min-h-0 overflow-auto">
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-5 pr-1">
+                <div className="flex flex-col gap-3">
+                  {leftItems.map((item, index) => (
+                    <div
+                      key={`${item.id}-left`}
+                      className="flex items-start gap-3 rounded-xl border px-4 py-3 shadow-sm transition-transform duration-200 hover:-translate-y-0.5"
+                      style={{
+                        backgroundColor: pairBackground,
+                        borderColor: pairBorder,
+                        color: textColor
+                      }}
+                    >
+                      <span
+                        className="inline-flex h-8 w-8 flex-none items-center justify-center rounded-lg text-xs font-semibold uppercase tracking-wide"
+                        style={{
+                          backgroundColor: badgeBackground,
+                          color: textColor
+                        }}
+                      >
+                        {String.fromCharCode(65 + (index % 26))}
+                      </span>
+                      <span className="text-sm leading-relaxed">{item.text}</span>
+                    </div>
+                  ))}
+                </div>
+
+                <div className="flex flex-col gap-3">
+                  {rightItems.map((item, index) => (
+                    <div
+                      key={`${item.id}-right`}
+                      className="flex items-start gap-3 rounded-xl border px-4 py-3 shadow-sm transition-transform duration-200 hover:-translate-y-0.5"
+                      style={{
+                        backgroundColor: pairBackground,
+                        borderColor: pairBorder,
+                        color: textColor
+                      }}
+                    >
+                      <span
+                        className="inline-flex h-8 w-8 flex-none items-center justify-center rounded-lg text-xs font-semibold tracking-wide"
+                        style={{
+                          backgroundColor: badgeBackground,
+                          color: textColor
+                        }}
+                      >
+                        {index + 1}
+                      </span>
+                      <span className="text-sm leading-relaxed">{item.text}</span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          )}
+        </TaskTileSection>
+
+        <div className="flex flex-wrap items-center gap-3 pt-2">
+          <ValidateButton
+            state="idle"
+            onClick={() => {}}
+            disabled
+            colors={validateButtonColors}
+            labels={validateButtonLabels}
+          />
+          <span
+            className="text-xs font-medium uppercase tracking-[0.32em]"
+            style={{ color: mutedLabelColor }}
+          >
+            Widok edytora
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default GeneralInteractive;

--- a/src/components/admin/tiles/general/Renderer.tsx
+++ b/src/components/admin/tiles/general/Renderer.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { GeneralTile } from '../../../../types/lessonEditor';
+import { createRichTextAdapter, type RichTextEditorProps } from '../RichTextEditor.tsx';
+import { BaseTileRendererProps, getReadableTextColor } from '../shared';
+import { GeneralInteractive } from './Interactive';
+
+export const GeneralTileRenderer: React.FC<BaseTileRendererProps<GeneralTile>> = ({
+  tile,
+  isSelected,
+  isEditingText,
+  isTestingMode,
+  onUpdateTile,
+  onFinishTextEditing,
+  onEditorReady,
+  onDoubleClick,
+  backgroundColor,
+  showBorder,
+}) => {
+  const generalTile = tile;
+  const textColor = getReadableTextColor(generalTile.content.backgroundColor || backgroundColor);
+
+  const wrapperStyle: React.CSSProperties = {
+    borderRadius: 'inherit',
+    backgroundColor,
+    border: showBorder ? '1px solid rgba(0, 0, 0, 0.08)' : 'none',
+  };
+
+  const renderInteractive = (
+    instructionEditorProps?: RichTextEditorProps,
+    isPreviewMode = false,
+  ) => (
+    <GeneralInteractive
+      tile={generalTile}
+      isTestingMode={isTestingMode}
+      instructionEditorProps={instructionEditorProps}
+      isPreview={isPreviewMode}
+      onRequestTextEditing={isPreviewMode ? undefined : onDoubleClick}
+    />
+  );
+
+  if (isEditingText && isSelected) {
+    const instructionAdapter = createRichTextAdapter({
+      source: generalTile.content,
+      fields: {
+        text: 'instruction',
+        richText: 'richInstruction',
+      },
+      defaults: {
+        fontFamily: 'Inter, system-ui, sans-serif',
+        fontSize: 16,
+        verticalAlign: 'top',
+        backgroundColor: generalTile.content.backgroundColor,
+        showBorder: true,
+      },
+    });
+
+    return (
+      <div className="w-full h-full overflow-hidden" style={wrapperStyle}>
+        {renderInteractive(
+          {
+            content: instructionAdapter.content,
+            onChange: (updatedContent) => {
+              onUpdateTile(tile.id, {
+                content: instructionAdapter.applyChanges(updatedContent),
+              });
+            },
+            onFinish: onFinishTextEditing,
+            onEditorReady,
+            textColor,
+          },
+          true,
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full h-full overflow-hidden" style={wrapperStyle}>
+      {renderInteractive()}
+    </div>
+  );
+};
+
+export default GeneralTileRenderer;

--- a/src/components/admin/tiles/general/index.ts
+++ b/src/components/admin/tiles/general/index.ts
@@ -1,0 +1,2 @@
+export { GeneralTileRenderer } from './Renderer';
+export { GeneralInteractive } from './Interactive';

--- a/src/hooks/useLessonContentManager.ts
+++ b/src/hooks/useLessonContentManager.ts
@@ -5,7 +5,8 @@ import {
   LessonTile,
   ProgrammingTile,
   SequencingTile,
-  TextTile
+  TextTile,
+  GeneralTile
 } from '../types/lessonEditor';
 import { GridUtils } from '../utils/gridUtils';
 import { logger } from '../utils/logger';
@@ -21,15 +22,16 @@ const tileFactoryMap: Record<LessonTile['type'], TileFactory> = {
   quiz: (position, page) => LessonContentService.createQuizTile(position, page),
   programming: (position, page) => LessonContentService.createProgrammingTile(position, page),
   sequencing: (position, page) => LessonContentService.createSequencingTile(position, page),
-  blanks: (position, page) => LessonContentService.createBlanksTile(position, page)
+  blanks: (position, page) => LessonContentService.createBlanksTile(position, page),
+  general: (position, page) => LessonContentService.createGeneralTile(position, page)
 };
 
 const isRichTextTile = (
   tile: LessonTile | null
-): tile is TextTile | ProgrammingTile | SequencingTile | BlanksTile => {
+): tile is TextTile | ProgrammingTile | SequencingTile | BlanksTile | GeneralTile => {
   return (
     !!tile &&
-    (tile.type === 'text' || tile.type === 'programming' || tile.type === 'sequencing' || tile.type === 'blanks')
+    (tile.type === 'text' || tile.type === 'programming' || tile.type === 'sequencing' || tile.type === 'blanks' || tile.type === 'general')
   );
 };
 
@@ -254,7 +256,7 @@ export const useLessonContentManager = ({
           };
 
           if (
-            (tile.type === 'text' || tile.type === 'programming' || tile.type === 'sequencing' || tile.type === 'blanks') &&
+            (tile.type === 'text' || tile.type === 'programming' || tile.type === 'sequencing' || tile.type === 'blanks' || tile.type === 'general') &&
             updates.content
           ) {
             updatedTile.content = {

--- a/src/services/lessonContentService.ts
+++ b/src/services/lessonContentService.ts
@@ -5,6 +5,7 @@ import {
   ProgrammingTile,
   SequencingTile,
   BlanksTile,
+  GeneralTile,
   CanvasSettings,
   GridPosition
 } from '../types/lessonEditor';
@@ -205,6 +206,27 @@ export class LessonContentService {
         ],
         correctFeedback: 'Świetnie! Prawidłowa kolejność.',
         incorrectFeedback: 'Spróbuj ponownie. Sprawdź kolejność elementów.'
+      }
+    };
+  }
+
+  /**
+   * Create a new general matching tile
+   */
+  static createGeneralTile(position: { x: number; y: number }, page = 1): GeneralTile {
+    const base = this.initializeTileBase('general', position, page, { colSpan: 4, rowSpan: 4 });
+
+    return {
+      ...base,
+      content: {
+        instruction: 'Połącz elementy z lewej i prawej strony.',
+        richInstruction: '<p style="margin: 0;">Połącz elementy z lewej i prawej strony.</p>',
+        backgroundColor: '#d4d4d4',
+        pairs: [
+          { id: 'pair-1', left: 'Element A', right: 'Dopasowanie 1' },
+          { id: 'pair-2', left: 'Element B', right: 'Dopasowanie 2' },
+          { id: 'pair-3', left: 'Element C', right: 'Dopasowanie 3' }
+        ]
       }
     };
   }

--- a/src/types/lessonEditor.ts
+++ b/src/types/lessonEditor.ts
@@ -17,7 +17,15 @@ export interface GridPosition {
 
 export interface LessonTile {
   id: string;
-  type: 'text' | 'image' | 'visualization' | 'quiz' | 'programming' | 'sequencing' | 'blanks';
+  type:
+    | 'text'
+    | 'image'
+    | 'visualization'
+    | 'quiz'
+    | 'programming'
+    | 'sequencing'
+    | 'blanks'
+    | 'general';
   position: Position;
   size: Size;
   gridPosition: GridPosition;
@@ -143,6 +151,20 @@ export interface BlanksTile extends LessonTile {
       id: string;
       text: string;
       isAuto?: boolean;
+    }>;
+  };
+}
+
+export interface GeneralTile extends LessonTile {
+  type: 'general';
+  content: {
+    instruction: string;
+    richInstruction?: string;
+    backgroundColor: string;
+    pairs: Array<{
+      id: string;
+      left: string;
+      right: string;
     }>;
   };
 }


### PR DESCRIPTION
## Summary
- add the general tile type to the editor data model, palette, renderer wiring, and creation factory
- implement the general tile renderer with instruction panel, shuffled pair columns, and validate button stub
- extend the side editor with background color controls and pair management for the general tile

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68debf857f748321984edd798ff88b38