### PR TITLE
Show validate button for previewed interactive tiles

### DIFF
--- a/packages/tiles-runtime/src/blanks/Interactive.tsx
+++ b/packages/tiles-runtime/src/blanks/Interactive.tsx
@@ -465,17 +465,15 @@ export const BlanksInteractive: React.FC<BlanksInteractiveProps> = ({
           </TaskTileSection>
         </div>
 
-        {isInteractionEnabled && (
-          <div className="flex flex-col items-center gap-2 pt-2">
-            <ValidateButton
-                state="idle"
-                disabled
-                onClick={() => {}}
-                colors={validateButtonColors}
-                labels={{ idle: 'Sprawdź odpowiedź', success: 'Dobrze!', error: 'Spróbuj ponownie' }}
-            />
-          </div>
-        )}
+        <div className="flex flex-col items-center gap-2 pt-2">
+          <ValidateButton
+            state={validationState}
+            disabled={!isInteractionEnabled}
+            onClick={() => {}}
+            colors={validateButtonColors}
+            labels={{ idle: 'Sprawdź odpowiedź', success: 'Dobrze!', error: 'Spróbuj ponownie' }}
+          />
+        </div>
       </div>
     </div>
   );

--- a/packages/tiles-runtime/src/pairing/Interactive.tsx
+++ b/packages/tiles-runtime/src/pairing/Interactive.tsx
@@ -55,6 +55,7 @@ export const PairingInteractive: React.FC<PairingInteractiveProps> = ({
 }) => {
   const accentColor = tile.content.backgroundColor || '#0f172a';
   const textColor = useMemo(() => getReadableTextColor(accentColor), [accentColor]);
+  const canInteract = !isPreview;
   const {
     panelBackground,
     panelBorder,
@@ -226,17 +227,15 @@ export const PairingInteractive: React.FC<PairingInteractiveProps> = ({
           )}
         </TaskTileSection>
 
-        {!isPreview && (
-          <div className="flex items-center justify-center pt-1">
-            <ValidateButton
-              state="idle"
-              disabled
-              onClick={() => {}}
-              colors={validateButtonColors}
-              labels={{ idle: 'Sprawdź odpowiedź', success: 'Dobrze!', error: 'Spróbuj ponownie' }}
-            />
-          </div>
-        )}
+        <div className="flex items-center justify-center pt-1">
+          <ValidateButton
+            state="idle"
+            disabled={!canInteract}
+            onClick={() => {}}
+            colors={validateButtonColors}
+            labels={{ idle: 'Sprawdź odpowiedź', success: 'Dobrze!', error: 'Spróbuj ponownie' }}
+          />
+        </div>
       </div>
     </div>
   );

--- a/packages/tiles-runtime/src/sequencing/Interactive.tsx
+++ b/packages/tiles-runtime/src/sequencing/Interactive.tsx
@@ -631,17 +631,15 @@ export const SequencingInteractive: React.FC<SequencingInteractiveProps> = ({
           </TaskTileSection>
         </div>
 
-        {!isPreview && (
-          <div className="flex flex-col items-center gap-2 pt-2">
-            <ValidateButton
-                state="idle"
-                disabled
-                onClick={() => {}}
-                colors={validateButtonColors}
-                labels={{ idle: 'Sprawdź odpowiedź', success: 'Dobrze!', error: 'Spróbuj ponownie' }}
-            />
-          </div>
-        )}
+        <div className="flex flex-col items-center gap-2 pt-2">
+          <ValidateButton
+            state={validationState}
+            disabled={!canInteract}
+            onClick={() => {}}
+            colors={validateButtonColors}
+            labels={{ idle: 'Sprawdź odpowiedź', success: 'Dobrze!', error: 'Spróbuj ponownie' }}
+          />
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- always render the validate button in blanks, pairing, and sequencing tiles
- ensure the button reflects the current validation state and disables when interaction is not allowed

## Testing
- npm run lint *(fails: missing @eslint/js dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68e15de6b78083219a221681eb139313