### PR TITLE
Add open answer task tile to lesson editor

### DIFF
--- a/src/components/admin/editor side/TilePalette.tsx
+++ b/src/components/admin/editor side/TilePalette.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Type, Image, Puzzle, Eye, HelpCircle, Plus, Code, ArrowUpDown } from 'lucide-react';
+import { Type, Image, Puzzle, Eye, HelpCircle, Plus, Code, ArrowUpDown, FileText } from 'lucide-react';
 import { TilePaletteItem } from '../../../types/lessonEditor.ts';
 
 interface TilePaletteProps {
@@ -42,6 +42,11 @@ const TILE_TYPES: TilePaletteItem[] = [
     type: 'blanks',
     title: 'Uzupełnij luki',
     icon: 'Puzzle'
+  },
+  {
+    type: 'open',
+    title: 'Odpowiedź otwarta',
+    icon: 'FileText'
   }
 ];
 
@@ -54,6 +59,7 @@ const getIcon = (iconName: string) => {
     case 'HelpCircle': return HelpCircle;
     case 'Code': return Code;
     case 'ArrowUpDown': return ArrowUpDown;
+    case 'FileText': return FileText;
     default: return Type;
   }
 };

--- a/src/components/admin/editor side/TileSideEditor.tsx
+++ b/src/components/admin/editor side/TileSideEditor.tsx
@@ -1,6 +1,27 @@
 import React from 'react';
-import { Plus, Trash2, Type, X, Image as ImageIcon, Eye, HelpCircle, Code, ArrowUpDown, Puzzle } from 'lucide-react';
-import { TextTile, ImageTile, LessonTile, ProgrammingTile, SequencingTile, QuizTile, BlanksTile } from '../../../types/lessonEditor.ts';
+import {
+  Plus,
+  Trash2,
+  Type,
+  X,
+  Image as ImageIcon,
+  Eye,
+  HelpCircle,
+  Code,
+  ArrowUpDown,
+  Puzzle,
+  FileText
+} from 'lucide-react';
+import {
+  TextTile,
+  ImageTile,
+  LessonTile,
+  ProgrammingTile,
+  SequencingTile,
+  QuizTile,
+  BlanksTile,
+  OpenTile
+} from '../../../types/lessonEditor.ts';
 import { ImageUploadComponent } from './ImageUploadComponent.tsx';
 import { ImagePositionControl } from './ImagePositionControl.tsx';
 import { SequencingEditor } from './SequencingEditor.tsx';
@@ -93,6 +114,7 @@ export const TileSideEditor: React.FC<TileSideEditorProps> = ({
       case 'programming': return Code;
       case 'sequencing': return ArrowUpDown;
       case 'blanks': return Puzzle;
+      case 'open': return FileText;
       default: return Type;
     }
   };
@@ -418,6 +440,265 @@ export const TileSideEditor: React.FC<TileSideEditorProps> = ({
 
                 )}
               </div>
+            </div>
+          </div>
+        );
+      }
+
+      case 'open': {
+        const openTile = tile as OpenTile;
+
+        const updateContent = (updates: Partial<OpenTile['content']>) => {
+          onUpdateTile(tile.id, {
+            content: {
+              ...openTile.content,
+              ...updates
+            },
+            updated_at: new Date().toISOString()
+          });
+        };
+
+        const handleAttachmentChange = (
+          attachmentId: string,
+          field: 'name' | 'description' | 'url',
+          value: string
+        ) => {
+          const attachments = (openTile.content.attachments ?? []).map(attachment =>
+            attachment.id === attachmentId
+              ? {
+                  ...attachment,
+                  [field]: value
+                }
+              : attachment
+          );
+
+          updateContent({ attachments });
+        };
+
+        const handleAddAttachment = () => {
+          const attachments = openTile.content.attachments ?? [];
+          const newAttachmentId = `attachment-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
+          updateContent({
+            attachments: [
+              ...attachments,
+              {
+                id: newAttachmentId,
+                name: `Nowy plik ${attachments.length + 1}`,
+                description: '',
+                url: ''
+              }
+            ]
+          });
+        };
+
+        const handleRemoveAttachment = (attachmentId: string) => {
+          const attachments = (openTile.content.attachments ?? []).filter(
+            attachment => attachment.id !== attachmentId
+          );
+
+          updateContent({ attachments });
+        };
+
+        const handlePairChange = (
+          pairId: string,
+          field: 'prompt' | 'response',
+          value: string
+        ) => {
+          const pairs = (openTile.content.pairs ?? []).map(pair =>
+            pair.id === pairId
+              ? {
+                  ...pair,
+                  [field]: value
+                }
+              : pair
+          );
+
+          updateContent({ pairs });
+        };
+
+        const handleAddPair = () => {
+          const pairs = openTile.content.pairs ?? [];
+          const newPairId = `pair-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
+          updateContent({
+            pairs: [
+              ...pairs,
+              {
+                id: newPairId,
+                prompt: `Element ${pairs.length + 1}`,
+                response: `Wartość ${pairs.length + 1}`
+              }
+            ]
+          });
+        };
+
+        const handleRemovePair = (pairId: string) => {
+          const pairs = (openTile.content.pairs ?? []).filter(pair => pair.id !== pairId);
+          updateContent({ pairs });
+        };
+
+        const attachments = openTile.content.attachments ?? [];
+        const pairs = openTile.content.pairs ?? [];
+
+        return (
+          <div className="space-y-6">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-3">Kolor akcentu</label>
+              <input
+                type="color"
+                value={openTile.content.backgroundColor}
+                onChange={(e) => updateContent({ backgroundColor: e.target.value })}
+                className="w-full h-12 border border-gray-300 rounded-lg cursor-pointer"
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">Oczekiwany format odpowiedzi</label>
+              <p className="text-xs text-gray-600 mb-2">
+                Ten tekst zostanie wyświetlony edytorowi obok pola odpowiedzi, aby wiedział jakiego formatu oczekujesz.
+              </p>
+              <textarea
+                value={openTile.content.expectedFormat}
+                onChange={(e) => updateContent({ expectedFormat: e.target.value })}
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm"
+                rows={3}
+                placeholder="np. ['napis1', 'napis2', 'napis3']"
+              />
+            </div>
+
+            <div className="space-y-4">
+              <div className="flex items-center justify-between">
+                <h4 className="text-sm font-semibold text-gray-900">Pliki do pobrania (opcjonalne)</h4>
+                <button
+                  type="button"
+                  onClick={handleAddAttachment}
+                  className="inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-blue-50 text-blue-600 text-sm font-medium hover:bg-blue-100 transition"
+                >
+                  <Plus className="w-4 h-4" />
+                  Dodaj plik
+                </button>
+              </div>
+
+              {attachments.length === 0 ? (
+                <p className="text-sm text-gray-600">
+                  Dodaj pliki, które uczeń będzie mógł pobrać przed rozwiązaniem zadania.
+                </p>
+              ) : (
+                <div className="space-y-3">
+                  {attachments.map(attachment => (
+                    <div
+                      key={attachment.id}
+                      className="border border-gray-200 rounded-xl p-4 bg-gray-50 space-y-3"
+                    >
+                      <div className="grid grid-cols-1 gap-3">
+                        <div>
+                          <label className="block text-xs font-medium text-gray-600 mb-1">Nazwa pliku</label>
+                          <input
+                            type="text"
+                            value={attachment.name}
+                            onChange={(e) => handleAttachmentChange(attachment.id, 'name', e.target.value)}
+                            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm"
+                            placeholder="np. instrukcja.pdf"
+                          />
+                        </div>
+                        <div>
+                          <label className="block text-xs font-medium text-gray-600 mb-1">Opis (opcjonalny)</label>
+                          <textarea
+                            value={attachment.description || ''}
+                            onChange={(e) => handleAttachmentChange(attachment.id, 'description', e.target.value)}
+                            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm"
+                            rows={2}
+                            placeholder="Krótki opis zawartości pliku"
+                          />
+                        </div>
+                        <div>
+                          <label className="block text-xs font-medium text-gray-600 mb-1">Adres URL (opcjonalny)</label>
+                          <input
+                            type="url"
+                            value={attachment.url || ''}
+                            onChange={(e) => handleAttachmentChange(attachment.id, 'url', e.target.value)}
+                            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm"
+                            placeholder="https://example.com/pliki/instrukcja.pdf"
+                          />
+                        </div>
+                      </div>
+
+                      <div className="flex justify-end">
+                        <button
+                          type="button"
+                          onClick={() => handleRemoveAttachment(attachment.id)}
+                          className="inline-flex items-center gap-1 text-rose-600 hover:bg-rose-50 px-3 py-2 rounded-lg text-sm"
+                        >
+                          <Trash2 className="w-4 h-4" />
+                          Usuń
+                        </button>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            <div className="space-y-4">
+              <div className="flex items-center justify-between">
+                <h4 className="text-sm font-semibold text-gray-900">Parowanie kontekstowe</h4>
+                <button
+                  type="button"
+                  onClick={handleAddPair}
+                  className="inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-blue-50 text-blue-600 text-sm font-medium hover:bg-blue-100 transition"
+                >
+                  <Plus className="w-4 h-4" />
+                  Dodaj parę
+                </button>
+              </div>
+
+              {pairs.length === 0 ? (
+                <p className="text-sm text-gray-600">
+                  Dodaj pary informacji, które zostaną zaprezentowane w kafelku w przetasowanej kolejności.
+                </p>
+              ) : (
+                <div className="space-y-3">
+                  {pairs.map(pair => (
+                    <div
+                      key={pair.id}
+                      className="border border-gray-200 rounded-xl p-4 bg-gray-50 space-y-3"
+                    >
+                      <div className="grid grid-cols-1 gap-3">
+                        <div>
+                          <label className="block text-xs font-medium text-gray-600 mb-1">Element</label>
+                          <input
+                            type="text"
+                            value={pair.prompt}
+                            onChange={(e) => handlePairChange(pair.id, 'prompt', e.target.value)}
+                            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm"
+                            placeholder="np. Nazwa pola"
+                          />
+                        </div>
+                        <div>
+                          <label className="block text-xs font-medium text-gray-600 mb-1">Odpowiedź</label>
+                          <input
+                            type="text"
+                            value={pair.response}
+                            onChange={(e) => handlePairChange(pair.id, 'response', e.target.value)}
+                            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm"
+                            placeholder="np. wartość oczekiwana"
+                          />
+                        </div>
+                      </div>
+
+                      <div className="flex justify-end">
+                        <button
+                          type="button"
+                          onClick={() => handleRemovePair(pair.id)}
+                          className="inline-flex items-center gap-1 text-rose-600 hover:bg-rose-50 px-3 py-2 rounded-lg text-sm"
+                        >
+                          <Trash2 className="w-4 h-4" />
+                          Usuń
+                        </button>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
             </div>
           </div>
         );

--- a/src/components/admin/editor side/TileSideEditor.tsx
+++ b/src/components/admin/editor side/TileSideEditor.tsx
@@ -499,45 +499,7 @@ export const TileSideEditor: React.FC<TileSideEditorProps> = ({
           updateContent({ attachments });
         };
 
-        const handlePairChange = (
-          pairId: string,
-          field: 'prompt' | 'response',
-          value: string
-        ) => {
-          const pairs = (openTile.content.pairs ?? []).map(pair =>
-            pair.id === pairId
-              ? {
-                  ...pair,
-                  [field]: value
-                }
-              : pair
-          );
-
-          updateContent({ pairs });
-        };
-
-        const handleAddPair = () => {
-          const pairs = openTile.content.pairs ?? [];
-          const newPairId = `pair-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
-          updateContent({
-            pairs: [
-              ...pairs,
-              {
-                id: newPairId,
-                prompt: `Element ${pairs.length + 1}`,
-                response: `Wartość ${pairs.length + 1}`
-              }
-            ]
-          });
-        };
-
-        const handleRemovePair = (pairId: string) => {
-          const pairs = (openTile.content.pairs ?? []).filter(pair => pair.id !== pairId);
-          updateContent({ pairs });
-        };
-
         const attachments = openTile.content.attachments ?? [];
-        const pairs = openTile.content.pairs ?? [];
 
         return (
           <div className="space-y-6">
@@ -638,67 +600,48 @@ export const TileSideEditor: React.FC<TileSideEditorProps> = ({
               )}
             </div>
 
-            <div className="space-y-4">
-              <div className="flex items-center justify-between">
-                <h4 className="text-sm font-semibold text-gray-900">Parowanie kontekstowe</h4>
+            <div className="space-y-3">
+              <label className="block text-sm font-medium text-gray-700">Poprawna odpowiedź</label>
+              <p className="text-xs text-gray-600">
+                Ten tekst zostanie użyty do walidacji. Zadbaj, by format odpowiedzi zgadzał się z instrukcją.
+              </p>
+              <textarea
+                value={openTile.content.correctAnswer ?? ''}
+                onChange={(e) => updateContent({ correctAnswer: e.target.value })}
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm"
+                rows={4}
+                placeholder="np. ['napis1', 'napis2', 'napis3']"
+              />
+
+              <div className="flex flex-wrap gap-3">
                 <button
                   type="button"
-                  onClick={handleAddPair}
-                  className="inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-blue-50 text-blue-600 text-sm font-medium hover:bg-blue-100 transition"
+                  onClick={() => updateContent({ ignoreCase: !openTile.content.ignoreCase })}
+                  className={`inline-flex items-center gap-2 px-3 py-2 rounded-lg border text-sm font-medium transition ${
+                    openTile.content.ignoreCase
+                      ? 'border-blue-500 bg-blue-50 text-blue-600 shadow-sm'
+                      : 'border-gray-200 text-gray-700 hover:border-gray-300 hover:bg-gray-50'
+                  }`}
                 >
-                  <Plus className="w-4 h-4" />
-                  Dodaj parę
+                  {(openTile.content.ignoreCase ?? false)
+                    ? 'Ignoruj wielkość liter'
+                    : 'Rozróżniaj wielkość liter'}
+                </button>
+
+                <button
+                  type="button"
+                  onClick={() => updateContent({ ignoreWhitespace: !openTile.content.ignoreWhitespace })}
+                  className={`inline-flex items-center gap-2 px-3 py-2 rounded-lg border text-sm font-medium transition ${
+                    openTile.content.ignoreWhitespace
+                      ? 'border-blue-500 bg-blue-50 text-blue-600 shadow-sm'
+                      : 'border-gray-200 text-gray-700 hover:border-gray-300 hover:bg-gray-50'
+                  }`}
+                >
+                  {(openTile.content.ignoreWhitespace ?? false)
+                    ? 'Ignoruj białe znaki'
+                    : 'Uwzględniaj białe znaki'}
                 </button>
               </div>
-
-              {pairs.length === 0 ? (
-                <p className="text-sm text-gray-600">
-                  Dodaj pary informacji, które zostaną zaprezentowane w kafelku w przetasowanej kolejności.
-                </p>
-              ) : (
-                <div className="space-y-3">
-                  {pairs.map(pair => (
-                    <div
-                      key={pair.id}
-                      className="border border-gray-200 rounded-xl p-4 bg-gray-50 space-y-3"
-                    >
-                      <div className="grid grid-cols-1 gap-3">
-                        <div>
-                          <label className="block text-xs font-medium text-gray-600 mb-1">Element</label>
-                          <input
-                            type="text"
-                            value={pair.prompt}
-                            onChange={(e) => handlePairChange(pair.id, 'prompt', e.target.value)}
-                            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm"
-                            placeholder="np. Nazwa pola"
-                          />
-                        </div>
-                        <div>
-                          <label className="block text-xs font-medium text-gray-600 mb-1">Odpowiedź</label>
-                          <input
-                            type="text"
-                            value={pair.response}
-                            onChange={(e) => handlePairChange(pair.id, 'response', e.target.value)}
-                            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm"
-                            placeholder="np. wartość oczekiwana"
-                          />
-                        </div>
-                      </div>
-
-                      <div className="flex justify-end">
-                        <button
-                          type="button"
-                          onClick={() => handleRemovePair(pair.id)}
-                          className="inline-flex items-center gap-1 text-rose-600 hover:bg-rose-50 px-3 py-2 rounded-lg text-sm"
-                        >
-                          <Trash2 className="w-4 h-4" />
-                          Usuń
-                        </button>
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              )}
             </div>
           </div>
         );

--- a/src/components/admin/editor top/TopToolbar.tsx
+++ b/src/components/admin/editor top/TopToolbar.tsx
@@ -5,14 +5,14 @@ import { FontSizeSelector } from './FontSizeSelector.tsx';
 import { TextColorPicker } from './TextColorPicker.tsx';
 import { FontSelector } from './FontSelector.tsx';
 import { AlignmentControls } from './AlignmentControls.tsx';
-import { LessonTile, ProgrammingTile, TextTile, SequencingTile } from '../../../types/lessonEditor.ts';
+import { LessonTile, ProgrammingTile, TextTile, SequencingTile, OpenTile } from '../../../types/lessonEditor.ts';
 
 
 interface TopToolbarProps {
   isTextEditing: boolean;
   onFinishTextEditing?: () => void;
   editor?: Editor | null;
-  selectedTile?: TextTile | ProgrammingTile | SequencingTile | null;
+  selectedTile?: TextTile | ProgrammingTile | SequencingTile | OpenTile | null;
   onUpdateTile?: (tileId: string, updates: Partial<LessonTile>) => void;
   currentPage?: number;
   totalPages?: number;
@@ -69,7 +69,7 @@ export const TopToolbar: React.FC<TopToolbarProps> = ({
   }, [editor]);
 
   useEffect(() => {
-    if (selectedTile?.type === 'text' || selectedTile?.type === 'sequencing') {
+    if (selectedTile?.type === 'text' || selectedTile?.type === 'sequencing' || selectedTile?.type === 'open') {
       setVerticalAlign(selectedTile.content.verticalAlign || 'top');
     }
   }, [selectedTile]);

--- a/src/components/admin/tiles/TileRenderer.tsx
+++ b/src/components/admin/tiles/TileRenderer.tsx
@@ -8,6 +8,7 @@ import { ImageTileRenderer } from './image';
 import { ProgrammingTileRenderer} from "./programming/Renderer.tsx";
 import { QuizTileRenderer } from './quiz';
 import { SequencingTileRenderer } from './sequencing';
+import { OpenTileRenderer } from './open';
 import { TextTileRenderer} from "./text/Renderer.tsx";
 
 interface TileRendererProps {
@@ -35,6 +36,7 @@ const TILE_RENDERERS: Partial<Record<LessonTile['type'], React.ComponentType<any
   quiz: QuizTileRenderer,
   sequencing: SequencingTileRenderer,
   blanks: BlanksTileRenderer,
+  open: OpenTileRenderer,
 };
 
 export const TileRenderer: React.FC<TileRendererProps> = ({

--- a/src/components/admin/tiles/open/Interactive.tsx
+++ b/src/components/admin/tiles/open/Interactive.tsx
@@ -1,0 +1,289 @@
+import React, { useCallback, useMemo } from 'react';
+import { FileText, Paperclip, Download, PenSquare, Shuffle } from 'lucide-react';
+import { OpenTile } from '../../../../types/lessonEditor';
+import { getReadableTextColor, surfaceColor } from '../../../../utils/colorUtils';
+import { createValidateButtonPalette } from '../../../../utils/surfacePalette.ts';
+import { TaskInstructionPanel } from '../TaskInstructionPanel.tsx';
+import { TaskTileSection } from '../TaskTileSection.tsx';
+import { RichTextEditor, RichTextEditorProps } from '../RichTextEditor.tsx';
+import { ValidateButton, ValidateButtonColors } from '../../../common/ValidateButton.tsx';
+
+interface OpenInteractiveProps {
+  tile: OpenTile;
+  isPreview?: boolean;
+  isTestingMode?: boolean;
+  onRequestTextEditing?: () => void;
+  instructionEditorProps?: RichTextEditorProps;
+}
+
+interface ShuffledResponse {
+  id: string;
+  text: string;
+}
+
+const deterministicShuffle = <T,>(items: T[], seed: string): T[] => {
+  const result = [...items];
+  let hash = 0;
+  for (let index = 0; index < seed.length; index += 1) {
+    hash = (hash * 31 + seed.charCodeAt(index)) >>> 0;
+  }
+
+  for (let i = result.length - 1; i > 0; i -= 1) {
+    hash = (hash * 1664525 + 1013904223) >>> 0;
+    const j = hash % (i + 1);
+    [result[i], result[j]] = [result[j], result[i]];
+  }
+
+  return result;
+};
+
+export const OpenInteractive: React.FC<OpenInteractiveProps> = ({
+  tile,
+  isPreview = false,
+  isTestingMode = false,
+  onRequestTextEditing,
+  instructionEditorProps,
+}) => {
+  const accentColor = tile.content.backgroundColor || '#0f172a';
+  const textColor = useMemo(() => getReadableTextColor(accentColor), [accentColor]);
+  const mutedLabelColor = textColor === '#0f172a' ? '#475569' : '#dbeafe';
+  const captionColor = textColor === '#0f172a' ? '#64748b' : '#cbd5f5';
+  const sectionBackground = surfaceColor(accentColor, textColor, 0.66, 0.4);
+  const sectionBorder = surfaceColor(accentColor, textColor, 0.52, 0.52);
+  const itemBackground = surfaceColor(accentColor, textColor, 0.72, 0.36);
+  const itemBorder = surfaceColor(accentColor, textColor, 0.6, 0.46);
+  const inputBackground = surfaceColor(accentColor, textColor, 0.78, 0.32);
+  const inputBorder = surfaceColor(accentColor, textColor, 0.6, 0.46);
+  const iconBackground = surfaceColor(accentColor, textColor, 0.54, 0.48);
+  const panelBackground = surfaceColor(accentColor, textColor, 0.62, 0.45);
+  const panelBorder = surfaceColor(accentColor, textColor, 0.5, 0.55);
+
+  const attachments = useMemo(() => tile.content.attachments ?? [], [tile.content.attachments]);
+  const pairs = useMemo(() => tile.content.pairs ?? [], [tile.content.pairs]);
+
+  const shuffledResponses = useMemo<ShuffledResponse[]>(() => {
+    const responses = pairs.map(pair => ({ id: pair.id, text: pair.response }));
+    return deterministicShuffle(responses, `${tile.id}-${tile.updated_at}`);
+  }, [pairs, tile.id, tile.updated_at]);
+
+  const validateButtonColors = useMemo<ValidateButtonColors>(
+    () => createValidateButtonPalette(accentColor, textColor),
+    [accentColor, textColor]
+  );
+
+  const handleTileDoubleClick = useCallback(() => {
+    if (isPreview) {
+      return;
+    }
+
+    onRequestTextEditing?.();
+  }, [isPreview, onRequestTextEditing]);
+
+  const answerPlaceholder = tile.content.expectedFormat
+    ? `Oczekiwany format:\n${tile.content.expectedFormat}`
+    : 'Wpisz swoją odpowiedź w tym miejscu.';
+
+  return (
+    <div className="relative w-full h-full" onDoubleClick={handleTileDoubleClick}>
+      <div
+        className="w-full h-full flex flex-col gap-6 transition-all duration-300 p-6 rounded-[inherit]"
+        style={{ color: textColor }}
+      >
+        <TaskInstructionPanel
+          icon={<FileText className="w-4 h-4" />}
+          label="Zadanie otwarte"
+          className="border"
+          style={{
+            backgroundColor: panelBackground,
+            borderColor: panelBorder,
+            color: textColor,
+          }}
+          iconWrapperClassName="w-9 h-9 rounded-xl flex items-center justify-center shadow-sm"
+          iconWrapperStyle={{
+            backgroundColor: iconBackground,
+            color: textColor,
+          }}
+          labelStyle={{ color: mutedLabelColor }}
+        >
+          {instructionEditorProps ? (
+            <RichTextEditor {...instructionEditorProps} />
+          ) : (
+            <div
+              className="text-base leading-relaxed"
+              dangerouslySetInnerHTML={{
+                __html: tile.content.richInstruction || `<p>${tile.content.instruction}</p>`
+              }}
+            />
+          )}
+        </TaskInstructionPanel>
+
+        {isTestingMode && (
+          <div
+            className="text-[11px] uppercase tracking-[0.32em]"
+            style={{ color: captionColor }}
+          >
+            Tryb testowania
+          </div>
+        )}
+
+        <TaskTileSection
+          icon={<Paperclip className="w-4 h-4" />}
+          title="Materiały do zadania"
+          className="shadow-sm"
+          style={{
+            backgroundColor: sectionBackground,
+            borderColor: sectionBorder,
+            color: textColor,
+          }}
+          headerClassName="px-5 py-4 border-b"
+          headerStyle={{ borderColor: sectionBorder, color: mutedLabelColor }}
+          titleStyle={{ color: mutedLabelColor }}
+          contentClassName="flex flex-col gap-3 px-5 py-4"
+        >
+          {attachments.length === 0 ? (
+            <p className="text-sm" style={{ color: captionColor }}>
+              Nie dodano żadnych plików. Dodaj je w panelu edycji, jeśli zadanie tego wymaga.
+            </p>
+          ) : (
+            <div className="space-y-3">
+              {attachments.map(attachment => (
+                <div
+                  key={attachment.id}
+                  className="flex flex-col gap-3 rounded-xl border p-4 sm:flex-row sm:items-center sm:justify-between"
+                  style={{
+                    backgroundColor: itemBackground,
+                    borderColor: itemBorder,
+                  }}
+                >
+                  <div>
+                    <p className="text-sm font-semibold" style={{ color: textColor }}>
+                      {attachment.name}
+                    </p>
+                    {attachment.description ? (
+                      <p className="text-xs" style={{ color: captionColor }}>
+                        {attachment.description}
+                      </p>
+                    ) : null}
+                  </div>
+                  <button
+                    type="button"
+                    disabled
+                    className="inline-flex items-center gap-2 px-3 py-2 rounded-lg border text-xs font-medium opacity-70 cursor-not-allowed"
+                    style={{
+                      borderColor: itemBorder,
+                      color: textColor,
+                      backgroundColor: 'transparent',
+                    }}
+                  >
+                    <Download className="w-4 h-4" />
+                    Pobierz (podgląd)
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+        </TaskTileSection>
+
+        <TaskTileSection
+          icon={<PenSquare className="w-4 h-4" />}
+          title="Twoja odpowiedź"
+          className="shadow-sm"
+          style={{
+            backgroundColor: sectionBackground,
+            borderColor: sectionBorder,
+            color: textColor,
+          }}
+          headerClassName="px-5 py-4 border-b"
+          headerStyle={{ borderColor: sectionBorder, color: mutedLabelColor }}
+          titleStyle={{ color: mutedLabelColor }}
+          contentClassName="flex flex-col gap-3 px-5 py-4"
+        >
+          <textarea
+            className="w-full min-h-[120px] resize-none rounded-xl px-4 py-3 text-sm"
+            style={{
+              backgroundColor: inputBackground,
+              borderColor: inputBorder,
+              color: textColor,
+            }}
+            placeholder={answerPlaceholder}
+            disabled
+          />
+          <p className="text-xs" style={{ color: captionColor }}>
+            Pole odpowiedzi jest zablokowane w edytorze. Uczniowie zobaczą aktywne pole w wersji uczniowskiej.
+          </p>
+        </TaskTileSection>
+
+        <TaskTileSection
+          icon={<Shuffle className="w-4 h-4" />}
+          title="Przykładowe pary"
+          className="shadow-sm"
+          style={{
+            backgroundColor: sectionBackground,
+            borderColor: sectionBorder,
+            color: textColor,
+          }}
+          headerClassName="px-5 py-4 border-b"
+          headerStyle={{ borderColor: sectionBorder, color: mutedLabelColor }}
+          titleStyle={{ color: mutedLabelColor }}
+          contentClassName="px-5 py-4"
+        >
+          {pairs.length === 0 ? (
+            <p className="text-sm" style={{ color: captionColor }}>
+              Dodaj pary w panelu edycji, aby pokazać uczniowi przykładowe elementy i odpowiedzi.
+            </p>
+          ) : (
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+              <div className="space-y-2">
+                <h4 className="text-xs font-semibold uppercase tracking-[0.2em]" style={{ color: captionColor }}>
+                  Elementy
+                </h4>
+                {pairs.map(pair => (
+                  <div
+                    key={`prompt-${pair.id}`}
+                    className="rounded-xl border px-4 py-3 text-sm"
+                    style={{
+                      backgroundColor: itemBackground,
+                      borderColor: itemBorder,
+                    }}
+                  >
+                    {pair.prompt}
+                  </div>
+                ))}
+              </div>
+              <div className="space-y-2">
+                <h4 className="text-xs font-semibold uppercase tracking-[0.2em]" style={{ color: captionColor }}>
+                  Odpowiedzi (przetasowane)
+                </h4>
+                {shuffledResponses.map(response => (
+                  <div
+                    key={`response-${response.id}`}
+                    className="rounded-xl border px-4 py-3 text-sm"
+                    style={{
+                      backgroundColor: itemBackground,
+                      borderColor: itemBorder,
+                    }}
+                  >
+                    {response.text}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </TaskTileSection>
+
+        <div className="flex flex-col items-center gap-2 pt-2">
+          <ValidateButton
+            state="idle"
+            disabled
+            onClick={() => {}}
+            colors={validateButtonColors}
+            labels={{ idle: 'Sprawdź odpowiedź', success: 'Dobrze!', error: 'Spróbuj ponownie' }}
+          />
+          <p className="text-xs text-center" style={{ color: captionColor }}>
+            Podgląd przycisku walidacji — interakcja będzie dostępna w wersji uczniowskiej.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/admin/tiles/open/Renderer.tsx
+++ b/src/components/admin/tiles/open/Renderer.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { OpenTile } from '../../../../types/lessonEditor';
+import { createRichTextAdapter, type RichTextEditorProps } from '../RichTextEditor.tsx';
+import { BaseTileRendererProps, getReadableTextColor } from '../shared';
+import { OpenInteractive } from './Interactive';
+
+export const OpenTileRenderer: React.FC<BaseTileRendererProps<OpenTile>> = ({
+  tile,
+  isSelected,
+  isEditingText,
+  isTestingMode,
+  onUpdateTile,
+  onFinishTextEditing,
+  onEditorReady,
+  onDoubleClick,
+  backgroundColor,
+  showBorder,
+}) => {
+  const openTile = tile;
+  const textColor = getReadableTextColor(openTile.content.backgroundColor || backgroundColor);
+
+  const wrapperStyle: React.CSSProperties = {
+    borderRadius: 'inherit',
+    backgroundColor,
+    border: showBorder ? '1px solid rgba(0, 0, 0, 0.08)' : 'none',
+  };
+
+  const renderOpenTile = (
+    instructionEditorProps?: RichTextEditorProps,
+    isPreviewMode = false,
+  ) => (
+    <OpenInteractive
+      tile={openTile}
+      isTestingMode={isTestingMode}
+      instructionEditorProps={instructionEditorProps}
+      isPreview={isPreviewMode}
+      onRequestTextEditing={isPreviewMode ? undefined : onDoubleClick}
+    />
+  );
+
+  if (isEditingText && isSelected) {
+    const instructionAdapter = createRichTextAdapter({
+      source: openTile.content,
+      fields: {
+        text: 'instruction',
+        richText: 'richInstruction',
+        fontFamily: 'fontFamily',
+        fontSize: 'fontSize',
+        verticalAlign: 'verticalAlign',
+      },
+      defaults: {
+        backgroundColor: openTile.content.backgroundColor,
+        showBorder: openTile.content.showBorder,
+      },
+    });
+
+    return (
+      <div className="w-full h-full overflow-hidden" style={wrapperStyle}>
+        {renderOpenTile(
+          {
+            content: instructionAdapter.content,
+            onChange: (updatedContent) => {
+              onUpdateTile(tile.id, {
+                content: instructionAdapter.applyChanges(updatedContent),
+              });
+            },
+            onFinish: onFinishTextEditing,
+            onEditorReady,
+            textColor,
+          },
+          true,
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full h-full overflow-hidden" style={wrapperStyle}>
+      {renderOpenTile()}
+    </div>
+  );
+};

--- a/src/components/admin/tiles/open/index.ts
+++ b/src/components/admin/tiles/open/index.ts
@@ -1,0 +1,2 @@
+export { OpenTileRenderer } from './Renderer';
+export { OpenInteractive } from './Interactive';

--- a/src/hooks/useLessonContentManager.ts
+++ b/src/hooks/useLessonContentManager.ts
@@ -5,7 +5,8 @@ import {
   LessonTile,
   ProgrammingTile,
   SequencingTile,
-  TextTile
+  TextTile,
+  OpenTile
 } from '../types/lessonEditor';
 import { GridUtils } from '../utils/gridUtils';
 import { logger } from '../utils/logger';
@@ -21,15 +22,22 @@ const tileFactoryMap: Record<LessonTile['type'], TileFactory> = {
   quiz: (position, page) => LessonContentService.createQuizTile(position, page),
   programming: (position, page) => LessonContentService.createProgrammingTile(position, page),
   sequencing: (position, page) => LessonContentService.createSequencingTile(position, page),
-  blanks: (position, page) => LessonContentService.createBlanksTile(position, page)
+  blanks: (position, page) => LessonContentService.createBlanksTile(position, page),
+  open: (position, page) => LessonContentService.createOpenTile(position, page)
 };
 
 const isRichTextTile = (
   tile: LessonTile | null
-): tile is TextTile | ProgrammingTile | SequencingTile | BlanksTile => {
+): tile is TextTile | ProgrammingTile | SequencingTile | BlanksTile | OpenTile => {
   return (
     !!tile &&
-    (tile.type === 'text' || tile.type === 'programming' || tile.type === 'sequencing' || tile.type === 'blanks')
+    (
+      tile.type === 'text' ||
+      tile.type === 'programming' ||
+      tile.type === 'sequencing' ||
+      tile.type === 'blanks' ||
+      tile.type === 'open'
+    )
   );
 };
 
@@ -254,7 +262,13 @@ export const useLessonContentManager = ({
           };
 
           if (
-            (tile.type === 'text' || tile.type === 'programming' || tile.type === 'sequencing' || tile.type === 'blanks') &&
+            (
+              tile.type === 'text' ||
+              tile.type === 'programming' ||
+              tile.type === 'sequencing' ||
+              tile.type === 'blanks' ||
+              tile.type === 'open'
+            ) &&
             updates.content
           ) {
             updatedTile.content = {

--- a/src/hooks/useTileInteractions.ts
+++ b/src/hooks/useTileInteractions.ts
@@ -33,7 +33,8 @@ export const useTileInteractions = ({
       tile.type === 'text' ||
       tile.type === 'programming' ||
       tile.type === 'sequencing' ||
-      tile.type === 'quiz'
+      tile.type === 'quiz' ||
+      tile.type === 'open'
     ) {
       dispatch({ type: 'startTextEditing', tileId: tile.id });
     } else if (tile.type === 'image') {

--- a/src/services/lessonContentService.ts
+++ b/src/services/lessonContentService.ts
@@ -253,17 +253,15 @@ export class LessonContentService {
         backgroundColor: '#d4d4d4',
         showBorder: true,
         expectedFormat: "['napis1', 'napis2', 'napis3']",
+        correctAnswer: "['napis1', 'napis2', 'napis3']",
+        ignoreCase: true,
+        ignoreWhitespace: true,
         attachments: [
           {
             id: 'attachment-instrukcja',
             name: 'instrukcja.pdf',
             description: 'Zawiera szczegółowe wymagania do zadania.'
           }
-        ],
-        pairs: [
-          { id: 'pair-1', prompt: 'Pole 1', response: 'napis1' },
-          { id: 'pair-2', prompt: 'Pole 2', response: 'napis2' },
-          { id: 'pair-3', prompt: 'Pole 3', response: 'napis3' }
         ]
       }
     };

--- a/src/services/lessonContentService.ts
+++ b/src/services/lessonContentService.ts
@@ -5,6 +5,7 @@ import {
   ProgrammingTile,
   SequencingTile,
   BlanksTile,
+  OpenTile,
   CanvasSettings,
   GridPosition
 } from '../types/lessonEditor';
@@ -230,6 +231,39 @@ export class LessonContentService {
           { id: 'auto-warszawa-1', text: 'Warszawa', isAuto: true },
           { id: 'auto-bialo-czerwona-flaga-2', text: 'biało-czerwona flaga', isAuto: true },
           { id: 'distractor-wisla', text: 'Wisła', isAuto: false }
+        ]
+      }
+    };
+  }
+
+  /**
+   * Create a new open answer tile
+   */
+  static createOpenTile(position: { x: number; y: number }, page = 1): OpenTile {
+    const base = this.initializeTileBase('open', position, page, { colSpan: 4, rowSpan: 4 });
+
+    return {
+      ...base,
+      content: {
+        instruction: 'Odpowiedz na pytanie w formacie opisanym poniżej.',
+        richInstruction: '<p style="margin: 0;">Odpowiedz na pytanie w formacie opisanym poniżej.</p>',
+        fontFamily: 'Inter, system-ui, sans-serif',
+        fontSize: 16,
+        verticalAlign: 'top',
+        backgroundColor: '#d4d4d4',
+        showBorder: true,
+        expectedFormat: "['napis1', 'napis2', 'napis3']",
+        attachments: [
+          {
+            id: 'attachment-instrukcja',
+            name: 'instrukcja.pdf',
+            description: 'Zawiera szczegółowe wymagania do zadania.'
+          }
+        ],
+        pairs: [
+          { id: 'pair-1', prompt: 'Pole 1', response: 'napis1' },
+          { id: 'pair-2', prompt: 'Pole 2', response: 'napis2' },
+          { id: 'pair-3', prompt: 'Pole 3', response: 'napis3' }
         ]
       }
     };

--- a/src/types/lessonEditor.ts
+++ b/src/types/lessonEditor.ts
@@ -166,16 +166,14 @@ export interface OpenTile extends LessonTile {
     backgroundColor: string;
     showBorder: boolean;
     expectedFormat: string;
+    correctAnswer: string;
+    ignoreCase: boolean;
+    ignoreWhitespace: boolean;
     attachments: Array<{
       id: string;
       name: string;
       description?: string;
       url?: string;
-    }>;
-    pairs: Array<{
-      id: string;
-      prompt: string;
-      response: string;
     }>;
   };
 }

--- a/src/types/lessonEditor.ts
+++ b/src/types/lessonEditor.ts
@@ -17,7 +17,15 @@ export interface GridPosition {
 
 export interface LessonTile {
   id: string;
-  type: 'text' | 'image' | 'visualization' | 'quiz' | 'programming' | 'sequencing' | 'blanks';
+  type:
+    | 'text'
+    | 'image'
+    | 'visualization'
+    | 'quiz'
+    | 'programming'
+    | 'sequencing'
+    | 'blanks'
+    | 'open';
   position: Position;
   size: Size;
   gridPosition: GridPosition;
@@ -143,6 +151,31 @@ export interface BlanksTile extends LessonTile {
       id: string;
       text: string;
       isAuto?: boolean;
+    }>;
+  };
+}
+
+export interface OpenTile extends LessonTile {
+  type: 'open';
+  content: {
+    instruction: string;
+    richInstruction?: string;
+    fontFamily: string;
+    fontSize: number;
+    verticalAlign: 'top' | 'center' | 'bottom';
+    backgroundColor: string;
+    showBorder: boolean;
+    expectedFormat: string;
+    attachments: Array<{
+      id: string;
+      name: string;
+      description?: string;
+      url?: string;
+    }>;
+    pairs: Array<{
+      id: string;
+      prompt: string;
+      response: string;
     }>;
   };
 }


### PR DESCRIPTION
## Summary
- add the new `open` lesson tile type with schema, default factory content, and editor wiring so it can be created and edited like existing task tiles
- surface the tile in the palette, renderer, toolbar, and interaction hooks so instructions can be edited and the tile can be moved/deleted like other blocks
- implement the open tile renderer/interactive preview that shows instructions, optional attachments, example pairs, a disabled answer field, and a preview validate button

## Testing
- `npm run lint` *(fails: existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dec23f61dc83218805e3672aa75e67