### PR TITLE
Improve open tile attachment editing and display

### DIFF
--- a/src/components/admin/editor side/TileSideEditor.tsx
+++ b/src/components/admin/editor side/TileSideEditor.tsx
@@ -487,7 +487,6 @@ export const TileSideEditor: React.FC<TileSideEditorProps> = ({
               {
                 id: newAttachmentId,
                 name: `Nowy plik ${attachments.length + 1}`,
-                description: '',
                 url: ''
               }
             ]
@@ -549,11 +548,11 @@ export const TileSideEditor: React.FC<TileSideEditorProps> = ({
                   {attachments.map(attachment => (
                     <div
                       key={attachment.id}
-                      className="border border-gray-200 rounded-xl p-4 bg-gray-50 space-y-3"
+                      className="border border-gray-200 rounded-xl p-4 bg-gray-50"
                     >
-                      <div className="grid grid-cols-1 gap-3">
-                        <div>
-                          <label className="block text-xs font-medium text-gray-600 mb-1">Nazwa pliku</label>
+                      <div className="grid grid-cols-1 gap-3 sm:grid-cols-[minmax(0,1fr)_minmax(0,1.4fr)_auto] sm:items-end">
+                        <div className="flex flex-col gap-1">
+                          <label className="text-xs font-medium text-gray-600">Nazwa pliku</label>
                           <input
                             type="text"
                             value={attachment.name}
@@ -562,38 +561,27 @@ export const TileSideEditor: React.FC<TileSideEditorProps> = ({
                             placeholder="np. instrukcja.pdf"
                           />
                         </div>
-                        <div>
-                          <label className="block text-xs font-medium text-gray-600 mb-1">Opis (opcjonalny)</label>
-                          <textarea
-                            value={attachment.description || ''}
-                            onChange={(e) => handleAttachmentChange(attachment.id, 'description', e.target.value)}
-                            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm"
-                            rows={2}
-                            placeholder="Krótki opis zawartości pliku"
-                          />
-                        </div>
-                        <div>
-                          <label className="block text-xs font-medium text-gray-600 mb-1">Adres URL (opcjonalny)</label>
+                        <div className="flex flex-col gap-1">
+                          <label className="text-xs font-medium text-gray-600">Adres URL</label>
                           <input
                             type="url"
-                            value={attachment.url || ''}
+                            required
+                            value={attachment.url ?? ''}
                             onChange={(e) => handleAttachmentChange(attachment.id, 'url', e.target.value)}
                             className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm"
                             placeholder="https://example.com/pliki/instrukcja.pdf"
                           />
                         </div>
-                      </div>
-
-                      <div className="flex justify-end">
                         <button
                           type="button"
                           onClick={() => handleRemoveAttachment(attachment.id)}
-                          className="inline-flex items-center gap-1 text-rose-600 hover:bg-rose-50 px-3 py-2 rounded-lg text-sm"
+                          className="inline-flex h-10 w-10 items-center justify-center self-start rounded-lg text-rose-600 transition hover:bg-rose-50 sm:self-end"
+                          aria-label="Usuń plik"
                         >
                           <Trash2 className="w-4 h-4" />
                         </button>
                       </div>
-                      </div>
+                    </div>
                   ))}
                 </div>
               )}

--- a/src/components/admin/editor side/TileSideEditor.tsx
+++ b/src/components/admin/editor side/TileSideEditor.tsx
@@ -486,7 +486,7 @@ export const TileSideEditor: React.FC<TileSideEditorProps> = ({
               ...attachments,
               {
                 id: newAttachmentId,
-                name: `Nowy plik ${attachments.length + 1}`,
+                name: '',
                 url: ''
               }
             ]
@@ -514,7 +514,67 @@ export const TileSideEditor: React.FC<TileSideEditorProps> = ({
                 className="w-full h-12 border border-gray-300 rounded-lg cursor-pointer"
               />
             </div>
-            
+
+            <div className="space-y-4">
+              <div className="flex items-center justify-between">
+                <h4 className="text-sm font-semibold text-gray-900">Pliki do pobrania</h4>
+                <button
+                    type="button"
+                    onClick={handleAddAttachment}
+                    className="inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-blue-50 text-blue-600 text-sm font-medium hover:bg-blue-100 transition"
+                >
+                  <Plus className="w-4 h-4" />
+                  Dodaj
+                </button>
+              </div>
+
+              {attachments.length === 0 ? (
+                  <p className="text-sm text-gray-600">
+                    Jeżeli to potrzebne, dodaj pliki, które uczeń będzie potrzebował do rozwiązania zadania.
+                  </p>
+              ) : (
+                  <div className="space-y-3">
+                    {attachments.map(attachment => (
+                        <div
+                            key={attachment.id}
+                            className="border border-gray-200 rounded-xl p-4 bg-gray-50"
+                        >
+                          <div className="grid grid-cols-[minmax(0,1fr)_auto] gap-3">
+                            <div className="flex flex-col gap-1">
+                              <input
+                                  type="text"
+                                  value={attachment.name}
+                                  onChange={(e) => handleAttachmentChange(attachment.id, 'name', e.target.value)}
+                                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm"
+                                  placeholder="np. instrukcja.pdf"
+                              />
+                            </div>
+                            <button
+                                type="button"
+                                onClick={() => handleRemoveAttachment(attachment.id)}
+                                className="inline-flex h-10 w-10 items-center justify-center self-start rounded-lg text-rose-600 transition hover:bg-rose-50"
+                                aria-label="Usuń plik"
+                            >
+                              <Trash2 className="w-4 h-4" />
+                            </button>
+
+                            <div className="flex flex-col gap-1 col-span-2">
+                              <input
+                                  type="url"
+                                  required
+                                  value={attachment.url ?? ''}
+                                  onChange={(e) => handleAttachmentChange(attachment.id, 'url', e.target.value)}
+                                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm"
+                                  placeholder="https://example.com/pliki/instrukcja.pdf"
+                              />
+                            </div>
+                          </div>
+                        </div>
+                    ))}
+                  </div>
+              )}
+            </div>
+
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-2">Oczekiwany format odpowiedzi</label>
               <textarea
@@ -524,67 +584,6 @@ export const TileSideEditor: React.FC<TileSideEditorProps> = ({
                 rows={3}
                 placeholder="np. ['napis1', 'napis2', 'napis3']"
               />
-            </div>
-
-            <div className="space-y-4">
-              <div className="flex items-center justify-between">
-                <h4 className="text-sm font-semibold text-gray-900">Pliki do pobrania</h4>
-                <button
-                  type="button"
-                  onClick={handleAddAttachment}
-                  className="inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-blue-50 text-blue-600 text-sm font-medium hover:bg-blue-100 transition"
-                >
-                  <Plus className="w-4 h-4" />
-                  Dodaj
-                </button>
-              </div>
-
-              {attachments.length === 0 ? (
-                <p className="text-sm text-gray-600">
-                  Jeżeli to potrzebne, dodaj pliki, które uczeń będzie potrzebował do rozwiązania zadania.
-                </p>
-              ) : (
-                <div className="space-y-3">
-                  {attachments.map(attachment => (
-                    <div
-                      key={attachment.id}
-                      className="border border-gray-200 rounded-xl p-4 bg-gray-50"
-                    >
-                      <div className="grid grid-cols-1 gap-3 sm:grid-cols-[minmax(0,1fr)_minmax(0,1.4fr)_auto] sm:items-end">
-                        <div className="flex flex-col gap-1">
-                          <label className="text-xs font-medium text-gray-600">Nazwa pliku</label>
-                          <input
-                            type="text"
-                            value={attachment.name}
-                            onChange={(e) => handleAttachmentChange(attachment.id, 'name', e.target.value)}
-                            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm"
-                            placeholder="np. instrukcja.pdf"
-                          />
-                        </div>
-                        <div className="flex flex-col gap-1">
-                          <label className="text-xs font-medium text-gray-600">Adres URL</label>
-                          <input
-                            type="url"
-                            required
-                            value={attachment.url ?? ''}
-                            onChange={(e) => handleAttachmentChange(attachment.id, 'url', e.target.value)}
-                            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm"
-                            placeholder="https://example.com/pliki/instrukcja.pdf"
-                          />
-                        </div>
-                        <button
-                          type="button"
-                          onClick={() => handleRemoveAttachment(attachment.id)}
-                          className="inline-flex h-10 w-10 items-center justify-center self-start rounded-lg text-rose-600 transition hover:bg-rose-50 sm:self-end"
-                          aria-label="Usuń plik"
-                        >
-                          <Trash2 className="w-4 h-4" />
-                        </button>
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              )}
             </div>
             
             <div className="space-y-3">
@@ -690,7 +689,7 @@ export const TileSideEditor: React.FC<TileSideEditorProps> = ({
                   className="inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-blue-50 text-blue-600 text-sm font-medium hover:bg-blue-100 transition"
                 >
                   <Plus className="w-4 h-4" />
-                  Dodaj parę
+                  Dodaj
                 </button>
               </div>
 
@@ -705,25 +704,8 @@ export const TileSideEditor: React.FC<TileSideEditorProps> = ({
                       key={pair.id}
                       className="border border-gray-200 rounded-xl p-4 bg-gray-50 space-y-4"
                     >
-                      <div className="flex items-center justify-between">
-                        <span className="text-xs font-semibold uppercase tracking-wider text-gray-500">
-                          Para {index + 1}
-                        </span>
-                        <button
-                          type="button"
-                          onClick={() => handleRemovePair(pair.id)}
-                          className="inline-flex items-center justify-center text-rose-600 hover:bg-rose-50 p-2 rounded-lg"
-                          aria-label={`Usuń parę ${index + 1}`}
-                        >
-                          <Trash2 className="w-4 h-4" />
-                        </button>
-                      </div>
-
-                      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-                        <div className="space-y-2">
-                          <label className="text-xs font-medium text-gray-600 uppercase tracking-wide">
-                            Element z lewej kolumny
-                          </label>
+                      <div className="grid grid-cols-[minmax(0,1fr)_auto] gap-3">
+                        <div className="flex flex-col gap-1">
                           <input
                             type="text"
                             value={pair.left}
@@ -732,10 +714,17 @@ export const TileSideEditor: React.FC<TileSideEditorProps> = ({
                             placeholder="Treść z lewej kolumny"
                           />
                         </div>
-                        <div className="space-y-2">
-                          <label className="text-xs font-medium text-gray-600 uppercase tracking-wide">
-                            Dopasowanie w prawej kolumnie
-                          </label>
+
+                        <button
+                            type="button"
+                            onClick={() => handleRemovePair(pair.id)}
+                            className="inline-flex items-center justify-center text-rose-600 hover:bg-rose-50 p-2 rounded-lg"
+                            aria-label={`Usuń parę ${index + 1}`}
+                        >
+                          <Trash2 className="w-4 h-4" />
+                        </button>
+
+                        <div className="flex flex-col gap-1 col-span-2">
                           <input
                             type="text"
                             value={pair.right}

--- a/src/components/admin/tiles/TaskTileSection.tsx
+++ b/src/components/admin/tiles/TaskTileSection.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 export interface TaskTileSectionProps extends React.HTMLAttributes<HTMLDivElement> {
   title: React.ReactNode;
   icon?: React.ReactNode;
-  rightContent?: React.ReactNode;
   headerClassName?: string;
   headerStyle?: React.CSSProperties;
   titleClassName?: string;
@@ -15,7 +14,6 @@ export interface TaskTileSectionProps extends React.HTMLAttributes<HTMLDivElemen
 export const TaskTileSection: React.FC<TaskTileSectionProps> = ({
   title,
   icon,
-  rightContent,
   className = '',
   headerClassName,
   headerStyle,
@@ -30,7 +28,6 @@ export const TaskTileSection: React.FC<TaskTileSectionProps> = ({
 
   const headerBaseClasses = [
     'flex items-center',
-    rightContent ? 'justify-between' : 'justify-start',
     headerClassName ?? 'px-5 py-4 border-b'
   ]
     .filter(Boolean)
@@ -49,7 +46,6 @@ export const TaskTileSection: React.FC<TaskTileSectionProps> = ({
           {icon && <span className="flex items-center justify-center">{icon}</span>}
           {typeof title === 'string' ? <span>{title}</span> : title}
         </div>
-        {rightContent ? <div>{rightContent}</div> : null}
       </div>
       <div className={contentClasses} style={contentStyle}>
         {children}

--- a/src/components/admin/tiles/blanks/Interactive.tsx
+++ b/src/components/admin/tiles/blanks/Interactive.tsx
@@ -127,7 +127,6 @@ export const BlanksInteractive: React.FC<BlanksInteractiveProps> = ({
     () => ({
       idle: (
         <>
-          <Sparkles className="h-5 w-5" aria-hidden="true" />
           <span>Sprawdź odpowiedzi</span>
         </>
       ),

--- a/src/components/admin/tiles/open/Interactive.tsx
+++ b/src/components/admin/tiles/open/Interactive.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo } from 'react';
-import { FileText, Paperclip, Download, PenSquare } from 'lucide-react';
+import { FileText, Paperclip, Download, PencilLine } from 'lucide-react';
 import { OpenTile } from '../../../../types/lessonEditor';
 import { getReadableTextColor, surfaceColor } from '../../../../utils/colorUtils';
 import { createValidateButtonPalette } from '../../../../utils/surfacePalette.ts';
@@ -118,50 +118,36 @@ export const OpenInteractive: React.FC<OpenInteractiveProps> = ({
               <p className="text-sm" style={{ color: captionColor }}>
                 Nie dodano żadnych plików. Dodaj je w panelu edycji, jeśli zadanie tego wymaga.
               </p>
-            ) : (
-              <ul className="flex flex-col gap-2">
+              ) : (
+              <div
+                className="rounded-xl border p-3"
+                style={{ backgroundColor: itemBackground, borderColor: itemBorder, color: textColor }}
+              >
+
+              <ul className="divide-y" style={{ borderColor: itemBorder }}>
                 {attachments.map((attachment, index) => (
-                  <li
-                    key={attachment.id}
-                    className="flex items-start gap-3 rounded-xl px-3 py-2"
-                    style={{
-                      backgroundColor: itemBackground,
-                      border: `1px solid ${itemBorder}`,
-                      color: textColor,
-                    }}
-                  >
-                    <span className="mt-0.5 flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg border"
-                      style={{
-                        borderColor: itemBorder,
-                        backgroundColor: sectionBackground,
-                        color: textColor,
-                      }}
+                  <li key={attachment.id} className="flex items-center gap-2 py-2">
+                    <span className="mt-0.5 flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-md border"
+                    style={{ borderColor: itemBorder, backgroundColor: sectionBackground, color: textColor }}
                     >
-                      <Download className="w-4 h-4" />
+                    <Download className="w-4 h-4" />
                     </span>
-                    <div className="min-w-0 flex-1">
-                      <p className="text-sm font-semibold truncate" style={{ color: textColor }}>
+                      <div className="min-w-0 flex-1">
+                        <p className="text-sm font-medium truncate" style={{ color: textColor }}>
                         {attachment.name || `Plik ${index + 1}`}
-                      </p>
-                      {attachment.description ? (
-                        <p className="text-xs" style={{ color: captionColor }}>
-                          {attachment.description}
                         </p>
-                      ) : null}
-                      <p className="text-xs break-all" style={{ color: captionColor }}>
-                        {attachment.url ?? ''}
-                      </p>
-                    </div>
+                      </div>
                   </li>
-                ))}
-              </ul>
+                  ))}
+                </ul>
+              </div>
             )}
           </TaskTileSection>
 
           <TaskTileSection
-            icon={<PenSquare className="w-4 h-4" />}
+            icon={<PencilLine className="w-4 h-4" />}
             title="Twoja odpowiedź"
-            className="shadow-sm min-h-0"
+            className="shadow-sm min-h-0 flex flex-col flex-1"
             style={{
               backgroundColor: sectionBackground,
               borderColor: sectionBorder,
@@ -170,10 +156,10 @@ export const OpenInteractive: React.FC<OpenInteractiveProps> = ({
             headerClassName="px-5 py-4 border-b"
             headerStyle={{ borderColor: sectionBorder, color: mutedLabelColor }}
             titleStyle={{ color: mutedLabelColor }}
-            contentClassName="flex-1 overflow-auto px-5 py-4"
+            contentClassName="flex flex-col flex-1 overflow-hidden px-5 py-4"
           >
             <textarea
-              className="w-full min-h-[120px] resize-none rounded-xl px-4 py-3 text-sm"
+              className="w-full flex-1 min-h-0 resize-none rounded-xl px-4 py-3 text-sm"
               style={{
                 backgroundColor: inputBackground,
                 borderColor: inputBorder,

--- a/src/components/admin/tiles/open/Interactive.tsx
+++ b/src/components/admin/tiles/open/Interactive.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo } from 'react';
-import { FileText, Paperclip, Download, PenSquare, CheckCircle2, Info } from 'lucide-react';
+import { FileText, Paperclip, Download, PenSquare } from 'lucide-react';
 import { OpenTile } from '../../../../types/lessonEditor';
 import { getReadableTextColor, surfaceColor } from '../../../../utils/colorUtils';
 import { createValidateButtonPalette } from '../../../../utils/surfacePalette.ts';
@@ -38,8 +38,6 @@ export const OpenInteractive: React.FC<OpenInteractiveProps> = ({
   const panelBorder = surfaceColor(accentColor, textColor, 0.5, 0.55);
 
   const attachments = useMemo(() => tile.content.attachments ?? [], [tile.content.attachments]);
-  const expectedFormat = tile.content.expectedFormat?.trim();
-  const correctAnswer = tile.content.correctAnswer?.trim();
 
   const validateButtonColors = useMemo<ValidateButtonColors>(
     () => createValidateButtonPalette(accentColor, textColor),
@@ -101,90 +99,91 @@ export const OpenInteractive: React.FC<OpenInteractiveProps> = ({
           </div>
         )}
 
-        <TaskTileSection
-          icon={<Paperclip className="w-4 h-4" />}
-          title="Materiały do zadania"
-          className="shadow-sm"
-          style={{
-            backgroundColor: sectionBackground,
-            borderColor: sectionBorder,
-            color: textColor,
-          }}
-          headerClassName="px-5 py-4 border-b"
-          headerStyle={{ borderColor: sectionBorder, color: mutedLabelColor }}
-          titleStyle={{ color: mutedLabelColor }}
-          contentClassName="flex flex-col gap-3 px-5 py-4"
-        >
-          {attachments.length === 0 ? (
-            <p className="text-sm" style={{ color: captionColor }}>
-              Nie dodano żadnych plików. Dodaj je w panelu edycji, jeśli zadanie tego wymaga.
-            </p>
-          ) : (
-            <div className="space-y-3">
-              {attachments.map(attachment => (
-                <div
-                  key={attachment.id}
-                  className="flex flex-col gap-3 rounded-xl border p-4 sm:flex-row sm:items-center sm:justify-between"
-                  style={{
-                    backgroundColor: itemBackground,
-                    borderColor: itemBorder,
-                  }}
-                >
-                  <div>
-                    <p className="text-sm font-semibold" style={{ color: textColor }}>
-                      {attachment.name}
-                    </p>
-                    {attachment.description ? (
-                      <p className="text-xs" style={{ color: captionColor }}>
-                        {attachment.description}
-                      </p>
-                    ) : null}
-                  </div>
-                  <button
-                    type="button"
-                    disabled
-                    className="inline-flex items-center gap-2 px-3 py-2 rounded-lg border text-xs font-medium opacity-70 cursor-not-allowed"
-                    style={{
-                      borderColor: itemBorder,
-                      color: textColor,
-                      backgroundColor: 'transparent',
-                    }}
-                  >
-                    <Download className="w-4 h-4" />
-                    Pobierz (podgląd)
-                  </button>
-                </div>
-              ))}
-            </div>
-          )}
-        </TaskTileSection>
-
-        <TaskTileSection
-          icon={<PenSquare className="w-4 h-4" />}
-          title="Twoja odpowiedź"
-          className="shadow-sm"
-          style={{
-            backgroundColor: sectionBackground,
-            borderColor: sectionBorder,
-            color: textColor,
-          }}
-          headerClassName="px-5 py-4 border-b"
-          headerStyle={{ borderColor: sectionBorder, color: mutedLabelColor }}
-          titleStyle={{ color: mutedLabelColor }}
-          contentClassName="flex flex-col gap-4 px-5 py-4"
-        >
-
-          <textarea
-            className="w-full min-h-[120px] resize-none rounded-xl px-4 py-3 text-sm"
+        <div className="flex-1 min-h-0 flex flex-col gap-6 overflow-hidden">
+          <TaskTileSection
+            icon={<Paperclip className="w-4 h-4" />}
+            title="Materiały do zadania"
+            className="shadow-sm min-h-0"
             style={{
-              backgroundColor: inputBackground,
-              borderColor: inputBorder,
+              backgroundColor: sectionBackground,
+              borderColor: sectionBorder,
               color: textColor,
             }}
-            placeholder={answerPlaceholder}
-            disabled
-          />
-        </TaskTileSection>
+            headerClassName="px-5 py-4 border-b"
+            headerStyle={{ borderColor: sectionBorder, color: mutedLabelColor }}
+            titleStyle={{ color: mutedLabelColor }}
+            contentClassName="flex-1 overflow-auto px-5 py-4"
+          >
+            {attachments.length === 0 ? (
+              <p className="text-sm" style={{ color: captionColor }}>
+                Nie dodano żadnych plików. Dodaj je w panelu edycji, jeśli zadanie tego wymaga.
+              </p>
+            ) : (
+              <ul className="flex flex-col gap-2">
+                {attachments.map((attachment, index) => (
+                  <li
+                    key={attachment.id}
+                    className="flex items-start gap-3 rounded-xl px-3 py-2"
+                    style={{
+                      backgroundColor: itemBackground,
+                      border: `1px solid ${itemBorder}`,
+                      color: textColor,
+                    }}
+                  >
+                    <span className="mt-0.5 flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg border"
+                      style={{
+                        borderColor: itemBorder,
+                        backgroundColor: sectionBackground,
+                        color: textColor,
+                      }}
+                    >
+                      <Download className="w-4 h-4" />
+                    </span>
+                    <div className="min-w-0 flex-1">
+                      <p className="text-sm font-semibold truncate" style={{ color: textColor }}>
+                        {attachment.name || `Plik ${index + 1}`}
+                      </p>
+                      {attachment.description ? (
+                        <p className="text-xs" style={{ color: captionColor }}>
+                          {attachment.description}
+                        </p>
+                      ) : null}
+                      <p className="text-xs break-all" style={{ color: captionColor }}>
+                        {attachment.url ?? ''}
+                      </p>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </TaskTileSection>
+
+          <TaskTileSection
+            icon={<PenSquare className="w-4 h-4" />}
+            title="Twoja odpowiedź"
+            className="shadow-sm min-h-0"
+            style={{
+              backgroundColor: sectionBackground,
+              borderColor: sectionBorder,
+              color: textColor,
+            }}
+            headerClassName="px-5 py-4 border-b"
+            headerStyle={{ borderColor: sectionBorder, color: mutedLabelColor }}
+            titleStyle={{ color: mutedLabelColor }}
+            contentClassName="flex-1 overflow-auto px-5 py-4"
+          >
+            <textarea
+              className="w-full min-h-[120px] resize-none rounded-xl px-4 py-3 text-sm"
+              style={{
+                backgroundColor: inputBackground,
+                borderColor: inputBorder,
+                color: textColor,
+              }}
+              placeholder={answerPlaceholder}
+              disabled
+            />
+          </TaskTileSection>
+        </div>
 
         <div className="flex flex-col items-center gap-2 pt-2">
           <ValidateButton

--- a/src/components/admin/tiles/pairing/Interactive.tsx
+++ b/src/components/admin/tiles/pairing/Interactive.tsx
@@ -93,7 +93,6 @@ export const PairingInteractive: React.FC<PairingInteractiveProps> = ({
     () => ({
       idle: (
         <>
-          <Shuffle className="h-5 w-5" aria-hidden="true" />
           <span>Sprawdź dopasowania</span>
         </>
       )
@@ -184,9 +183,6 @@ export const PairingInteractive: React.FC<PairingInteractiveProps> = ({
           ) : (
             <div className="h-full flex flex-col gap-5 lg:flex-row min-h-0">
               <div className="flex-1 min-h-0 flex flex-col">
-                <span className="text-xs uppercase tracking-[0.32em]" style={{ color: columnCaptionColor }}>
-                  Lewa kolumna
-                </span>
                 <div className="mt-3 flex-1 min-h-0 overflow-y-auto space-y-3 pr-1">
                   {tile.content.pairs.map((pair, index) => (
                     <div
@@ -209,9 +205,6 @@ export const PairingInteractive: React.FC<PairingInteractiveProps> = ({
               </div>
 
               <div className="flex-1 min-h-0 flex flex-col">
-                <span className="text-xs uppercase tracking-[0.32em]" style={{ color: columnCaptionColor }}>
-                  Prawa kolumna
-                </span>
                 <div className="mt-3 flex-1 min-h-0 overflow-y-auto space-y-3 pr-1">
                   {shuffledRightItems.map((item, index) => (
                     <div
@@ -240,9 +233,10 @@ export const PairingInteractive: React.FC<PairingInteractiveProps> = ({
           <div className="flex items-center justify-center pt-1">
             <ValidateButton
               state="idle"
+              disabled
               onClick={() => {}}
               colors={validateButtonColors}
-              labels={validateButtonLabels}
+              labels={{ idle: 'Sprawdź odpowiedź', success: 'Dobrze!', error: 'Spróbuj ponownie' }}
             />
           </div>
         )}

--- a/src/services/lessonContentService.ts
+++ b/src/services/lessonContentService.ts
@@ -79,7 +79,7 @@ export class LessonContentService {
    * Create a new text tile
    */
   static createTextTile(position: { x: number; y: number }, page = 1): TextTile {
-    const base = this.initializeTileBase('text', position, page, { colSpan: 2, rowSpan: 1 });
+    const base = this.initializeTileBase('text', position, page, { colSpan: 4, rowSpan: 2 });
 
     return {
       ...base,
@@ -99,7 +99,7 @@ export class LessonContentService {
    * Create a new image tile
    */
   static createImageTile(position: { x: number; y: number }, page = 1): LessonTile {
-    const base = this.initializeTileBase('image', position, page, { colSpan: 2, rowSpan: 2 });
+    const base = this.initializeTileBase('image', position, page, { colSpan: 4, rowSpan: 4 });
 
     return {
       ...base,
@@ -118,7 +118,7 @@ export class LessonContentService {
    * Create a new visualization tile
    */
   static createVisualizationTile(position: { x: number; y: number }, page = 1): LessonTile {
-    const base = this.initializeTileBase('visualization', position, page, { colSpan: 3, rowSpan: 3 });
+    const base = this.initializeTileBase('visualization', position, page, { colSpan: 6, rowSpan: 6 });
 
     return {
       ...base,
@@ -140,7 +140,7 @@ export class LessonContentService {
    * Create a new quiz tile
    */
   static createQuizTile(position: { x: number; y: number }, page = 1): LessonTile {
-    const base = this.initializeTileBase('quiz', position, page, { colSpan: 4, rowSpan: 3 });
+    const base = this.initializeTileBase('quiz', position, page, { colSpan: 8, rowSpan: 6 });
 
     return {
       ...base,
@@ -165,7 +165,7 @@ export class LessonContentService {
    * Create a new programming task tile
    */
   static createProgrammingTile(position: { x: number; y: number }, page = 1): ProgrammingTile {
-    const base = this.initializeTileBase('programming', position, page, { colSpan: 4, rowSpan: 3 });
+    const base = this.initializeTileBase('programming', position, page, { colSpan: 8, rowSpan: 6 });
 
     return {
       ...base,
@@ -188,7 +188,7 @@ export class LessonContentService {
    * Create a new sequencing tile
    */
   static createSequencingTile(position: { x: number; y: number }, page = 1): SequencingTile {
-    const base = this.initializeTileBase('sequencing', position, page, { colSpan: 4, rowSpan: 5 });
+    const base = this.initializeTileBase('sequencing', position, page, { colSpan: 8, rowSpan: 10 });
 
     return {
       ...base,
@@ -215,7 +215,7 @@ export class LessonContentService {
    * Create a new pairing tile
    */
   static createPairingTile(position: { x: number; y: number }, page = 1): PairingTile {
-    const base = this.initializeTileBase('pairing', position, page, { colSpan: 4, rowSpan: 4 });
+    const base = this.initializeTileBase('pairing', position, page, { colSpan: 8, rowSpan: 9 });
 
     return {
       ...base,
@@ -240,7 +240,7 @@ export class LessonContentService {
    * Create a new match pairs (fill-in-the-blanks) tile
    */
   static createBlanksTile(position: { x: number; y: number }, page = 1): BlanksTile {
-    const base = this.initializeTileBase('blanks', position, page, { colSpan: 5, rowSpan: 4 });
+    const base = this.initializeTileBase('blanks', position, page, { colSpan: 10, rowSpan: 8 });
 
     return {
       ...base,
@@ -266,7 +266,7 @@ export class LessonContentService {
    * Create a new open answer tile
    */
   static createOpenTile(position: { x: number; y: number }, page = 1): OpenTile {
-    const base = this.initializeTileBase('open', position, page, { colSpan: 4, rowSpan: 4 });
+    const base = this.initializeTileBase('open', position, page, { colSpan: 8, rowSpan: 9 });
 
     return {
       ...base,
@@ -286,7 +286,6 @@ export class LessonContentService {
           {
             id: 'attachment-instrukcja',
             name: 'instrukcja.pdf',
-            description: 'Zawiera szczegółowe wymagania do zadania.',
             url: 'https://example.com/materialy/instrukcja.pdf'
           }
         ]

--- a/src/services/lessonContentService.ts
+++ b/src/services/lessonContentService.ts
@@ -286,7 +286,8 @@ export class LessonContentService {
           {
             id: 'attachment-instrukcja',
             name: 'instrukcja.pdf',
-            description: 'Zawiera szczegółowe wymagania do zadania.'
+            description: 'Zawiera szczegółowe wymagania do zadania.',
+            url: 'https://example.com/materialy/instrukcja.pdf'
           }
         ]
       }

--- a/src/types/lessonEditor.ts
+++ b/src/types/lessonEditor.ts
@@ -173,7 +173,6 @@ export interface OpenTile extends LessonTile {
     attachments: Array<{
       id: string;
       name: string;
-      description?: string;
       url: string;
         }>;
   };

--- a/src/types/lessonEditor.ts
+++ b/src/types/lessonEditor.ts
@@ -174,7 +174,7 @@ export interface OpenTile extends LessonTile {
       id: string;
       name: string;
       description?: string;
-      url?: string;
+      url: string;
         }>;
   };
 }

--- a/src/utils/gridUtils.ts
+++ b/src/utils/gridUtils.ts
@@ -1,8 +1,8 @@
 import { Position, Size, GridPosition, CanvasSettings } from '../types/lessonEditor';
 
 export class GridUtils {
-  static readonly GRID_COLUMNS = 6;
-  static readonly GRID_CELL_SIZE = 120;
+  static readonly GRID_COLUMNS = 14;
+  static readonly GRID_CELL_SIZE = 60;
   static readonly GRID_GAP = 8;
 
   /**
@@ -149,13 +149,13 @@ export class GridUtils {
    * Calculate required canvas height based on tiles
    */
   static calculateCanvasHeight(tiles: any[]): number {
-    if (tiles.length === 0) return 6; // Minimum height
+    if (tiles.length === 0) return 12; // Minimum height
     
     const maxRow = Math.max(...tiles.map(tile => 
       tile.gridPosition.row + tile.gridPosition.rowSpan
     ));
     
-    return Math.max(6, maxRow + 2); // Add some padding
+    return Math.max(12, maxRow + 2); // Add some padding
   }
 
   /**


### PR DESCRIPTION
## Summary
- streamline the open tile side editor by requiring attachment URLs, removing the description field, and tightening layout spacing
- present downloadable materials in a compact list within the open task tile and make the task sections scroll when vertical space is limited
- require attachment URLs in the open tile type definition and seed data to match the editor changes

## Testing
- npm run lint *(fails: pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dfd6cf785483219f62e7f9e724f0eb