### PR TITLE
Enable sequencing tile solving in lesson view

### DIFF
--- a/packages/tiles-runtime/src/RuntimeTileRenderer.tsx
+++ b/packages/tiles-runtime/src/RuntimeTileRenderer.tsx
@@ -24,8 +24,11 @@ import { OpenInteractive } from './open';
 import { SequencingInteractive } from './sequencing';
 import { PairingInteractive } from './pairing';
 
+type RuntimeMode = 'preview' | 'student';
+
 interface RuntimeTileRendererProps {
   tile: LessonTile;
+  mode?: RuntimeMode;
 }
 
 const deriveChromeAppearance = (
@@ -42,7 +45,7 @@ const deriveChromeAppearance = (
   };
 };
 
-export const RuntimeTileRenderer: React.FC<RuntimeTileRendererProps> = ({ tile }) => {
+export const RuntimeTileRenderer: React.FC<RuntimeTileRendererProps> = ({ tile, mode = 'preview' }) => {
   switch (tile.type) {
     case 'text':
       return <TextTileView tile={tile as TextTile} />;
@@ -69,7 +72,7 @@ export const RuntimeTileRenderer: React.FC<RuntimeTileRendererProps> = ({ tile }
     case 'sequencing':
       return (
         <TileChrome {...deriveChromeAppearance(tile)}>
-          <SequencingInteractive tile={tile as SequencingTile} isPreview />
+          <SequencingInteractive tile={tile as SequencingTile} isPreview={mode !== 'student'} />
         </TileChrome>
       );
     case 'pairing':

--- a/packages/tiles-runtime/src/canvas/LessonRuntimeCanvas.tsx
+++ b/packages/tiles-runtime/src/canvas/LessonRuntimeCanvas.tsx
@@ -7,13 +7,18 @@ import { RuntimeTileRenderer } from '../RuntimeTileRenderer';
 interface LessonRuntimeCanvasProps {
   tiles: LessonTile[];
   canvasSettings: CanvasSettings;
+  mode?: 'preview' | 'student';
 }
 
 const getGridColumns = (canvasSettings: CanvasSettings): number => {
   return canvasSettings.width ?? GridUtils.GRID_COLUMNS;
 };
 
-export const LessonRuntimeCanvas: React.FC<LessonRuntimeCanvasProps> = ({ tiles, canvasSettings }) => {
+export const LessonRuntimeCanvas: React.FC<LessonRuntimeCanvasProps> = ({
+  tiles,
+  canvasSettings,
+  mode = 'preview',
+}) => {
   const columns = Math.max(getGridColumns(canvasSettings), 1);
   const rows = Math.max(canvasSettings.height, 1);
   const cellSize = canvasSettings.gridSize;
@@ -51,7 +56,7 @@ export const LessonRuntimeCanvas: React.FC<LessonRuntimeCanvasProps> = ({ tiles,
                   gridRow: `${row + 1} / span ${Math.max(rowSpan, 1)}`,
                 }}
               >
-                <RuntimeTileRenderer tile={tile} />
+                <RuntimeTileRenderer tile={tile} mode={mode} />
               </TileContainer>
             );
           })}

--- a/packages/tiles-runtime/src/sequencing/Interactive.tsx
+++ b/packages/tiles-runtime/src/sequencing/Interactive.tsx
@@ -634,10 +634,10 @@ export const SequencingInteractive: React.FC<SequencingInteractiveProps> = ({
         <div className="flex flex-col items-center gap-2 pt-2">
           <ValidateButton
             state={validationState}
-            disabled={!canInteract}
-            onClick={() => {}}
+            disabled={!canInteract || !sequenceComplete}
+            onClick={checkSequence}
             colors={validateButtonColors}
-            labels={{ idle: 'Sprawdź odpowiedź', success: 'Dobrze!', error: 'Spróbuj ponownie' }}
+            labels={validateButtonLabels}
           />
         </div>
       </div>

--- a/src/Pages/LessonView.tsx
+++ b/src/Pages/LessonView.tsx
@@ -94,7 +94,11 @@ export const LessonView: React.FC<LessonViewProps> = ({ lesson, course, onBack }
             Dodaj kafelki w edytorze, aby zobaczyć podgląd lekcji.
           </div>
         ) : (
-          <LessonRuntimeCanvas tiles={tilesForPage} canvasSettings={lessonContent.canvas_settings} />
+          <LessonRuntimeCanvas
+            tiles={tilesForPage}
+            canvasSettings={lessonContent.canvas_settings}
+            mode="student"
+          />
         )}
 
         {totalPages > 1 && (


### PR DESCRIPTION
## Summary
- allow the lesson runtime canvas to propagate a runtime mode flag down to tile renderers
- enable the sequencing tile runtime to validate the dragged sequence and gate the validate button on completion
- switch the lesson view to student mode so sequencing tiles become solvable

## Testing
- npm run build *(fails: missing local vite binary before dependencies are installed)*
- npm install *(fails: npm registry returns 403 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e164497b888321b715f60a7b08d351