### PR TITLE
Align student lesson view with editor canvas dimensions

### DIFF
--- a/packages/tiles-runtime/src/canvas/LessonRuntimeCanvas.tsx
+++ b/packages/tiles-runtime/src/canvas/LessonRuntimeCanvas.tsx
@@ -14,38 +14,48 @@ const getGridColumns = (canvasSettings: CanvasSettings): number => {
 };
 
 export const LessonRuntimeCanvas: React.FC<LessonRuntimeCanvasProps> = ({ tiles, canvasSettings }) => {
-  const columns = getGridColumns(canvasSettings);
-  const cellSize = canvasSettings.gridSize + GridUtils.GRID_GAP;
+  const columns = Math.max(getGridColumns(canvasSettings), 1);
+  const rows = Math.max(canvasSettings.height, 1);
+  const cellSize = canvasSettings.gridSize;
+  const gap = GridUtils.GRID_GAP;
+
+  const canvasWidth = columns * cellSize + (columns - 1) * gap;
+  const canvasMinHeight = rows * cellSize + (rows - 1) * gap;
 
   return (
-    <div
-      className="w-full rounded-3xl bg-slate-50 p-6 border border-slate-200 shadow-inner"
-    >
+    <div className="w-full rounded-3xl bg-slate-50 p-6 border border-slate-200 shadow-inner">
       <div
-        className="w-full"
+        className="mx-auto"
         style={{
-          display: 'grid',
-          gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))`,
-          gridAutoRows: `${cellSize}px`,
-          gap: `${GridUtils.GRID_GAP}px`,
+          width: canvasWidth,
+          minHeight: canvasMinHeight,
         }}
       >
-        {tiles.map(tile => {
-          const { col, row, colSpan, rowSpan } = tile.gridPosition;
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: `repeat(${columns}, ${cellSize}px)`,
+            gridAutoRows: `${cellSize}px`,
+            gap: `${gap}px`,
+          }}
+        >
+          {tiles.map(tile => {
+            const { col, row, colSpan, rowSpan } = tile.gridPosition;
 
-          return (
-            <TileContainer
-              key={tile.id}
-              className="relative flex"
-              style={{
-                gridColumn: `${col + 1} / span ${Math.max(colSpan, 1)}`,
-                gridRow: `${row + 1} / span ${Math.max(rowSpan, 1)}`,
-              }}
-            >
-              <RuntimeTileRenderer tile={tile} />
-            </TileContainer>
-          );
-        })}
+            return (
+              <TileContainer
+                key={tile.id}
+                className="relative flex"
+                style={{
+                  gridColumn: `${col + 1} / span ${Math.max(colSpan, 1)}`,
+                  gridRow: `${row + 1} / span ${Math.max(rowSpan, 1)}`,
+                }}
+              >
+                <RuntimeTileRenderer tile={tile} />
+              </TileContainer>
+            );
+          })}
+        </div>
       </div>
     </div>
   );

--- a/src/components/admin/canvas/LessonCanvas.tsx
+++ b/src/components/admin/canvas/LessonCanvas.tsx
@@ -53,15 +53,20 @@ export const LessonCanvas = forwardRef<HTMLDivElement, LessonCanvasProps>(({
   });
 
   // Calculate canvas dimensions
+  const columns = Math.max(content.canvas_settings.width ?? GridUtils.GRID_COLUMNS, 1);
+  const rows = Math.max(content.canvas_settings.height, 1);
+  const cellSize = content.canvas_settings.gridSize;
+  const gap = GridUtils.GRID_GAP;
+
   const canvasStyle = {
-    width: GridUtils.GRID_COLUMNS * (content.canvas_settings.gridSize + GridUtils.GRID_GAP) - GridUtils.GRID_GAP,
-    minHeight: content.canvas_settings.height * (content.canvas_settings.gridSize + GridUtils.GRID_GAP) - GridUtils.GRID_GAP
+    width: columns * cellSize + (columns - 1) * gap,
+    minHeight: rows * cellSize + (rows - 1) * gap
   };
 
   const renderGridBackground = () => {
     if (!showGrid) return null;
     
-    const cellSize = content.canvas_settings.gridSize + GridUtils.GRID_GAP;
+    const cellSizeWithGap = content.canvas_settings.gridSize + GridUtils.GRID_GAP;
     
     return (
       <div 
@@ -71,7 +76,7 @@ export const LessonCanvas = forwardRef<HTMLDivElement, LessonCanvasProps>(({
             linear-gradient(to right, #e5e7eb 1px, transparent 1px),
             linear-gradient(to bottom, #e5e7eb 1px, transparent 1px)
           `,
-          backgroundSize: `${cellSize}px ${cellSize}px`
+          backgroundSize: `${cellSizeWithGap}px ${cellSizeWithGap}px`
         }}
       />
     );
@@ -155,7 +160,7 @@ export const LessonCanvas = forwardRef<HTMLDivElement, LessonCanvasProps>(({
       {/* Canvas Info */}
       <div className="mt-4 text-center">
         <p className="text-xs text-gray-500">
-          Siatka: {GridUtils.GRID_COLUMNS} × {content.canvas_settings.height} kafelków
+          Siatka: {columns} × {content.canvas_settings.height} kafelków
           {showGrid && ' • Siatka włączona'}
         </p>
       </div>


### PR DESCRIPTION
## Summary
- unify the lesson editor canvas sizing logic around the configured grid width and height
- update the runtime canvas to use matching pixel-based grid dimensions and center it in the preview shell
- expose the configured column count in the editor UI so both canvases reflect the same grid geometry

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68e160fda6288321b12d8f1262f74b32