### PR TITLE
feat: unify tile tile container styling across editor and runtime

### DIFF
--- a/packages/tiles-editor/src/components/TileFrame.tsx
+++ b/packages/tiles-editor/src/components/TileFrame.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { Move, Trash2 } from 'lucide-react';
 import { LessonTile } from 'tiles-core';
+import { TileContainer } from 'ui-primitives';
 
 const RESIZE_HANDLES = [
   { handle: 'nw', position: { x: 0, y: 0 }, cursor: 'nw-resize' },
@@ -13,7 +14,7 @@ const RESIZE_HANDLES = [
   { handle: 'e', position: { x: 1, y: 0.5 }, cursor: 'e-resize' }
 ] as const;
 
-const TILE_CORNER = 'rounded-xl';
+const TILE_CORNER = 'rounded-3xl';
 
 export interface TileFrameProps {
   tile: LessonTile;
@@ -106,7 +107,6 @@ export const TileFrame: React.FC<TileFrameProps> = ({
     );
   }, [handleResizeStart, isEditingText, isFramelessTextTile, isImageEditing, isSelected, isTestingMode, tile.gridPosition]);
 
-  const elevationClass = isSelected ? 'shadow-lg' : 'shadow-sm';
   const allowMouseDown = !isDraggingImage && !isTestingMode;
 
   return (
@@ -115,7 +115,7 @@ export const TileFrame: React.FC<TileFrameProps> = ({
         isEditing || isImageEditing || isEditingText ? 'z-20' : 'z-10'
       } ${
         isSelected ? 'ring-2 ring-blue-500 ring-opacity-75' : ''
-      } ${elevationClass}`}
+      }`}
       style={{
         left: tile.position.x,
         top: tile.position.y,
@@ -127,9 +127,16 @@ export const TileFrame: React.FC<TileFrameProps> = ({
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
     >
-      <div className={`relative h-full w-full ${TILE_CORNER} overflow-hidden`}>
+      <TileContainer
+        radius="3xl"
+        elevation="lg"
+        className={`relative h-full w-full transition-shadow duration-200 ${
+          isFramelessTextTile ? 'bg-transparent' : ''
+        }`}
+        backgroundColor={isFramelessTextTile ? 'transparent' : undefined}
+      >
         {children({ isHovered })}
-      </div>
+      </TileContainer>
 
       {(isSelected || isHovered) && !isEditingText && !isImageEditing && (
         <div

--- a/packages/ui-primitives/src/TileContainer.tsx
+++ b/packages/ui-primitives/src/TileContainer.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+
+const joinClassNames = (...values: Array<string | undefined | false>) =>
+  values.filter(Boolean).join(' ');
+
+const radiusClassNames = {
+  xl: 'rounded-xl',
+  '2xl': 'rounded-2xl',
+  '3xl': 'rounded-3xl',
+} as const;
+
+type Radius = keyof typeof radiusClassNames;
+
+type OverflowBehavior = 'hidden' | 'clip' | 'visible';
+
+const overflowClassNames: Record<OverflowBehavior, string> = {
+  hidden: 'overflow-hidden',
+  clip: 'overflow-clip',
+  visible: 'overflow-visible',
+};
+
+type Elevation = 'none' | 'sm' | 'md' | 'lg';
+
+const elevationClassNames: Record<Elevation, string> = {
+  none: '',
+  sm: 'shadow-sm',
+  md: 'shadow-md',
+  lg: 'shadow-[0_16px_32px_rgba(15,23,42,0.12)]',
+};
+
+export interface TileContainerProps extends React.HTMLAttributes<HTMLDivElement> {
+  radius?: Radius;
+  overflowBehavior?: OverflowBehavior;
+  elevation?: Elevation;
+  backgroundColor?: string;
+  showBorder?: boolean;
+  borderColor?: string;
+}
+
+export const TileContainer = React.forwardRef<HTMLDivElement, TileContainerProps>(
+  (
+    {
+      radius = '3xl',
+      overflowBehavior = 'hidden',
+      elevation = 'lg',
+      backgroundColor = '#ffffff',
+      showBorder = false,
+      borderColor = 'rgba(15, 23, 42, 0.08)',
+      className,
+      style,
+      children,
+      ...rest
+    },
+    ref,
+  ) => {
+    return (
+      <div
+        ref={ref}
+        className={joinClassNames(
+          'w-full h-full',
+          radiusClassNames[radius],
+          overflowClassNames[overflowBehavior],
+          elevationClassNames[elevation],
+          showBorder && 'border',
+          className,
+        )}
+        style={{
+          backgroundColor,
+          border: showBorder ? `1px solid ${borderColor}` : 'none',
+          ...style,
+        }}
+        {...rest}
+      >
+        {children}
+      </div>
+    );
+  },
+);
+
+TileContainer.displayName = 'TileContainer';
+
+export default TileContainer;

--- a/packages/ui-primitives/src/index.ts
+++ b/packages/ui-primitives/src/index.ts
@@ -1,5 +1,6 @@
 
 export * from './TileChrome';
+export * from './TileContainer';
 export * from './views';
 export * from './TaskInstructionPanel';
 export * from './TaskTileSection';

--- a/src/components/runtime/LessonRuntimeCanvas.tsx
+++ b/src/components/runtime/LessonRuntimeCanvas.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { CanvasSettings, LessonTile } from 'tiles-core';
 import { RuntimeTileRenderer } from 'tiles-runtime';
 import { GridUtils } from 'tiles-core/utils';
+import { TileContainer } from 'ui-primitives';
 
 interface LessonRuntimeCanvasProps {
   tiles: LessonTile[];
@@ -33,20 +34,16 @@ export const LessonRuntimeCanvas: React.FC<LessonRuntimeCanvasProps> = ({ tiles,
           const { col, row, colSpan, rowSpan } = tile.gridPosition;
 
           return (
-            <div
+            <TileContainer
               key={tile.id}
               className="relative flex"
               style={{
                 gridColumn: `${col + 1} / span ${Math.max(colSpan, 1)}`,
                 gridRow: `${row + 1} / span ${Math.max(rowSpan, 1)}`,
-                borderRadius: '1.5rem',
-                overflow: 'hidden',
-                boxShadow: '0 16px 32px rgba(15, 23, 42, 0.12)',
-                backgroundColor: '#ffffff',
               }}
             >
               <RuntimeTileRenderer tile={tile} />
-            </div>
+            </TileContainer>
           );
         })}
       </div>


### PR DESCRIPTION
## Summary
- add a TileContainer primitive in ui-primitives to share tile border radius, shadow, and overflow styling
- update the editor TileFrame to render tiles with the shared container so previews match runtime chrome
- switch LessonRuntimeCanvas to use the shared container for consistent tile presentation

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js' imported from eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68e15779f7808321b1ab100d447fe05a