### PR TITLE
Add open answer tile for lesson editor

### DIFF
--- a/src/components/admin/editor side/TilePalette.tsx
+++ b/src/components/admin/editor side/TilePalette.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Type, Image, Puzzle, Eye, HelpCircle, Plus, Code, ArrowUpDown } from 'lucide-react';
+import { Type, Image, Puzzle, Eye, HelpCircle, Plus, Code, ArrowUpDown, NotebookPen } from 'lucide-react';
 import { TilePaletteItem } from '../../../types/lessonEditor.ts';
 
 interface TilePaletteProps {
@@ -33,7 +33,7 @@ const TILE_TYPES: TilePaletteItem[] = [
     title: 'Zadanie programistyczne',
     icon: 'Code'
   },
-  {
+  { 
     type: 'sequencing',
     title: 'Ćwiczenie sekwencyjne',
     icon: 'ArrowUpDown'
@@ -42,6 +42,11 @@ const TILE_TYPES: TilePaletteItem[] = [
     type: 'blanks',
     title: 'Uzupełnij luki',
     icon: 'Puzzle'
+  },
+  {
+    type: 'open',
+    title: 'Odpowiedź otwarta',
+    icon: 'NotebookPen'
   }
 ];
 
@@ -54,6 +59,7 @@ const getIcon = (iconName: string) => {
     case 'HelpCircle': return HelpCircle;
     case 'Code': return Code;
     case 'ArrowUpDown': return ArrowUpDown;
+    case 'NotebookPen': return NotebookPen;
     default: return Type;
   }
 };

--- a/src/components/admin/editor side/TileSideEditor.tsx
+++ b/src/components/admin/editor side/TileSideEditor.tsx
@@ -1,6 +1,29 @@
 import React from 'react';
-import { Plus, Trash2, Type, X, Image as ImageIcon, Eye, HelpCircle, Code, ArrowUpDown, Puzzle } from 'lucide-react';
-import { TextTile, ImageTile, LessonTile, ProgrammingTile, SequencingTile, QuizTile, BlanksTile } from '../../../types/lessonEditor.ts';
+import {
+  Plus,
+  Trash2,
+  Type,
+  X,
+  Image as ImageIcon,
+  Eye,
+  HelpCircle,
+  Code,
+  ArrowUpDown,
+  Puzzle,
+  NotebookPen,
+  Paperclip,
+  Shuffle
+} from 'lucide-react';
+import {
+  TextTile,
+  ImageTile,
+  LessonTile,
+  ProgrammingTile,
+  SequencingTile,
+  QuizTile,
+  BlanksTile,
+  OpenTile
+} from '../../../types/lessonEditor.ts';
 import { ImageUploadComponent } from './ImageUploadComponent.tsx';
 import { ImagePositionControl } from './ImagePositionControl.tsx';
 import { SequencingEditor } from './SequencingEditor.tsx';
@@ -93,6 +116,7 @@ export const TileSideEditor: React.FC<TileSideEditorProps> = ({
       case 'programming': return Code;
       case 'sequencing': return ArrowUpDown;
       case 'blanks': return Puzzle;
+      case 'open': return NotebookPen;
       default: return Type;
     }
   };
@@ -418,6 +442,282 @@ export const TileSideEditor: React.FC<TileSideEditorProps> = ({
 
                 )}
               </div>
+            </div>
+          </div>
+        );
+      }
+
+      case 'open': {
+        const openTile = tile as OpenTile;
+
+        const updateContent = (updates: Partial<OpenTile['content']>) => {
+          onUpdateTile(tile.id, {
+            content: {
+              ...openTile.content,
+              ...updates
+            },
+            updated_at: new Date().toISOString()
+          });
+        };
+
+        const handleAttachmentFieldChange = (
+          attachmentId: string,
+          field: 'name' | 'description' | 'url',
+          value: string
+        ) => {
+          const attachments = openTile.content.attachments.map(attachment =>
+            attachment.id === attachmentId
+              ? { ...attachment, [field]: value }
+              : attachment
+          );
+
+          updateContent({ attachments });
+        };
+
+        const handleAddAttachment = () => {
+          const newAttachmentId = `attachment-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
+          updateContent({
+            attachments: [
+              ...openTile.content.attachments,
+              {
+                id: newAttachmentId,
+                name: `Nowy plik ${openTile.content.attachments.length + 1}`,
+                description: '',
+                url: ''
+              }
+            ]
+          });
+        };
+
+        const handleRemoveAttachment = (attachmentId: string) => {
+          updateContent({
+            attachments: openTile.content.attachments.filter(attachment => attachment.id !== attachmentId)
+          });
+        };
+
+        const handlePairChange = (
+          pairId: string,
+          field: 'prompt' | 'response',
+          value: string
+        ) => {
+          const pairs = openTile.content.pairs.map(pair =>
+            pair.id === pairId
+              ? { ...pair, [field]: value }
+              : pair
+          );
+
+          updateContent({ pairs });
+        };
+
+        const handleAddPair = () => {
+          const newPairId = `pair-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
+          updateContent({
+            pairs: [
+              ...openTile.content.pairs,
+              {
+                id: newPairId,
+                prompt: `Element ${openTile.content.pairs.length + 1}`,
+                response: 'Opis elementu'
+              }
+            ]
+          });
+        };
+
+        const handleRemovePair = (pairId: string) => {
+          updateContent({ pairs: openTile.content.pairs.filter(pair => pair.id !== pairId) });
+        };
+
+        return (
+          <div className="space-y-6">
+            <div className="grid grid-cols-1 gap-4">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-3">Kolor tła kafelka</label>
+                <input
+                  type="color"
+                  value={openTile.content.backgroundColor}
+                  onChange={(e) => updateContent({ backgroundColor: e.target.value })}
+                  className="w-full h-12 border border-gray-300 rounded-lg cursor-pointer"
+                />
+              </div>
+
+              <label className="flex items-center space-x-3 p-4 bg-gray-50 rounded-lg">
+                <input
+                  type="checkbox"
+                  checked={openTile.content.showBorder}
+                  onChange={(e) => updateContent({ showBorder: e.target.checked })}
+                  className="w-5 h-5 text-blue-600"
+                />
+                <div>
+                  <span className="text-sm font-medium text-gray-900">Pokaż obramowanie kafelka</span>
+                  <p className="text-xs text-gray-600 mt-1">
+                    Obramowanie pomaga odróżnić kafelek od tła lekcji.
+                  </p>
+                </div>
+              </label>
+            </div>
+
+            <div className="grid grid-cols-1 gap-4">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-2">Oczekiwany format odpowiedzi</label>
+                <textarea
+                  value={openTile.content.expectedFormat}
+                  onChange={(e) => updateContent({ expectedFormat: e.target.value })}
+                  rows={3}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm font-mono"
+                  placeholder="np. ['napis1', 'napis2', 'napis3']"
+                />
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-2">Tekst w polu odpowiedzi</label>
+                <input
+                  type="text"
+                  value={openTile.content.answerPlaceholder}
+                  onChange={(e) => updateContent({ answerPlaceholder: e.target.value })}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm"
+                  placeholder="Opis widoczny w wyłączonym polu odpowiedzi"
+                />
+              </div>
+            </div>
+
+            <div className="space-y-4">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-2 text-sm font-semibold text-gray-900">
+                  <Paperclip className="w-4 h-4" />
+                  Pliki do pobrania
+                </div>
+                <button
+                  type="button"
+                  onClick={handleAddAttachment}
+                  className="inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-blue-50 text-blue-600 text-sm font-medium hover:bg-blue-100 transition"
+                >
+                  <Plus className="w-4 h-4" />
+                  Dodaj plik
+                </button>
+              </div>
+
+              {openTile.content.attachments.length === 0 ? (
+                <p className="text-sm text-gray-600">
+                  Dodaj materiały, które uczeń będzie mógł pobrać przed rozwiązaniem zadania.
+                </p>
+              ) : (
+                <div className="space-y-4">
+                  {openTile.content.attachments.map(attachment => (
+                    <div key={attachment.id} className="border border-gray-200 rounded-xl p-4 bg-gray-50 space-y-3">
+                      <div className="flex items-center justify-between">
+                        <div className="flex items-center gap-2 text-sm font-medium text-gray-900">
+                          <NotebookPen className="w-4 h-4 text-blue-600" />
+                          <span>{attachment.name}</span>
+                        </div>
+                        <button
+                          type="button"
+                          onClick={() => handleRemoveAttachment(attachment.id)}
+                          className="p-2 text-gray-400 hover:text-red-500 transition"
+                          aria-label="Usuń plik"
+                        >
+                          <Trash2 className="w-4 h-4" />
+                        </button>
+                      </div>
+
+                      <div className="grid grid-cols-1 gap-3">
+                        <div>
+                          <label className="block text-xs font-medium text-gray-600 mb-1">Nazwa wyświetlana</label>
+                          <input
+                            type="text"
+                            value={attachment.name}
+                            onChange={(e) => handleAttachmentFieldChange(attachment.id, 'name', e.target.value)}
+                            className="w-full px-3 py-2 border border-gray-200 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm"
+                          />
+                        </div>
+                        <div>
+                          <label className="block text-xs font-medium text-gray-600 mb-1">Opis</label>
+                          <input
+                            type="text"
+                            value={attachment.description || ''}
+                            onChange={(e) => handleAttachmentFieldChange(attachment.id, 'description', e.target.value)}
+                            className="w-full px-3 py-2 border border-gray-200 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm"
+                            placeholder="Krótki opis pliku"
+                          />
+                        </div>
+                        <div>
+                          <label className="block text-xs font-medium text-gray-600 mb-1">Adres URL</label>
+                          <input
+                            type="url"
+                            value={attachment.url || ''}
+                            onChange={(e) => handleAttachmentFieldChange(attachment.id, 'url', e.target.value)}
+                            className="w-full px-3 py-2 border border-gray-200 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm"
+                            placeholder="https://..."
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            <div className="space-y-4">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-2 text-sm font-semibold text-gray-900">
+                  <Shuffle className="w-4 h-4" />
+                  Pary kontekstowe
+                </div>
+                <button
+                  type="button"
+                  onClick={handleAddPair}
+                  className="inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-blue-50 text-blue-600 text-sm font-medium hover:bg-blue-100 transition"
+                >
+                  <Plus className="w-4 h-4" />
+                  Dodaj parę
+                </button>
+              </div>
+
+              {openTile.content.pairs.length === 0 ? (
+                <p className="text-sm text-gray-600">
+                  Dodaj pary informacji, które pojawią się w kafelku jako wskazówki dla ucznia.
+                </p>
+              ) : (
+                <div className="space-y-4">
+                  {openTile.content.pairs.map((pair, index) => (
+                    <div key={pair.id} className="border border-gray-200 rounded-xl p-4 bg-gray-50 space-y-3">
+                      <div className="flex items-center justify-between">
+                        <span className="text-sm font-medium text-gray-900">Para {index + 1}</span>
+                        <button
+                          type="button"
+                          onClick={() => handleRemovePair(pair.id)}
+                          className="p-2 text-gray-400 hover:text-red-500 transition"
+                          aria-label="Usuń parę"
+                        >
+                          <Trash2 className="w-4 h-4" />
+                        </button>
+                      </div>
+
+                      <div className="grid grid-cols-1 gap-3">
+                        <div>
+                          <label className="block text-xs font-medium text-gray-600 mb-1">Lewy element</label>
+                          <input
+                            type="text"
+                            value={pair.prompt}
+                            onChange={(e) => handlePairChange(pair.id, 'prompt', e.target.value)}
+                            className="w-full px-3 py-2 border border-gray-200 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm"
+                            placeholder="np. Nazwa pola"
+                          />
+                        </div>
+                        <div>
+                          <label className="block text-xs font-medium text-gray-600 mb-1">Prawy element</label>
+                          <input
+                            type="text"
+                            value={pair.response}
+                            onChange={(e) => handlePairChange(pair.id, 'response', e.target.value)}
+                            className="w-full px-3 py-2 border border-gray-200 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm"
+                            placeholder="np. Wartość oczekiwana"
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
             </div>
           </div>
         );

--- a/src/components/admin/tiles/TileRenderer.tsx
+++ b/src/components/admin/tiles/TileRenderer.tsx
@@ -8,6 +8,7 @@ import { ImageTileRenderer } from './image';
 import { ProgrammingTileRenderer} from "./programming/Renderer.tsx";
 import { QuizTileRenderer } from './quiz';
 import { SequencingTileRenderer } from './sequencing';
+import { OpenTileRenderer } from './open';
 import { TextTileRenderer} from "./text/Renderer.tsx";
 
 interface TileRendererProps {
@@ -35,6 +36,7 @@ const TILE_RENDERERS: Partial<Record<LessonTile['type'], React.ComponentType<any
   quiz: QuizTileRenderer,
   sequencing: SequencingTileRenderer,
   blanks: BlanksTileRenderer,
+  open: OpenTileRenderer,
 };
 
 export const TileRenderer: React.FC<TileRendererProps> = ({

--- a/src/components/admin/tiles/open/Interactive.tsx
+++ b/src/components/admin/tiles/open/Interactive.tsx
@@ -1,0 +1,323 @@
+import React, { useMemo } from 'react';
+import { NotebookPen, Download, Paperclip, Shuffle, Info } from 'lucide-react';
+import { OpenTile } from '../../../../types/lessonEditor.ts';
+import { TaskInstructionPanel } from '../TaskInstructionPanel.tsx';
+import { TaskTileSection } from '../TaskTileSection.tsx';
+import { RichTextEditor, type RichTextEditorProps } from '../RichTextEditor.tsx';
+import { ValidateButton } from '../../../common/ValidateButton.tsx';
+import { getReadableTextColor, surfaceColor } from '../shared.ts';
+import { createSurfacePalette, createValidateButtonPalette } from '../../../../utils/surfacePalette.ts';
+
+interface OpenInteractiveProps {
+  tile: OpenTile;
+  isPreview?: boolean;
+  onRequestTextEditing?: () => void;
+  instructionEditorProps?: RichTextEditorProps;
+}
+
+export const OpenInteractive: React.FC<OpenInteractiveProps> = ({
+  tile,
+  onRequestTextEditing,
+  instructionEditorProps
+}) => {
+  const accentColor = tile.content.backgroundColor || '#0f172a';
+  const textColor = useMemo(() => getReadableTextColor(accentColor), [accentColor]);
+  const mutedLabelColor = textColor === '#0f172a' ? '#475569' : '#dbeafe';
+  const subtleCaptionColor = textColor === '#0f172a' ? '#64748b' : '#e2e8f0';
+
+  const surfaces = useMemo(
+    () =>
+      createSurfacePalette(accentColor, textColor, {
+        frameBorder: { lighten: 0.5, darken: 0.6 },
+        panelBackground: { lighten: 0.64, darken: 0.42 },
+        panelBorder: { lighten: 0.5, darken: 0.58 },
+        iconBackground: { lighten: 0.58, darken: 0.46 },
+        sectionBackground: { lighten: 0.7, darken: 0.36 },
+        sectionBorder: { lighten: 0.54, darken: 0.56 },
+        cardBackground: { lighten: 0.78, darken: 0.28 },
+        cardBorder: { lighten: 0.62, darken: 0.5 },
+        inputBackground: { lighten: 0.82, darken: 0.24 },
+        inputBorder: { lighten: 0.62, darken: 0.5 },
+        badgeBackground: { lighten: 0.74, darken: 0.32 },
+        badgeBorder: { lighten: 0.6, darken: 0.44 }
+      }),
+    [accentColor, textColor]
+  );
+
+  const validateButtonColors = useMemo(
+    () => createValidateButtonPalette(accentColor, textColor),
+    [accentColor, textColor]
+  );
+
+  const attachments = useMemo(() => tile.content.attachments ?? [], [tile.content.attachments]);
+  const pairs = useMemo(() => tile.content.pairs ?? [], [tile.content.pairs]);
+  const expectedFormat = tile.content.expectedFormat?.trim().length
+    ? tile.content.expectedFormat
+    : "['napis1', 'napis2', 'napis3']";
+  const answerPlaceholder = tile.content.answerPlaceholder || 'Odpowiedź ucznia pojawi się tutaj...';
+
+  const shuffledRightColumn = useMemo(() => {
+    if (pairs.length <= 1) {
+      return [...pairs];
+    }
+
+    const [, ...rest] = pairs;
+    return [...rest, pairs[0]];
+  }, [pairs]);
+
+  const containerStyle: React.CSSProperties = {
+    borderRadius: 'inherit',
+    backgroundColor: tile.content.backgroundColor || '#ffffff',
+    border:
+      tile.content.showBorder === false
+        ? 'none'
+        : `1px solid ${surfaces.frameBorder}`,
+    color: textColor
+  };
+
+  const renderInstructionContent = () => {
+    if (instructionEditorProps) {
+      return (
+        <RichTextEditor
+          content={instructionEditorProps.content}
+          onChange={instructionEditorProps.onChange}
+          onFinish={instructionEditorProps.onFinish}
+          onEditorReady={instructionEditorProps.onEditorReady}
+          textColor={instructionEditorProps.textColor ?? textColor}
+        />
+      );
+    }
+
+    return (
+      <div
+        className="text-sm leading-relaxed space-y-2"
+        style={{
+          fontFamily: tile.content.fontFamily,
+          fontSize: `${tile.content.fontSize}px`
+        }}
+        onDoubleClick={onRequestTextEditing}
+        role="textbox"
+        tabIndex={0}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter' && event.metaKey) {
+            onRequestTextEditing?.();
+          }
+        }}
+        dangerouslySetInnerHTML={{
+          __html: tile.content.richInstruction || tile.content.instruction
+        }}
+      />
+    );
+  };
+
+  return (
+    <div className="w-full h-full overflow-hidden" style={containerStyle}>
+      <div className="w-full h-full flex flex-col gap-5 p-5">
+        <TaskInstructionPanel
+          icon={<NotebookPen className="w-4 h-4" />}
+          label="Instrukcja"
+          className="border transition-colors duration-300"
+          style={{
+            backgroundColor: surfaces.panelBackground,
+            color: textColor,
+            borderColor: surfaces.panelBorder
+          }}
+          iconWrapperStyle={{
+            backgroundColor: surfaces.iconBackground,
+            color: textColor
+          }}
+          labelStyle={{ color: mutedLabelColor }}
+          bodyClassName="px-5 pb-5 text-sm leading-relaxed space-y-3"
+        >
+          {renderInstructionContent()}
+        </TaskInstructionPanel>
+
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 flex-1 min-h-0">
+          <TaskTileSection
+            className="h-full"
+            style={{
+              backgroundColor: surfaces.sectionBackground,
+              borderColor: surfaces.sectionBorder,
+              color: textColor
+            }}
+            icon={<Paperclip className="w-4 h-4" />}
+            title="Materiały do pobrania"
+            headerClassName="px-5 py-4 border-b"
+            headerStyle={{ borderColor: surfaces.sectionBorder, color: mutedLabelColor }}
+            titleStyle={{ color: mutedLabelColor }}
+            contentClassName="px-5 py-4 space-y-3 overflow-auto"
+          >
+            {attachments.length === 0 ? (
+              <div className="text-sm" style={{ color: subtleCaptionColor }}>
+                Brak dodatkowych materiałów. Dodaj pliki w panelu edycji, jeśli zadanie tego wymaga.
+              </div>
+            ) : (
+              attachments.map((attachment) => (
+                <div
+                  key={attachment.id}
+                  className="rounded-xl border px-4 py-3 flex items-center justify-between gap-3"
+                  style={{
+                    backgroundColor: surfaces.cardBackground,
+                    borderColor: surfaces.cardBorder
+                  }}
+                >
+                  <div className="flex flex-col">
+                    <span className="text-sm font-semibold" style={{ color: textColor }}>
+                      {attachment.name}
+                    </span>
+                    {attachment.description ? (
+                      <span className="text-xs" style={{ color: subtleCaptionColor }}>
+                        {attachment.description}
+                      </span>
+                    ) : null}
+                  </div>
+                  <button
+                    type="button"
+                    disabled
+                    className="inline-flex items-center gap-2 px-3 py-2 rounded-lg border text-xs font-medium opacity-70"
+                    style={{
+                      borderColor: surfaces.cardBorder,
+                      color: subtleCaptionColor,
+                      cursor: 'not-allowed'
+                    }}
+                  >
+                    <Download className="w-4 h-4" />
+                    Pobierz
+                  </button>
+                </div>
+              ))
+            )}
+          </TaskTileSection>
+
+          <TaskTileSection
+            className="h-full"
+            style={{
+              backgroundColor: surfaces.sectionBackground,
+              borderColor: surfaces.sectionBorder,
+              color: textColor
+            }}
+            icon={<Shuffle className="w-4 h-4" />}
+            title="Pary kontekstowe"
+            headerClassName="px-5 py-4 border-b"
+            headerStyle={{ borderColor: surfaces.sectionBorder, color: mutedLabelColor }}
+            titleStyle={{ color: mutedLabelColor }}
+            contentClassName="px-5 py-4 flex flex-col gap-4 overflow-auto"
+          >
+            {pairs.length === 0 ? (
+              <div className="text-sm" style={{ color: subtleCaptionColor }}>
+                Dodaj pary w panelu edycji, aby zaprezentować uczniowi dodatkowe informacje lub podpowiedzi.
+              </div>
+            ) : (
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                <div className="space-y-3">
+                  {pairs.map((pair, index) => (
+                    <div
+                      key={`left-${pair.id}`}
+                      className="rounded-xl border px-4 py-3"
+                      style={{
+                        backgroundColor: surfaces.cardBackground,
+                        borderColor: surfaces.cardBorder
+                      }}
+                    >
+                      <span className="text-xs font-semibold" style={{ color: mutedLabelColor }}>
+                        Lewa kolumna {index + 1}
+                      </span>
+                      <div className="text-sm font-medium" style={{ color: textColor }}>
+                        {pair.prompt}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+                <div className="space-y-3">
+                  {shuffledRightColumn.map((pair, index) => (
+                    <div
+                      key={`right-${pair.id}`}
+                      className="rounded-xl border px-4 py-3"
+                      style={{
+                        backgroundColor: surfaces.cardBackground,
+                        borderColor: surfaces.cardBorder
+                      }}
+                    >
+                      <span className="text-xs font-semibold" style={{ color: mutedLabelColor }}>
+                        Prawa kolumna {index + 1}
+                      </span>
+                      <div className="text-sm font-medium" style={{ color: textColor }}>
+                        {pair.response}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </TaskTileSection>
+        </div>
+
+        <TaskTileSection
+          className="rounded-2xl"
+          style={{
+            backgroundColor: surfaceColor(accentColor, textColor, 0.76, 0.3),
+            borderColor: surfaces.sectionBorder,
+            color: textColor
+          }}
+          icon={<Info className="w-4 h-4" />}
+          title="Odpowiedź ucznia"
+          headerClassName="px-5 py-4 border-b"
+          headerStyle={{ borderColor: surfaces.sectionBorder, color: mutedLabelColor }}
+          titleStyle={{ color: mutedLabelColor }}
+          contentClassName="px-5 py-4 space-y-3"
+        >
+          <div>
+            <span className="text-xs font-semibold uppercase tracking-wide" style={{ color: subtleCaptionColor }}>
+              Oczekiwany format
+            </span>
+          <pre
+            className="mt-2 px-3 py-2 rounded-lg border text-xs overflow-x-auto"
+            style={{
+              backgroundColor: surfaces.inputBackground,
+              borderColor: surfaces.inputBorder,
+              color: textColor
+            }}
+          >
+            {expectedFormat}
+          </pre>
+          </div>
+
+          <textarea
+            disabled
+            className="w-full min-h-[120px] px-4 py-3 rounded-xl border text-sm resize-none"
+            style={{
+              backgroundColor: surfaces.inputBackground,
+              borderColor: surfaces.inputBorder,
+              color: textColor,
+              cursor: 'not-allowed'
+            }}
+            placeholder={answerPlaceholder}
+          />
+
+          <p className="text-xs" style={{ color: subtleCaptionColor }}>
+            Pole odpowiedzi jest wyłączone w podglądzie edytora. Uczeń wypełni je w wersji uczniowskiej platformy.
+          </p>
+        </TaskTileSection>
+
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 pt-1">
+          <ValidateButton
+            state="idle"
+            onClick={() => undefined}
+            disabled
+            colors={validateButtonColors}
+            labels={{
+              idle: 'Sprawdź odpowiedź',
+              success: 'Dobrze!',
+              error: 'Spróbuj ponownie'
+            }}
+          />
+          <span className="text-xs" style={{ color: subtleCaptionColor }}>
+            Przyciski interakcji są dostępne po stronie ucznia. W edytorze służą jedynie do podglądu układu.
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default OpenInteractive;

--- a/src/components/admin/tiles/open/Renderer.tsx
+++ b/src/components/admin/tiles/open/Renderer.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { OpenTile } from '../../../../types/lessonEditor.ts';
+import { createRichTextAdapter } from '../RichTextEditor.tsx';
+import { BaseTileRendererProps } from '../shared.ts';
+import { OpenInteractive } from './Interactive.tsx';
+
+export const OpenTileRenderer: React.FC<BaseTileRendererProps<OpenTile>> = ({
+  tile,
+  isSelected,
+  isEditingText,
+  onUpdateTile,
+  onFinishTextEditing,
+  onEditorReady,
+  onDoubleClick,
+  backgroundColor,
+}) => {
+  const openTile = tile;
+
+  const wrapperStyle: React.CSSProperties = {
+    borderRadius: 'inherit',
+    backgroundColor,
+    border: 'none',
+  };
+
+  if (isEditingText && isSelected) {
+    const instructionAdapter = createRichTextAdapter({
+      source: openTile.content,
+      fields: {
+        text: 'instruction',
+        richText: 'richInstruction',
+        fontFamily: 'fontFamily',
+        fontSize: 'fontSize',
+      },
+      defaults: {
+        backgroundColor: openTile.content.backgroundColor,
+        showBorder: openTile.content.showBorder,
+        verticalAlign: 'top',
+      },
+    });
+
+    return (
+      <div className="w-full h-full overflow-hidden" style={wrapperStyle}>
+        <OpenInteractive
+          tile={openTile}
+          instructionEditorProps={{
+            content: instructionAdapter.content,
+            onChange: (updatedContent) => {
+              onUpdateTile(tile.id, {
+                content: instructionAdapter.applyChanges(updatedContent),
+              });
+            },
+            onFinish: onFinishTextEditing,
+            onEditorReady,
+          }}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full h-full overflow-hidden" style={wrapperStyle}>
+      <OpenInteractive tile={openTile} onRequestTextEditing={onDoubleClick} />
+    </div>
+  );
+};
+
+export default OpenTileRenderer;

--- a/src/components/admin/tiles/open/index.ts
+++ b/src/components/admin/tiles/open/index.ts
@@ -1,0 +1,2 @@
+export { OpenTileRenderer } from './Renderer.tsx';
+export { OpenInteractive } from './Interactive.tsx';

--- a/src/hooks/useLessonContentManager.ts
+++ b/src/hooks/useLessonContentManager.ts
@@ -5,7 +5,8 @@ import {
   LessonTile,
   ProgrammingTile,
   SequencingTile,
-  TextTile
+  TextTile,
+  OpenTile
 } from '../types/lessonEditor';
 import { GridUtils } from '../utils/gridUtils';
 import { logger } from '../utils/logger';
@@ -21,15 +22,22 @@ const tileFactoryMap: Record<LessonTile['type'], TileFactory> = {
   quiz: (position, page) => LessonContentService.createQuizTile(position, page),
   programming: (position, page) => LessonContentService.createProgrammingTile(position, page),
   sequencing: (position, page) => LessonContentService.createSequencingTile(position, page),
-  blanks: (position, page) => LessonContentService.createBlanksTile(position, page)
+  blanks: (position, page) => LessonContentService.createBlanksTile(position, page),
+  open: (position, page) => LessonContentService.createOpenTile(position, page)
 };
 
 const isRichTextTile = (
   tile: LessonTile | null
-): tile is TextTile | ProgrammingTile | SequencingTile | BlanksTile => {
+): tile is TextTile | ProgrammingTile | SequencingTile | BlanksTile | OpenTile => {
   return (
     !!tile &&
-    (tile.type === 'text' || tile.type === 'programming' || tile.type === 'sequencing' || tile.type === 'blanks')
+    (
+      tile.type === 'text' ||
+      tile.type === 'programming' ||
+      tile.type === 'sequencing' ||
+      tile.type === 'blanks' ||
+      tile.type === 'open'
+    )
   );
 };
 
@@ -254,7 +262,13 @@ export const useLessonContentManager = ({
           };
 
           if (
-            (tile.type === 'text' || tile.type === 'programming' || tile.type === 'sequencing' || tile.type === 'blanks') &&
+            (
+              tile.type === 'text' ||
+              tile.type === 'programming' ||
+              tile.type === 'sequencing' ||
+              tile.type === 'blanks' ||
+              tile.type === 'open'
+            ) &&
             updates.content
           ) {
             updatedTile.content = {

--- a/src/hooks/useTileInteractions.ts
+++ b/src/hooks/useTileInteractions.ts
@@ -33,7 +33,8 @@ export const useTileInteractions = ({
       tile.type === 'text' ||
       tile.type === 'programming' ||
       tile.type === 'sequencing' ||
-      tile.type === 'quiz'
+      tile.type === 'quiz' ||
+      tile.type === 'open'
     ) {
       dispatch({ type: 'startTextEditing', tileId: tile.id });
     } else if (tile.type === 'image') {

--- a/src/services/lessonContentService.ts
+++ b/src/services/lessonContentService.ts
@@ -5,6 +5,7 @@ import {
   ProgrammingTile,
   SequencingTile,
   BlanksTile,
+  OpenTile,
   CanvasSettings,
   GridPosition
 } from '../types/lessonEditor';
@@ -205,6 +206,53 @@ export class LessonContentService {
         ],
         correctFeedback: 'Świetnie! Prawidłowa kolejność.',
         incorrectFeedback: 'Spróbuj ponownie. Sprawdź kolejność elementów.'
+      }
+    };
+  }
+
+  /**
+   * Create a new open task tile
+   */
+  static createOpenTile(position: { x: number; y: number }, page = 1): OpenTile {
+    const base = this.initializeTileBase('open', position, page, { colSpan: 5, rowSpan: 5 });
+
+    return {
+      ...base,
+      content: {
+        instruction: 'Przeczytaj polecenie i przygotuj odpowiedź.',
+        richInstruction: '<p style="margin: 0;">Przeczytaj polecenie i przygotuj odpowiedź.</p>',
+        fontFamily: 'Inter, system-ui, sans-serif',
+        fontSize: 16,
+        backgroundColor: '#d4d4d4',
+        showBorder: true,
+        expectedFormat: "['napis1', 'napis2', 'napis3']",
+        answerPlaceholder: 'Odpowiedź ucznia pojawi się tutaj... (pole jest wyłączone w podglądzie)',
+        attachments: [
+          {
+            id: 'attachment-instrukcja',
+            name: 'instrukcja.pdf',
+            description: 'Opis zadania do pobrania',
+            url: '#'
+          },
+          {
+            id: 'attachment-dane',
+            name: 'dane.csv',
+            description: 'Przykładowe dane wejściowe',
+            url: '#'
+          }
+        ],
+        pairs: [
+          {
+            id: 'pair-1',
+            prompt: 'Przykładowe wejście',
+            response: "['napis1', 'napis2', 'napis3']"
+          },
+          {
+            id: 'pair-2',
+            prompt: 'Przykładowe wyjście',
+            response: "['wynik1', 'wynik2']"
+          }
+        ]
       }
     };
   }

--- a/src/types/lessonEditor.ts
+++ b/src/types/lessonEditor.ts
@@ -17,7 +17,7 @@ export interface GridPosition {
 
 export interface LessonTile {
   id: string;
-  type: 'text' | 'image' | 'visualization' | 'quiz' | 'programming' | 'sequencing' | 'blanks';
+  type: 'text' | 'image' | 'visualization' | 'quiz' | 'programming' | 'sequencing' | 'blanks' | 'open';
   position: Position;
   size: Size;
   gridPosition: GridPosition;
@@ -143,6 +143,31 @@ export interface BlanksTile extends LessonTile {
       id: string;
       text: string;
       isAuto?: boolean;
+    }>;
+  };
+}
+
+export interface OpenTile extends LessonTile {
+  type: 'open';
+  content: {
+    instruction: string;
+    richInstruction?: string;
+    fontFamily: string;
+    fontSize: number;
+    backgroundColor: string;
+    showBorder: boolean;
+    expectedFormat: string;
+    answerPlaceholder: string;
+    attachments: Array<{
+      id: string;
+      name: string;
+      description?: string;
+      url?: string;
+    }>;
+    pairs: Array<{
+      id: string;
+      prompt: string;
+      response: string;
     }>;
   };
 }


### PR DESCRIPTION
## Summary
- introduce a new "open" task tile with instruction panel, attachment list, shuffled context pairs, disabled answer field and validate button preview
- expose the tile in the palette, renderer, and lesson content factory so editors can add and configure it
- extend the side editor controls to manage background color, attachments, expected format, and context pairs for open tasks

## Testing
- npm run lint *(fails: existing lint errors in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68dec23f61dc83218805e3672aa75e67