### PR TITLE
refactor: centralize grid utils in tiles-core

### DIFF
--- a/packages/tiles-core/src/utils/GridUtils.ts
+++ b/packages/tiles-core/src/utils/GridUtils.ts
@@ -1,4 +1,4 @@
-import { Position, Size, GridPosition, CanvasSettings, LessonTile } from 'tiles-core';
+import { Position, Size, GridPosition, CanvasSettings, LessonTile } from '../types';
 
 export class GridUtils {
   static readonly GRID_COLUMNS = 14;

--- a/packages/tiles-core/src/utils/index.ts
+++ b/packages/tiles-core/src/utils/index.ts
@@ -1,3 +1,4 @@
 export * from './colorUtils';
 export * from './surfacePalette';
 export * from './blanks';
+export * from './GridUtils';

--- a/packages/tiles-editor/src/hooks/useLessonContentManager.ts
+++ b/packages/tiles-editor/src/hooks/useLessonContentManager.ts
@@ -12,7 +12,7 @@ import {
   BlanksTile,
   migrateTileConfig
 } from 'tiles-core';
-import { GridUtils } from '../utils/gridUtils';
+import { GridUtils } from 'tiles-core/utils';
 import { logger } from '../utils/logger';
 import { EditorAction } from '../state/editorReducer';
 

--- a/packages/tiles-editor/src/hooks/useTileInteractions.ts
+++ b/packages/tiles-editor/src/hooks/useTileInteractions.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect, RefObject } from 'react';
 import { Lesson, LessonTile, GridPosition, EditorState, TextTile, ImageTile } from 'tiles-core';
 import { EditorAction } from '../state/editorReducer';
-import { GridUtils } from '../utils/gridUtils';
+import { GridUtils } from 'tiles-core/utils';
 import { logger } from '../utils/logger';
 
 interface UseTileInteractionsProps {

--- a/packages/tiles-editor/src/index.ts
+++ b/packages/tiles-editor/src/index.ts
@@ -9,4 +9,3 @@ export * from './hooks/useLessonContentManager';
 export * from './hooks/useTileInteractions';
 export * from './state/editorReducer';
 export * from './services/lessonContentService';
-export * from './utils/gridUtils';

--- a/packages/tiles-editor/src/services/lessonContentService.ts
+++ b/packages/tiles-editor/src/services/lessonContentService.ts
@@ -11,7 +11,7 @@ import {
   GridPosition,
   TILE_VERSION
 } from 'tiles-core';
-import { GridUtils } from '../utils/gridUtils';
+import { GridUtils } from 'tiles-core/utils';
 import { logger } from '../utils/logger';
 
 const DEFAULT_CANVAS_SETTINGS: CanvasSettings = {

--- a/src/components/admin/canvas/LessonCanvas.tsx
+++ b/src/components/admin/canvas/LessonCanvas.tsx
@@ -1,7 +1,8 @@
 import React, { forwardRef } from 'react';
 import { Type } from 'lucide-react';
 import { Lesson, LessonTile, EditorState } from 'tiles-core';
-import { TileRenderer, useTileInteractions, GridUtils, EditorAction } from 'tiles-editor';
+import { TileRenderer, useTileInteractions, EditorAction } from 'tiles-editor';
+import { GridUtils } from 'tiles-core/utils';
 import { Editor } from '@tiptap/react';
 
 interface LessonCanvasProps {

--- a/src/components/runtime/LessonRuntimeCanvas.tsx
+++ b/src/components/runtime/LessonRuntimeCanvas.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { CanvasSettings, LessonTile } from 'tiles-core';
 import { RuntimeTileRenderer } from 'tiles-runtime';
-import { GridUtils } from 'tiles-editor';
+import { GridUtils } from 'tiles-core/utils';
 
 interface LessonRuntimeCanvasProps {
   tiles: LessonTile[];


### PR DESCRIPTION
## Summary
- move `GridUtils` into the shared tiles-core utilities package and export it there
- update editor and runtime modules to consume the shared `GridUtils` export

## Testing
- npm run test *(fails: existing TypeScript configuration errors across the workspace)*
- npm run lint *(fails: missing @eslint/js dependency referenced by eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68e146d9bd8c83219f722b0fff231fbe