### PR TITLE
Move lesson runtime canvas into runtime package

### DIFF
--- a/packages/tiles-runtime/package.json
+++ b/packages/tiles-runtime/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "tiles-runtime",
+  "version": "0.0.0",
+  "private": true,
+  "main": "src/index.ts",
+  "types": "src/index.ts"
+}

--- a/packages/tiles-runtime/src/canvas/LessonRuntimeCanvas.tsx
+++ b/packages/tiles-runtime/src/canvas/LessonRuntimeCanvas.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { CanvasSettings, LessonTile } from 'tiles-core';
-import { RuntimeTileRenderer } from 'tiles-runtime';
 import { GridUtils } from 'tiles-core/utils';
 import { TileContainer } from 'ui-primitives';
+import { RuntimeTileRenderer } from '../RuntimeTileRenderer';
 
 interface LessonRuntimeCanvasProps {
   tiles: LessonTile[];

--- a/packages/tiles-runtime/src/canvas/index.ts
+++ b/packages/tiles-runtime/src/canvas/index.ts
@@ -1,0 +1,1 @@
+export * from './LessonRuntimeCanvas';

--- a/packages/tiles-runtime/src/index.ts
+++ b/packages/tiles-runtime/src/index.ts
@@ -1,4 +1,5 @@
 export * from './RuntimeTileRenderer';
+export * from './canvas';
 export * from './views';
 export * from './quiz';
 export * from './blanks';

--- a/packages/tiles-runtime/tsconfig.json
+++ b/packages/tiles-runtime/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.app.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "baseUrl": "./src"
+  },
+  "include": ["src"]
+}

--- a/src/Pages/LessonView.tsx
+++ b/src/Pages/LessonView.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { ArrowLeft, LayoutDashboard, Loader2 } from 'lucide-react';
 import { Course, Lesson, LessonTile } from 'tiles-core';
-import { LessonRuntimeCanvas } from '../components/runtime/LessonRuntimeCanvas';
+import { LessonRuntimeCanvas } from 'tiles-runtime';
 import { LessonRuntimeService } from '../services/lessonRuntimeService';
 
 interface LessonViewProps {


### PR DESCRIPTION
## Summary
- add package metadata and TypeScript config to tiles-runtime so it mirrors tiles-editor
- move LessonRuntimeCanvas into the tiles-runtime package and re-export it from the package entry point
- update LessonView to consume LessonRuntimeCanvas via the tiles-runtime alias

## Testing
- `npm test -- LessonView` *(fails: existing TypeScript configuration for packages/ui-primitives lacks JSX support when running the test build)*

------
https://chatgpt.com/codex/tasks/task_e_68e159634f208321b1e1a5eac5e25ad5