### PR TITLE
feat: add editor support for open task tile

### DIFF
--- a/src/components/admin/editor side/OpenEditor.tsx
+++ b/src/components/admin/editor side/OpenEditor.tsx
@@ -1,0 +1,222 @@
+import React from 'react';
+import { Plus, Trash2, Paperclip, Shuffle } from 'lucide-react';
+import { LessonTile, OpenTile } from '../../../types/lessonEditor.ts';
+
+interface OpenEditorProps {
+  tile: OpenTile;
+  onUpdateTile: (tileId: string, updates: Partial<LessonTile>) => void;
+}
+
+export const OpenEditor: React.FC<OpenEditorProps> = ({ tile, onUpdateTile }) => {
+  const attachments = tile.content.attachments ?? [];
+  const pairs = tile.content.pairs ?? [];
+
+  const handleContentUpdate = (field: keyof OpenTile['content'], value: OpenTile['content'][typeof field]) => {
+    onUpdateTile(tile.id, {
+      content: {
+        ...tile.content,
+        [field]: value
+      },
+      updated_at: new Date().toISOString()
+    });
+  };
+
+  const handleAttachmentChange = (attachmentId: string, field: 'name' | 'url', value: string) => {
+    const updated = attachments.map(attachment =>
+      attachment.id === attachmentId ? { ...attachment, [field]: value } : attachment
+    );
+    handleContentUpdate('attachments', updated);
+  };
+
+  const handleRemoveAttachment = (attachmentId: string) => {
+    const updated = attachments.filter(attachment => attachment.id !== attachmentId);
+    handleContentUpdate('attachments', updated);
+  };
+
+  const handleAddAttachment = () => {
+    const newAttachment = {
+      id: `attachment-${Date.now()}`,
+      name: `Załącznik ${attachments.length + 1}`,
+      url: ''
+    };
+    handleContentUpdate('attachments', [...attachments, newAttachment]);
+  };
+
+  const handlePairChange = (pairId: string, field: 'prompt' | 'answer', value: string) => {
+    const updatedPairs = pairs.map(pair =>
+      pair.id === pairId ? { ...pair, [field]: value } : pair
+    );
+    handleContentUpdate('pairs', updatedPairs);
+  };
+
+  const handleRemovePair = (pairId: string) => {
+    const updatedPairs = pairs.filter(pair => pair.id !== pairId);
+    handleContentUpdate('pairs', updatedPairs);
+  };
+
+  const handleAddPair = () => {
+    const newPair = {
+      id: `pair-${Date.now()}`,
+      prompt: `Przykładowe wejście ${pairs.length + 1}`,
+      answer: `Przykładowa odpowiedź ${pairs.length + 1}`
+    };
+    handleContentUpdate('pairs', [...pairs, newPair]);
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-3">Kolor tła kafelka</label>
+        <input
+          type="color"
+          value={tile.content.backgroundColor}
+          onChange={(event) => handleContentUpdate('backgroundColor', event.target.value)}
+          className="w-full h-12 border border-gray-300 rounded-lg cursor-pointer"
+        />
+      </div>
+
+      <div>
+        <label className="flex items-center space-x-3 p-4 bg-gray-50 rounded-lg">
+          <input
+            type="checkbox"
+            checked={tile.content.showBorder}
+            onChange={(event) => handleContentUpdate('showBorder', event.target.checked)}
+            className="w-5 h-5 text-blue-600"
+          />
+          <div>
+            <span className="text-sm font-medium text-gray-900">Pokaż obramowanie kafelka</span>
+            <p className="text-xs text-gray-600 mt-1">
+              Gdy wyłączone, kafelek wtopi się w tło bez dodatkowej ramki.
+            </p>
+          </div>
+        </label>
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-2">
+          Opis oczekiwanego formatu odpowiedzi
+        </label>
+        <textarea
+          value={tile.content.expectedFormat}
+          onChange={(event) => handleContentUpdate('expectedFormat', event.target.value)}
+          rows={3}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm"
+          placeholder="np. oczekiwany format: ['napis1', 'napis2', 'napis3']"
+        />
+      </div>
+
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2 text-sm font-semibold text-gray-900">
+            <Paperclip className="w-4 h-4" />
+            <span>Materiały do pobrania</span>
+          </div>
+          <button
+            type="button"
+            onClick={handleAddAttachment}
+            className="inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-blue-50 text-blue-600 text-sm font-medium hover:bg-blue-100 transition"
+          >
+            <Plus className="w-4 h-4" />
+            Dodaj
+          </button>
+        </div>
+
+        {attachments.length === 0 ? (
+          <p className="text-sm text-gray-600">
+            Dodaj pliki, które uczniowie będą mogli pobrać przed rozpoczęciem zadania.
+          </p>
+        ) : (
+          <div className="space-y-3">
+            {attachments.map(attachment => (
+              <div key={attachment.id} className="border border-gray-200 rounded-xl p-4 bg-gray-50 space-y-3">
+                <div className="flex flex-col gap-3">
+                  <div className="flex items-center gap-3">
+                    <input
+                      type="text"
+                      value={attachment.name}
+                      onChange={(event) => handleAttachmentChange(attachment.id, 'name', event.target.value)}
+                      className="flex-1 px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm"
+                      placeholder="Nazwa pliku"
+                    />
+                    <button
+                      type="button"
+                      onClick={() => handleRemoveAttachment(attachment.id)}
+                      className="inline-flex items-center justify-center text-rose-600 hover:bg-rose-50 p-2 rounded-lg"
+                    >
+                      <Trash2 className="w-4 h-4" />
+                    </button>
+                  </div>
+                  <input
+                    type="text"
+                    value={attachment.url}
+                    onChange={(event) => handleAttachmentChange(attachment.id, 'url', event.target.value)}
+                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm"
+                    placeholder="Adres URL lub ścieżka do pliku"
+                  />
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2 text-sm font-semibold text-gray-900">
+            <Shuffle className="w-4 h-4" />
+            <span>Przykładowe pary do walidacji</span>
+          </div>
+          <button
+            type="button"
+            onClick={handleAddPair}
+            className="inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-blue-50 text-blue-600 text-sm font-medium hover:bg-blue-100 transition"
+          >
+            <Plus className="w-4 h-4" />
+            Dodaj parę
+          </button>
+        </div>
+
+        {pairs.length === 0 ? (
+          <p className="text-sm text-gray-600">
+            Dodaj przykładowe pary wejść i oczekiwanych odpowiedzi. W podglądzie kafelka zostaną one automatycznie przemieszane.
+          </p>
+        ) : (
+          <div className="space-y-3">
+            {pairs.map(pair => (
+              <div key={pair.id} className="border border-gray-200 rounded-xl p-4 bg-gray-50 space-y-3">
+                <div className="flex flex-col gap-3">
+                  <input
+                    type="text"
+                    value={pair.prompt}
+                    onChange={(event) => handlePairChange(pair.id, 'prompt', event.target.value)}
+                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm"
+                    placeholder="Opis wejścia"
+                  />
+                  <input
+                    type="text"
+                    value={pair.answer}
+                    onChange={(event) => handlePairChange(pair.id, 'answer', event.target.value)}
+                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm"
+                    placeholder="Oczekiwana odpowiedź"
+                  />
+                  <div className="flex justify-end">
+                    <button
+                      type="button"
+                      onClick={() => handleRemovePair(pair.id)}
+                      className="inline-flex items-center justify-center text-rose-600 hover:bg-rose-50 px-3 py-1 rounded-lg text-sm"
+                    >
+                      <Trash2 className="w-4 h-4 mr-1" />
+                      Usuń
+                    </button>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default OpenEditor;

--- a/src/components/admin/editor side/TilePalette.tsx
+++ b/src/components/admin/editor side/TilePalette.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Type, Image, Puzzle, Eye, HelpCircle, Plus, Code, ArrowUpDown } from 'lucide-react';
+import { Type, Image, Puzzle, Eye, HelpCircle, Plus, Code, ArrowUpDown, PenSquare } from 'lucide-react';
 import { TilePaletteItem } from '../../../types/lessonEditor.ts';
 
 interface TilePaletteProps {
@@ -42,6 +42,11 @@ const TILE_TYPES: TilePaletteItem[] = [
     type: 'blanks',
     title: 'Uzupełnij luki',
     icon: 'Puzzle'
+  },
+  {
+    type: 'open',
+    title: 'Zadanie otwarte',
+    icon: 'PenSquare'
   }
 ];
 
@@ -54,6 +59,7 @@ const getIcon = (iconName: string) => {
     case 'HelpCircle': return HelpCircle;
     case 'Code': return Code;
     case 'ArrowUpDown': return ArrowUpDown;
+    case 'PenSquare': return PenSquare;
     default: return Type;
   }
 };

--- a/src/components/admin/editor side/TileSideEditor.tsx
+++ b/src/components/admin/editor side/TileSideEditor.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
-import { Plus, Trash2, Type, X, Image as ImageIcon, Eye, HelpCircle, Code, ArrowUpDown, Puzzle } from 'lucide-react';
-import { TextTile, ImageTile, LessonTile, ProgrammingTile, SequencingTile, QuizTile, BlanksTile } from '../../../types/lessonEditor.ts';
+import { Plus, Trash2, Type, X, Image as ImageIcon, Eye, HelpCircle, Code, ArrowUpDown, Puzzle, PenSquare } from 'lucide-react';
+import { TextTile, ImageTile, LessonTile, ProgrammingTile, SequencingTile, QuizTile, BlanksTile, OpenTile } from '../../../types/lessonEditor.ts';
 import { ImageUploadComponent } from './ImageUploadComponent.tsx';
 import { ImagePositionControl } from './ImagePositionControl.tsx';
 import { SequencingEditor } from './SequencingEditor.tsx';
+import { OpenEditor } from './OpenEditor.tsx';
 import { extractPlaceholdersFromTemplate } from '../../../utils/blanks.ts';
 
 interface TileSideEditorProps {
@@ -93,6 +94,7 @@ export const TileSideEditor: React.FC<TileSideEditorProps> = ({
       case 'programming': return Code;
       case 'sequencing': return ArrowUpDown;
       case 'blanks': return Puzzle;
+      case 'open': return PenSquare;
       default: return Type;
     }
   };
@@ -262,6 +264,16 @@ export const TileSideEditor: React.FC<TileSideEditorProps> = ({
             onUpdateTile={onUpdateTile}
             isTesting={isTesting}
             onToggleTesting={onToggleTesting}
+          />
+        );
+      }
+
+      case 'open': {
+        const openTile = tile as OpenTile;
+        return (
+          <OpenEditor
+            tile={openTile}
+            onUpdateTile={onUpdateTile}
           />
         );
       }

--- a/src/components/admin/editor top/TopToolbar.tsx
+++ b/src/components/admin/editor top/TopToolbar.tsx
@@ -5,14 +5,14 @@ import { FontSizeSelector } from './FontSizeSelector.tsx';
 import { TextColorPicker } from './TextColorPicker.tsx';
 import { FontSelector } from './FontSelector.tsx';
 import { AlignmentControls } from './AlignmentControls.tsx';
-import { LessonTile, ProgrammingTile, TextTile, SequencingTile } from '../../../types/lessonEditor.ts';
+import { LessonTile, ProgrammingTile, TextTile, SequencingTile, OpenTile } from '../../../types/lessonEditor.ts';
 
 
 interface TopToolbarProps {
   isTextEditing: boolean;
   onFinishTextEditing?: () => void;
   editor?: Editor | null;
-  selectedTile?: TextTile | ProgrammingTile | SequencingTile | null;
+  selectedTile?: TextTile | ProgrammingTile | SequencingTile | OpenTile | null;
   onUpdateTile?: (tileId: string, updates: Partial<LessonTile>) => void;
   currentPage?: number;
   totalPages?: number;
@@ -69,7 +69,7 @@ export const TopToolbar: React.FC<TopToolbarProps> = ({
   }, [editor]);
 
   useEffect(() => {
-    if (selectedTile?.type === 'text' || selectedTile?.type === 'sequencing') {
+    if (selectedTile?.type === 'text' || selectedTile?.type === 'sequencing' || selectedTile?.type === 'open') {
       setVerticalAlign(selectedTile.content.verticalAlign || 'top');
     }
   }, [selectedTile]);

--- a/src/components/admin/tiles/TileRenderer.tsx
+++ b/src/components/admin/tiles/TileRenderer.tsx
@@ -9,6 +9,7 @@ import { ProgrammingTileRenderer} from "./programming/Renderer.tsx";
 import { QuizTileRenderer } from './quiz';
 import { SequencingTileRenderer } from './sequencing';
 import { TextTileRenderer} from "./text/Renderer.tsx";
+import { OpenTileRenderer } from './open';
 
 interface TileRendererProps {
   tile: LessonTile;
@@ -35,6 +36,7 @@ const TILE_RENDERERS: Partial<Record<LessonTile['type'], React.ComponentType<any
   quiz: QuizTileRenderer,
   sequencing: SequencingTileRenderer,
   blanks: BlanksTileRenderer,
+  open: OpenTileRenderer,
 };
 
 export const TileRenderer: React.FC<TileRendererProps> = ({
@@ -81,7 +83,9 @@ export const TileRenderer: React.FC<TileRendererProps> = ({
   };
 
   const handleDoubleClick =
-    tile.type === 'sequencing' || tile.type === 'blanks' ? undefined : onDoubleClick;
+    tile.type === 'sequencing' || tile.type === 'blanks' || tile.type === 'open'
+      ? undefined
+      : onDoubleClick;
 
 
   return (

--- a/src/components/admin/tiles/open/Interactive.tsx
+++ b/src/components/admin/tiles/open/Interactive.tsx
@@ -1,0 +1,367 @@
+import React, { useCallback, useMemo } from 'react';
+import { FileText, Paperclip, Sparkles, Shuffle, ListChecks } from 'lucide-react';
+import { OpenTile } from '../../../../types/lessonEditor';
+import { getReadableTextColor, lightenColor, darkenColor } from '../../../../utils/colorUtils';
+import {
+  createSurfacePalette,
+  createValidateButtonPalette
+} from '../../../../utils/surfacePalette.ts';
+import { TaskInstructionPanel } from '../TaskInstructionPanel.tsx';
+import { TaskTileSection } from '../TaskTileSection.tsx';
+import { RichTextEditor, RichTextEditorProps } from '../RichTextEditor.tsx';
+import {
+  ValidateButton,
+  ValidateButtonColors,
+  ValidateButtonState
+} from '../../../common/ValidateButton.tsx';
+
+interface OpenInteractiveProps {
+  tile: OpenTile;
+  isPreview?: boolean;
+  isTestingMode?: boolean;
+  onRequestTextEditing?: () => void;
+  instructionEditorProps?: RichTextEditorProps;
+}
+
+interface PairItem {
+  id: string;
+  text: string;
+}
+
+const stableShuffle = <T,>(items: T[], seed: string): T[] => {
+  const hash = (value: string) => {
+    let h = 0;
+    for (let i = 0; i < value.length; i += 1) {
+      h = Math.imul(31, h) + value.charCodeAt(i);
+    }
+    return Math.abs(h);
+  };
+
+  return items
+    .map((item, index) => ({
+      item,
+      weight: hash(`${seed}-${index}-${JSON.stringify(item)}`),
+      index
+    }))
+    .sort((a, b) => (a.weight - b.weight) || (a.index - b.index))
+    .map(entry => entry.item);
+};
+
+export const OpenInteractive: React.FC<OpenInteractiveProps> = ({
+  tile,
+  onRequestTextEditing,
+  instructionEditorProps
+}) => {
+  const accentColor = tile.content.backgroundColor || '#0f172a';
+  const textColor = useMemo(() => getReadableTextColor(accentColor), [accentColor]);
+  const gradientStart = useMemo(() => lightenColor(accentColor, 0.06), [accentColor]);
+  const gradientEnd = useMemo(() => darkenColor(accentColor, 0.06), [accentColor]);
+  const {
+    frameBorderColor,
+    panelBackground,
+    panelBorder,
+    iconBackground,
+    sectionBackground,
+    sectionBorder,
+    attachmentBackground,
+    attachmentBorder,
+    pairCardBackground,
+    pairCardBorder,
+    formatBackground,
+    formatBorder
+  } = useMemo(
+    () =>
+      createSurfacePalette(accentColor, textColor, {
+        frameBorderColor: { lighten: 0.5, darken: 0.6 },
+        panelBackground: { lighten: 0.64, darken: 0.45 },
+        panelBorder: { lighten: 0.52, darken: 0.52 },
+        iconBackground: { lighten: 0.56, darken: 0.48 },
+        sectionBackground: { lighten: 0.66, darken: 0.38 },
+        sectionBorder: { lighten: 0.5, darken: 0.5 },
+        attachmentBackground: { lighten: 0.72, darken: 0.34 },
+        attachmentBorder: { lighten: 0.56, darken: 0.46 },
+        pairCardBackground: { lighten: 0.7, darken: 0.3 },
+        pairCardBorder: { lighten: 0.54, darken: 0.46 },
+        formatBackground: { lighten: 0.78, darken: 0.28 },
+        formatBorder: { lighten: 0.58, darken: 0.42 }
+      }),
+    [accentColor, textColor]
+  );
+  const mutedLabelColor = textColor === '#0f172a' ? '#475569' : '#dbeafe';
+  const secondaryTextColor = textColor === '#0f172a' ? '#1f2937' : '#e2e8f0';
+  const captionColor = textColor === '#0f172a' ? '#64748b' : '#dbeafe';
+
+  const attachments = tile.content.attachments ?? [];
+  const pairs = tile.content.pairs ?? [];
+
+  const leftItems = useMemo<PairItem[]>(
+    () => stableShuffle(
+      pairs.map(pair => ({ id: pair.id, text: pair.prompt })),
+      `${tile.id}-left`
+    ),
+    [pairs, tile.id]
+  );
+  const rightItems = useMemo<PairItem[]>(
+    () => stableShuffle(
+      pairs.map(pair => ({ id: pair.id, text: pair.answer })),
+      `${tile.id}-right`
+    ),
+    [pairs, tile.id]
+  );
+
+  const validateButtonColors = useMemo<ValidateButtonColors>(
+    () =>
+      createValidateButtonPalette(accentColor, textColor, {
+        idle: {
+          background: textColor === '#0f172a' ? darkenColor(accentColor, 0.18) : lightenColor(accentColor, 0.24),
+          color: textColor === '#0f172a' ? '#f8fafc' : '#0f172a',
+          border: 'transparent'
+        }
+      }),
+    [accentColor, textColor]
+  );
+
+  const validateButtonLabels = useMemo(
+    () => ({
+      idle: (
+        <>
+          <Sparkles className="h-5 w-5" aria-hidden="true" />
+          <span>Podgląd walidacji</span>
+        </>
+      ),
+      success: (
+        <>
+          <span aria-hidden="true">✅</span>
+          <span>Dobrze!</span>
+        </>
+      ),
+      error: (
+        <>
+          <span aria-hidden="true">⚠️</span>
+          <span>Niepoprawne</span>
+        </>
+      )
+    }),
+    []
+  );
+
+  const validationState: ValidateButtonState = 'idle';
+
+  const expectedFormat = (tile.content.expectedFormat || '').trim();
+
+  const handleTileDoubleClick = useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      if (instructionEditorProps) {
+        return;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      onRequestTextEditing?.();
+    },
+    [instructionEditorProps, onRequestTextEditing]
+  );
+
+  return (
+    <div className="relative w-full h-full" onDoubleClick={handleTileDoubleClick}>
+      <div
+        className="w-full h-full flex flex-col gap-6 p-6"
+        style={{
+          borderRadius: 'inherit',
+          color: textColor,
+          backgroundColor: 'transparent',
+          backgroundImage: `linear-gradient(135deg, ${gradientStart}, ${gradientEnd})`,
+          border: tile.content.showBorder !== false ? `1px solid ${frameBorderColor}` : 'none',
+          boxShadow: tile.content.showBorder !== false ? '0 24px 48px rgba(15, 23, 42, 0.22)' : 'none'
+        }}
+      >
+        <TaskInstructionPanel
+          icon={<FileText className="w-4 h-4" />}
+          label="Zadanie"
+          className="border"
+          style={{
+            backgroundColor: panelBackground,
+            borderColor: panelBorder,
+            color: textColor
+          }}
+          iconWrapperClassName="w-9 h-9 rounded-xl flex items-center justify-center shadow-sm"
+          iconWrapperStyle={{
+            backgroundColor: iconBackground,
+            color: textColor
+          }}
+          labelStyle={{ color: mutedLabelColor }}
+          bodyClassName="px-5 pb-5"
+        >
+          {instructionEditorProps ? (
+            <RichTextEditor {...instructionEditorProps} />
+          ) : (
+            <div
+              className="text-base leading-relaxed"
+              style={{
+                fontFamily: tile.content.fontFamily,
+                fontSize: `${tile.content.fontSize}px`
+              }}
+              dangerouslySetInnerHTML={{
+                __html: tile.content.richInstruction || tile.content.instruction
+              }}
+            />
+          )}
+        </TaskInstructionPanel>
+
+        <TaskTileSection
+          className="border"
+          style={{
+            backgroundColor: sectionBackground,
+            borderColor: sectionBorder,
+            color: textColor
+          }}
+          icon={<Paperclip className="w-4 h-4" />}
+          title="Materiały do pobrania"
+          titleStyle={{ color: mutedLabelColor }}
+          contentClassName="px-5 py-4 space-y-3"
+        >
+          {attachments.length === 0 ? (
+            <p className="text-sm" style={{ color: captionColor }}>
+              Brak dodatkowych plików do pobrania.
+            </p>
+          ) : (
+            <div className="grid gap-3 sm:grid-cols-2">
+              {attachments.map(attachment => (
+                <div
+                  key={attachment.id}
+                  className="flex items-center gap-3 rounded-xl border px-4 py-3 text-sm"
+                  style={{
+                    backgroundColor: attachmentBackground,
+                    borderColor: attachmentBorder,
+                    color: secondaryTextColor
+                  }}
+                >
+                  <Paperclip className="h-4 w-4" aria-hidden="true" />
+                  <div className="flex flex-col">
+                    <span className="font-medium" style={{ color: textColor }}>
+                      {attachment.name || 'Bez nazwy'}
+                    </span>
+                    <span className="text-xs" style={{ color: captionColor }}>
+                      {attachment.url || 'Podgląd adresu pliku'}
+                    </span>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </TaskTileSection>
+
+        <TaskTileSection
+          className="border"
+          style={{
+            backgroundColor: sectionBackground,
+            borderColor: sectionBorder,
+            color: textColor
+          }}
+          icon={<ListChecks className="w-4 h-4" />}
+          title="Odpowiedź ucznia"
+          titleStyle={{ color: mutedLabelColor }}
+          contentClassName="px-5 py-4 space-y-4"
+        >
+          <div
+            className="rounded-xl border px-4 py-3 text-sm"
+            style={{
+              backgroundColor: formatBackground,
+              borderColor: formatBorder,
+              color: secondaryTextColor
+            }}
+          >
+            {expectedFormat ? expectedFormat : 'Oczekiwany format odpowiedzi zostanie ustawiony w edytorze bocznym.'}
+          </div>
+          <div className="space-y-2">
+            <label className="text-xs font-semibold uppercase tracking-wide" style={{ color: mutedLabelColor }}>
+              Pole odpowiedzi (podgląd)
+            </label>
+            <textarea
+              disabled
+              placeholder="Miejsce na odpowiedź ucznia (podgląd)"
+              className="w-full rounded-xl border border-dashed border-slate-400/40 bg-white/60 px-3 py-2 text-sm text-slate-500"
+              style={{
+                cursor: 'not-allowed',
+                resize: 'vertical',
+                minHeight: '96px'
+              }}
+            />
+            <p className="text-xs" style={{ color: captionColor }}>
+              Pole odpowiedzi zostanie aktywowane w widoku ucznia.
+            </p>
+          </div>
+        </TaskTileSection>
+
+        <TaskTileSection
+          className="border"
+          style={{
+            backgroundColor: sectionBackground,
+            borderColor: sectionBorder,
+            color: textColor
+          }}
+          icon={<Shuffle className="w-4 h-4" />}
+          title="Przykładowe pary walidacyjne"
+          titleStyle={{ color: mutedLabelColor }}
+          contentClassName="px-5 py-4"
+        >
+          {pairs.length === 0 ? (
+            <p className="text-sm" style={{ color: captionColor }}>
+              Dodaj pary w panelu bocznym, aby zobaczyć przykładowe dane testowe.
+            </p>
+          ) : (
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="space-y-3">
+                <h4 className="text-xs font-semibold uppercase tracking-wide" style={{ color: mutedLabelColor }}>
+                  Wejścia
+                </h4>
+                {leftItems.map(item => (
+                  <div
+                    key={item.id}
+                    className="rounded-xl border px-4 py-3 text-sm font-medium"
+                    style={{
+                      backgroundColor: pairCardBackground,
+                      borderColor: pairCardBorder,
+                      color: secondaryTextColor
+                    }}
+                  >
+                    {item.text || 'Przykładowe wejście'}
+                  </div>
+                ))}
+              </div>
+              <div className="space-y-3">
+                <h4 className="text-xs font-semibold uppercase tracking-wide" style={{ color: mutedLabelColor }}>
+                  Oczekiwane odpowiedzi
+                </h4>
+                {rightItems.map(item => (
+                  <div
+                    key={item.id}
+                    className="rounded-xl border px-4 py-3 text-sm font-medium"
+                    style={{
+                      backgroundColor: pairCardBackground,
+                      borderColor: pairCardBorder,
+                      color: secondaryTextColor
+                    }}
+                  >
+                    {item.text || 'Przykładowa odpowiedź'}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </TaskTileSection>
+
+        <div className="flex justify-center pt-2">
+          <ValidateButton
+            state={validationState}
+            onClick={() => {}}
+            disabled
+            colors={validateButtonColors}
+            labels={validateButtonLabels}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default OpenInteractive;

--- a/src/components/admin/tiles/open/Renderer.tsx
+++ b/src/components/admin/tiles/open/Renderer.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { OpenTile } from '../../../../types/lessonEditor';
+import { createRichTextAdapter, type RichTextEditorProps } from '../RichTextEditor.tsx';
+import { BaseTileRendererProps, getReadableTextColor } from '../shared';
+import { OpenInteractive } from './Interactive';
+
+export const OpenTileRenderer: React.FC<BaseTileRendererProps<OpenTile>> = ({
+  tile,
+  isSelected,
+  isEditingText,
+  isTestingMode,
+  onUpdateTile,
+  onFinishTextEditing,
+  onEditorReady,
+  onDoubleClick,
+  backgroundColor,
+  showBorder,
+}) => {
+  const openTile = tile;
+  const textColor = getReadableTextColor(openTile.content.backgroundColor || backgroundColor);
+
+  const wrapperStyle: React.CSSProperties = {
+    borderRadius: 'inherit',
+    backgroundColor,
+    border: showBorder ? '1px solid rgba(0, 0, 0, 0.08)' : 'none',
+  };
+
+  const renderOpenTile = (
+    instructionEditorProps?: RichTextEditorProps,
+    isPreviewMode = false,
+  ) => (
+    <OpenInteractive
+      tile={openTile}
+      isTestingMode={isTestingMode}
+      instructionEditorProps={instructionEditorProps}
+      isPreview={isPreviewMode}
+      onRequestTextEditing={isPreviewMode ? undefined : onDoubleClick}
+    />
+  );
+
+  if (isEditingText && isSelected) {
+    const instructionAdapter = createRichTextAdapter({
+      source: openTile.content,
+      fields: {
+        text: 'instruction',
+        richText: 'richInstruction',
+        fontFamily: 'fontFamily',
+        fontSize: 'fontSize',
+        verticalAlign: 'verticalAlign',
+      },
+      defaults: {
+        backgroundColor: openTile.content.backgroundColor,
+        showBorder: openTile.content.showBorder,
+      },
+    });
+
+    return (
+      <div className="w-full h-full overflow-hidden" style={wrapperStyle}>
+        {renderOpenTile(
+          {
+            content: instructionAdapter.content,
+            onChange: (updatedContent) => {
+              onUpdateTile(tile.id, {
+                content: instructionAdapter.applyChanges(updatedContent),
+              });
+            },
+            onFinish: onFinishTextEditing,
+            onEditorReady,
+            textColor,
+          },
+          true,
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full h-full overflow-hidden" style={wrapperStyle}>
+      {renderOpenTile()}
+    </div>
+  );
+};

--- a/src/components/admin/tiles/open/index.ts
+++ b/src/components/admin/tiles/open/index.ts
@@ -1,0 +1,2 @@
+export { OpenTileRenderer } from './Renderer';
+export { OpenInteractive } from './Interactive';

--- a/src/hooks/useLessonContentManager.ts
+++ b/src/hooks/useLessonContentManager.ts
@@ -5,7 +5,8 @@ import {
   LessonTile,
   ProgrammingTile,
   SequencingTile,
-  TextTile
+  TextTile,
+  OpenTile
 } from '../types/lessonEditor';
 import { GridUtils } from '../utils/gridUtils';
 import { logger } from '../utils/logger';
@@ -21,15 +22,16 @@ const tileFactoryMap: Record<LessonTile['type'], TileFactory> = {
   quiz: (position, page) => LessonContentService.createQuizTile(position, page),
   programming: (position, page) => LessonContentService.createProgrammingTile(position, page),
   sequencing: (position, page) => LessonContentService.createSequencingTile(position, page),
-  blanks: (position, page) => LessonContentService.createBlanksTile(position, page)
+  blanks: (position, page) => LessonContentService.createBlanksTile(position, page),
+  open: (position, page) => LessonContentService.createOpenTile(position, page)
 };
 
 const isRichTextTile = (
   tile: LessonTile | null
-): tile is TextTile | ProgrammingTile | SequencingTile | BlanksTile => {
+): tile is TextTile | ProgrammingTile | SequencingTile | BlanksTile | OpenTile => {
   return (
     !!tile &&
-    (tile.type === 'text' || tile.type === 'programming' || tile.type === 'sequencing' || tile.type === 'blanks')
+    (tile.type === 'text' || tile.type === 'programming' || tile.type === 'sequencing' || tile.type === 'blanks' || tile.type === 'open')
   );
 };
 
@@ -254,7 +256,13 @@ export const useLessonContentManager = ({
           };
 
           if (
-            (tile.type === 'text' || tile.type === 'programming' || tile.type === 'sequencing' || tile.type === 'blanks') &&
+            (
+              tile.type === 'text' ||
+              tile.type === 'programming' ||
+              tile.type === 'sequencing' ||
+              tile.type === 'blanks' ||
+              tile.type === 'open'
+            ) &&
             updates.content
           ) {
             updatedTile.content = {

--- a/src/services/lessonContentService.ts
+++ b/src/services/lessonContentService.ts
@@ -5,6 +5,7 @@ import {
   ProgrammingTile,
   SequencingTile,
   BlanksTile,
+  OpenTile,
   CanvasSettings,
   GridPosition
 } from '../types/lessonEditor';
@@ -205,6 +206,46 @@ export class LessonContentService {
         ],
         correctFeedback: 'Świetnie! Prawidłowa kolejność.',
         incorrectFeedback: 'Spróbuj ponownie. Sprawdź kolejność elementów.'
+      }
+    };
+  }
+
+  /**
+   * Create a new open task tile
+   */
+  static createOpenTile(position: { x: number; y: number }, page = 1): OpenTile {
+    const base = this.initializeTileBase('open', position, page, { colSpan: 4, rowSpan: 4 });
+
+    return {
+      ...base,
+      content: {
+        instruction: 'Przeczytaj polecenie i przygotuj odpowiedź.',
+        richInstruction: '<p style="margin: 0;">Przeczytaj polecenie i przygotuj odpowiedź.</p>',
+        fontFamily: 'Inter, system-ui, sans-serif',
+        fontSize: 16,
+        verticalAlign: 'top',
+        backgroundColor: '#d4d4d4',
+        showBorder: true,
+        expectedFormat: "Oczekiwany format: ['element1', 'element2', 'element3']",
+        attachments: [
+          {
+            id: 'attachment-1',
+            name: 'instrukcja.pdf',
+            url: '#'
+          }
+        ],
+        pairs: [
+          {
+            id: 'pair-1',
+            prompt: 'Przykładowe wejście 1',
+            answer: 'Przykładowa odpowiedź 1'
+          },
+          {
+            id: 'pair-2',
+            prompt: 'Przykładowe wejście 2',
+            answer: 'Przykładowa odpowiedź 2'
+          }
+        ]
       }
     };
   }

--- a/src/types/lessonEditor.ts
+++ b/src/types/lessonEditor.ts
@@ -17,7 +17,7 @@ export interface GridPosition {
 
 export interface LessonTile {
   id: string;
-  type: 'text' | 'image' | 'visualization' | 'quiz' | 'programming' | 'sequencing' | 'blanks';
+  type: 'text' | 'image' | 'visualization' | 'quiz' | 'programming' | 'sequencing' | 'blanks' | 'open';
   position: Position;
   size: Size;
   gridPosition: GridPosition;
@@ -125,6 +125,30 @@ export interface SequencingTile extends LessonTile {
     }>;
     correctFeedback: string;
     incorrectFeedback: string;
+  };
+}
+
+export interface OpenTile extends LessonTile {
+  type: 'open';
+  content: {
+    instruction: string;
+    richInstruction?: string;
+    fontFamily: string;
+    fontSize: number;
+    verticalAlign: 'top' | 'center' | 'bottom';
+    backgroundColor: string;
+    showBorder: boolean;
+    expectedFormat: string;
+    attachments: Array<{
+      id: string;
+      name: string;
+      url: string;
+    }>;
+    pairs: Array<{
+      id: string;
+      prompt: string;
+      answer: string;
+    }>;
   };
 }
 


### PR DESCRIPTION
## Summary
- introduce an open task tile type with preview UI, palette registration, and renderer wiring
- add a dedicated side editor that manages background, attachments, format hint, and validation pairs
- extend lesson services, type definitions, and toolbar handling to persist open tile content

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dec23f61dc83218805e3672aa75e67