### PR TITLE
refactor: move validate button palette to ui layer

### DIFF
--- a/packages/tiles-core/src/utils/surfacePalette.ts
+++ b/packages/tiles-core/src/utils/surfacePalette.ts
@@ -1,9 +1,4 @@
-import { surfaceColor, lightenColor, darkenColor } from './colorUtils';
-import {
-  ValidateButtonColors,
-  ValidateButtonState,
-  ValidateButtonColorConfig
-} from 'ui-primitives';
+import { surfaceColor } from './colorUtils';
 
 export interface SurfaceColorDefinition {
   lighten: number;
@@ -24,43 +19,3 @@ export const createSurfacePalette = <T extends string>(
   }, {} as Record<T, string>);
 };
 
-const BUTTON_STATES: ValidateButtonState[] = ['idle', 'success', 'error'];
-
-const BASE_SUCCESS: ValidateButtonColorConfig = {
-  background: '#dcfce7',
-  color: '#166534',
-  border: '#bbf7d0'
-};
-
-const BASE_ERROR: ValidateButtonColorConfig = {
-  background: '#fee2e2',
-  color: '#b91c1c',
-  border: '#fecaca'
-};
-
-export const createValidateButtonPalette = (
-  accentColor: string,
-  textColor: string,
-  overrides?: ValidateButtonColors
-): ValidateButtonColors => {
-  const baseIdle: ValidateButtonColorConfig = {
-    background:
-      textColor === '#0f172a'
-        ? darkenColor(accentColor, 0.2)
-        : lightenColor(accentColor, 0.24),
-    color: textColor === '#0f172a' ? '#f8fafc' : '#0f172a',
-    border: 'transparent'
-  };
-
-  const base: Record<ValidateButtonState, ValidateButtonColorConfig> = {
-    idle: baseIdle,
-    success: BASE_SUCCESS,
-    error: BASE_ERROR
-  };
-
-  return BUTTON_STATES.reduce<ValidateButtonColors>((acc, state) => {
-    const override = overrides?.[state];
-    acc[state] = override ? { ...base[state], ...override } : base[state];
-    return acc;
-  }, {} as ValidateButtonColors);
-};

--- a/packages/tiles-runtime/src/blanks/Interactive.tsx
+++ b/packages/tiles-runtime/src/blanks/Interactive.tsx
@@ -5,7 +5,6 @@ import {
   createBlankId,
   createPlaceholderRegex,
   createSurfacePalette,
-  createValidateButtonPalette,
   getReadableTextColor,
   surfaceColor
 } from 'tiles-core/utils';
@@ -13,6 +12,7 @@ import {
   TaskInstructionPanel,
   TaskTileSection,
   ValidateButton,
+  createValidateButtonPalette,
   type ValidateButtonColors,
   type ValidateButtonState
 } from 'ui-primitives';

--- a/packages/tiles-runtime/src/open/Interactive.tsx
+++ b/packages/tiles-runtime/src/open/Interactive.tsx
@@ -1,8 +1,14 @@
 import React, { useCallback, useMemo } from 'react';
 import { FileText, Paperclip, Download, PencilLine } from 'lucide-react';
 import { OpenTile } from 'tiles-core';
-import { getReadableTextColor, surfaceColor, createValidateButtonPalette } from 'tiles-core/utils';
-import { TaskInstructionPanel, TaskTileSection, ValidateButton, type ValidateButtonColors } from 'ui-primitives';
+import { getReadableTextColor, surfaceColor } from 'tiles-core/utils';
+import {
+  TaskInstructionPanel,
+  TaskTileSection,
+  ValidateButton,
+  createValidateButtonPalette,
+  type ValidateButtonColors
+} from 'ui-primitives';
 
 interface OpenInteractiveProps {
   tile: OpenTile;

--- a/packages/tiles-runtime/src/pairing/Interactive.tsx
+++ b/packages/tiles-runtime/src/pairing/Interactive.tsx
@@ -1,15 +1,12 @@
 import React, { useMemo } from 'react';
 import { Link2, Shuffle, Sparkles } from 'lucide-react';
 import { PairingTile } from 'tiles-core';
-import {
-  createSurfacePalette,
-  createValidateButtonPalette,
-  getReadableTextColor
-} from 'tiles-core/utils';
+import { createSurfacePalette, getReadableTextColor } from 'tiles-core/utils';
 import {
   TaskInstructionPanel,
   TaskTileSection,
   ValidateButton,
+  createValidateButtonPalette,
   type ValidateButtonColors
 } from 'ui-primitives';
 

--- a/packages/tiles-runtime/src/sequencing/Interactive.tsx
+++ b/packages/tiles-runtime/src/sequencing/Interactive.tsx
@@ -5,13 +5,13 @@ import {
   darkenColor,
   getReadableTextColor,
   lightenColor,
-  createSurfacePalette,
-  createValidateButtonPalette
+  createSurfacePalette
 } from 'tiles-core/utils';
 import {
   TaskInstructionPanel,
   TaskTileSection,
   ValidateButton,
+  createValidateButtonPalette,
   type ValidateButtonColors,
   type ValidateButtonState
 } from 'ui-primitives';

--- a/packages/ui-primitives/src/index.ts
+++ b/packages/ui-primitives/src/index.ts
@@ -4,3 +4,4 @@ export * from './views';
 export * from './TaskInstructionPanel';
 export * from './TaskTileSection';
 export * from './ValidateButton';
+export * from './validateButtonPalette';

--- a/packages/ui-primitives/src/validateButtonPalette.ts
+++ b/packages/ui-primitives/src/validateButtonPalette.ts
@@ -1,0 +1,47 @@
+import { darkenColor, lightenColor } from 'tiles-core/utils';
+import type {
+  ValidateButtonColorConfig,
+  ValidateButtonColors,
+  ValidateButtonState
+} from './ValidateButton';
+
+const BUTTON_STATES: ValidateButtonState[] = ['idle', 'success', 'error'];
+
+const BASE_SUCCESS: ValidateButtonColorConfig = {
+  background: '#dcfce7',
+  color: '#166534',
+  border: '#bbf7d0'
+};
+
+const BASE_ERROR: ValidateButtonColorConfig = {
+  background: '#fee2e2',
+  color: '#b91c1c',
+  border: '#fecaca'
+};
+
+export const createValidateButtonPalette = (
+  accentColor: string,
+  textColor: string,
+  overrides?: ValidateButtonColors
+): ValidateButtonColors => {
+  const baseIdle: ValidateButtonColorConfig = {
+    background:
+      textColor === '#0f172a'
+        ? darkenColor(accentColor, 0.2)
+        : lightenColor(accentColor, 0.24),
+    color: textColor === '#0f172a' ? '#f8fafc' : '#0f172a',
+    border: 'transparent'
+  };
+
+  const base: Record<ValidateButtonState, ValidateButtonColorConfig> = {
+    idle: baseIdle,
+    success: BASE_SUCCESS,
+    error: BASE_ERROR
+  };
+
+  return BUTTON_STATES.reduce<ValidateButtonColors>((acc, state) => {
+    const override = overrides?.[state];
+    acc[state] = override ? { ...base[state], ...override } : base[state];
+    return acc;
+  }, {} as ValidateButtonColors);
+};


### PR DESCRIPTION
## Summary
- move the validate button palette helper into the ui-primitives package and export it alongside the button types
- update runtime interactive components to consume the ui-level palette factory
- simplify the tiles-core surface palette utility so it no longer depends on ui-specific types

## Testing
- npm run lint *(fails: missing @eslint/js package referenced by eslint.config.js)*
- npm test *(fails: existing TypeScript JSX configuration issues in ui-primitives views)*

------
https://chatgpt.com/codex/tasks/task_e_68e157607a4883218b3b76ae588de398