### PR TITLE
Remove sequencing tile testing mode from editor

### DIFF
--- a/packages/tiles-editor/src/components/TileFrame.tsx
+++ b/packages/tiles-editor/src/components/TileFrame.tsx
@@ -22,7 +22,6 @@ export interface TileFrameProps {
   isEditing: boolean;
   isEditingText: boolean;
   isImageEditing: boolean;
-  isTestingMode?: boolean;
   isDraggingImage: boolean;
   showGrid: boolean;
   isFramelessTextTile?: boolean;
@@ -38,7 +37,6 @@ export const TileFrame: React.FC<TileFrameProps> = ({
   isEditing,
   isEditingText,
   isImageEditing,
-  isTestingMode = false,
   isDraggingImage,
   showGrid,
   isFramelessTextTile = false,
@@ -79,7 +77,7 @@ export const TileFrame: React.FC<TileFrameProps> = ({
   }, [tile.id]);
 
   const renderResizeHandles = useCallback(() => {
-    if (!isSelected || isEditingText || isImageEditing || isTestingMode) {
+    if (!isSelected || isEditingText || isImageEditing) {
       return null;
     }
 
@@ -105,9 +103,9 @@ export const TileFrame: React.FC<TileFrameProps> = ({
         ))}
       </>
     );
-  }, [handleResizeStart, isEditingText, isFramelessTextTile, isImageEditing, isSelected, isTestingMode, tile.gridPosition]);
+  }, [handleResizeStart, isEditingText, isFramelessTextTile, isImageEditing, isSelected, tile.gridPosition]);
 
-  const allowMouseDown = !isDraggingImage && !isTestingMode;
+  const allowMouseDown = !isDraggingImage;
 
   return (
     <div

--- a/packages/tiles-editor/src/components/TileRenderer.tsx
+++ b/packages/tiles-editor/src/components/TileRenderer.tsx
@@ -19,7 +19,6 @@ interface TileRendererProps {
   isEditing: boolean;
   isEditingText: boolean;
   isImageEditing: boolean;
-  isTestingMode?: boolean;
   onMouseDown: (e: React.MouseEvent) => void;
   onImageMouseDown: (e: React.MouseEvent, tile?: ImageTile) => void;
   isDraggingImage: boolean;
@@ -47,7 +46,6 @@ export const TileRenderer: React.FC<TileRendererProps> = ({
   isSelected,
   isEditing,
   isImageEditing,
-  isTestingMode = false,
   onMouseDown,
   onImageMouseDown,
   isDraggingImage,
@@ -74,7 +72,6 @@ export const TileRenderer: React.FC<TileRendererProps> = ({
     isEditing,
     isEditingText,
     isImageEditing,
-    isTestingMode,
     isDraggingImage,
     onDoubleClick,
     onUpdateTile,
@@ -92,7 +89,6 @@ export const TileRenderer: React.FC<TileRendererProps> = ({
       isEditing={isEditing}
       isEditingText={isEditingText}
       isImageEditing={isImageEditing}
-      isTestingMode={isTestingMode}
       isDraggingImage={isDraggingImage}
       showGrid={showGrid}
       isFramelessTextTile={isFramelessTextTile}

--- a/packages/tiles-editor/src/components/shared.ts
+++ b/packages/tiles-editor/src/components/shared.ts
@@ -8,7 +8,6 @@ export interface BaseTileRendererProps<T extends LessonTile = LessonTile> {
   isEditing: boolean;
   isEditingText: boolean;
   isImageEditing: boolean;
-  isTestingMode?: boolean;
   isDraggingImage: boolean;
   onDoubleClick: () => void;
   onUpdateTile: (tileId: string, updates: Partial<LessonTile>) => void;

--- a/packages/tiles-editor/src/hooks/useLessonContentManager.ts
+++ b/packages/tiles-editor/src/hooks/useLessonContentManager.ts
@@ -71,7 +71,6 @@ export const useLessonContentManager = ({
   const [currentPage, setCurrentPage] = useState(1);
   const [isLoading, setIsLoading] = useState(true);
   const [isSaving, setIsSaving] = useState(false);
-  const [testingTileIds, setTestingTileIds] = useState<string[]>([]);
 
   const normalizeTilePage = useCallback((tile: LessonTile): LessonTile => ({
     ...tile,
@@ -125,7 +124,6 @@ export const useLessonContentManager = ({
 
       setLessonContent(normalizedContent);
       setCurrentPage(1);
-      setTestingTileIds([]);
       logger.info(`Loaded lesson content with ${normalizedTiles.length} tiles across ${totalPages} pages`);
     } catch (err) {
       logger.error('Failed to load lesson content:', err);
@@ -319,12 +317,6 @@ export const useLessonContentManager = ({
     },
     [computeMaxCanvasHeight, getMaxPageFromTiles, dispatch]
   );
-
-  const toggleTestingTile = useCallback((tileId: string) => {
-    setTestingTileIds(prev =>
-      prev.includes(tileId) ? prev.filter(id => id !== tileId) : [...prev, tileId]
-    );
-  }, []);
 
   const deleteTile = useCallback(
     (tileId: string) => {
@@ -569,11 +561,9 @@ export const useLessonContentManager = ({
     pagedContent,
     selectedTile,
     selectedRichTextTile,
-    testingTileIds,
     addTile,
     updateTile,
     deleteTile,
-    toggleTestingTile,
     addPage,
     deletePage,
     changePage,

--- a/packages/tiles-editor/src/side-editors/SequencingEditor.tsx
+++ b/packages/tiles-editor/src/side-editors/SequencingEditor.tsx
@@ -1,19 +1,15 @@
 import React, { useState } from 'react';
-import { Plus, Trash2, GripVertical, RotateCcw, Sparkles, Square } from 'lucide-react';
+import { Plus, Trash2, GripVertical, RotateCcw } from 'lucide-react';
 import { SequencingTile } from 'tiles-core';
 
 interface SequencingEditorProps {
   tile: SequencingTile;
   onUpdateTile: (tileId: string, updates: Partial<SequencingTile>) => void;
-  isTesting?: boolean;
-  onToggleTesting?: (tileId: string) => void;
 }
 
 export const SequencingEditor: React.FC<SequencingEditorProps> = ({
   tile,
   onUpdateTile,
-  isTesting = false,
-  onToggleTesting
 }) => {
   const [draggedItem, setDraggedItem] = useState<string | null>(null);
 
@@ -111,32 +107,6 @@ export const SequencingEditor: React.FC<SequencingEditorProps> = ({
             onChange={(e) => handleContentUpdate('backgroundColor', e.target.value)}
             className="w-full h-12 border border-gray-300 rounded-lg cursor-pointer"
         />
-      </div>
-
-      <div className="p-4 rounded-lg border border-gray-200 bg-white shadow-sm">
-        <div className="flex items-start justify-between gap-3">
-          <div>
-            <h3 className="text-sm font-semibold text-gray-900">Tryb testowania</h3>
-            <p className="text-xs text-gray-600 mt-1">
-              {isTesting
-                ? 'Tryb ucznia jest aktywny. Kafelek na płótnie jest zablokowany przed przypadkową edycją.'
-                : 'Wyłącz interakcje edycyjne kafelka i sprawdź zadanie dokładnie tak, jak zobaczy je uczeń.'}
-            </p>
-          </div>
-          <button
-            type="button"
-            onClick={() => onToggleTesting?.(tile.id)}
-            disabled={!onToggleTesting}
-            className={`inline-flex items-center gap-2 px-3 py-2 text-xs font-medium rounded-lg transition-colors shadow-sm ${
-              isTesting
-                ? 'bg-slate-900 text-white hover:bg-slate-800'
-                : 'bg-blue-600 text-white hover:bg-blue-500'
-            } disabled:opacity-60 disabled:cursor-not-allowed`}
-          >
-            {isTesting ? <Square className="w-4 h-4" /> : <Sparkles className="w-4 h-4" />}
-            <span>{isTesting ? 'Zakończ testowanie' : 'Przetestuj zadanie'}</span>
-          </button>
-        </div>
       </div>
 
       {/* Items Management */}

--- a/packages/tiles-editor/src/side-editors/TileSideEditor.tsx
+++ b/packages/tiles-editor/src/side-editors/TileSideEditor.tsx
@@ -33,16 +33,12 @@ interface TileSideEditorProps {
   tile: LessonTile | undefined;
   onUpdateTile: (tileId: string, updates: Partial<LessonTile>) => void;
   onSelectTile?: (tileId: string | null) => void;
-  isTesting?: boolean;
-  onToggleTesting?: (tileId: string) => void;
 }
 
 export const TileSideEditor: React.FC<TileSideEditorProps> = ({
   tile,
   onUpdateTile,
   onSelectTile,
-  isTesting = false,
-  onToggleTesting
 }) => {
 
   if (!tile) {
@@ -285,8 +281,6 @@ export const TileSideEditor: React.FC<TileSideEditorProps> = ({
           <SequencingEditor
             tile={sequencingTile}
             onUpdateTile={onUpdateTile}
-            isTesting={isTesting}
-            onToggleTesting={onToggleTesting}
           />
         );
       }

--- a/packages/tiles-editor/src/tiles/blanks/Renderer.tsx
+++ b/packages/tiles-editor/src/tiles/blanks/Renderer.tsx
@@ -9,7 +9,6 @@ export const BlanksTileRenderer: React.FC<BaseTileRendererProps<BlanksTile>> = (
   tile,
   isSelected,
   isEditingText,
-  isTestingMode,
   onUpdateTile,
   onFinishTextEditing,
   onEditorReady,
@@ -26,7 +25,6 @@ export const BlanksTileRenderer: React.FC<BaseTileRendererProps<BlanksTile>> = (
   ) => (
     <BlanksInteractive
       tile={blanksTile}
-      isTestingMode={isTestingMode}
       instructionContent={instructionContent}
       isPreview={isPreviewMode}
       onRequestTextEditing={isPreviewMode ? undefined : onDoubleClick}

--- a/packages/tiles-editor/src/tiles/open/Renderer.tsx
+++ b/packages/tiles-editor/src/tiles/open/Renderer.tsx
@@ -9,7 +9,6 @@ export const OpenTileRenderer: React.FC<BaseTileRendererProps<OpenTile>> = ({
   tile,
   isSelected,
   isEditingText,
-  isTestingMode,
   onUpdateTile,
   onFinishTextEditing,
   onEditorReady,
@@ -26,7 +25,6 @@ export const OpenTileRenderer: React.FC<BaseTileRendererProps<OpenTile>> = ({
   ) => (
     <OpenInteractive
       tile={openTile}
-      isTestingMode={isTestingMode}
       instructionContent={instructionContent}
       isPreview={isPreviewMode}
       onRequestTextEditing={isPreviewMode ? undefined : onDoubleClick}

--- a/packages/tiles-editor/src/tiles/pairing/Renderer.tsx
+++ b/packages/tiles-editor/src/tiles/pairing/Renderer.tsx
@@ -9,7 +9,6 @@ export const PairingTileRenderer: React.FC<BaseTileRendererProps<PairingTile>> =
   tile,
   isSelected,
   isEditingText,
-  isTestingMode,
   onUpdateTile,
   onFinishTextEditing,
   onEditorReady,
@@ -26,7 +25,6 @@ export const PairingTileRenderer: React.FC<BaseTileRendererProps<PairingTile>> =
   ) => (
     <PairingInteractive
       tile={pairingTile}
-      isTestingMode={isTestingMode}
       instructionContent={instructionContent}
       isPreview={isPreviewMode}
       onRequestTextEditing={isPreviewMode ? undefined : onDoubleClick}

--- a/packages/tiles-editor/src/tiles/quiz/Renderer.tsx
+++ b/packages/tiles-editor/src/tiles/quiz/Renderer.tsx
@@ -9,7 +9,6 @@ export const QuizTileRenderer: React.FC<BaseTileRendererProps<QuizTile>> = ({
   tile,
   isSelected,
   isEditingText,
-  isTestingMode,
   onUpdateTile,
   onFinishTextEditing,
   onEditorReady,
@@ -76,7 +75,6 @@ export const QuizTileRenderer: React.FC<BaseTileRendererProps<QuizTile>> = ({
     <TileChrome backgroundColor={backgroundColor} showBorder={showBorder}>
       <QuizInteractive
         tile={quizTile}
-        isTestingMode={isTestingMode}
         onRequestTextEditing={onDoubleClick}
       />
     </TileChrome>

--- a/packages/tiles-editor/src/tiles/sequencing/Renderer.tsx
+++ b/packages/tiles-editor/src/tiles/sequencing/Renderer.tsx
@@ -9,7 +9,6 @@ export const SequencingTileRenderer: React.FC<BaseTileRendererProps<SequencingTi
   tile,
   isSelected,
   isEditingText,
-  isTestingMode,
   onUpdateTile,
   onFinishTextEditing,
   onEditorReady,
@@ -26,7 +25,6 @@ export const SequencingTileRenderer: React.FC<BaseTileRendererProps<SequencingTi
   ) => (
     <SequencingInteractive
       tile={sequencingTile}
-      isTestingMode={isTestingMode}
       instructionContent={instructionContent}
       isPreview={isPreviewMode}
       onRequestTextEditing={isPreviewMode ? undefined : onDoubleClick}

--- a/src/Pages/LessonEditor.tsx
+++ b/src/Pages/LessonEditor.tsx
@@ -38,11 +38,9 @@ export const LessonEditor: React.FC<LessonEditorProps> = ({ lesson, course, onBa
     pagedContent,
     selectedTile,
     selectedRichTextTile,
-    testingTileIds,
     addTile,
     updateTile,
     deleteTile,
-    toggleTestingTile,
     addPage,
     deletePage,
     changePage,
@@ -362,8 +360,6 @@ export const LessonEditor: React.FC<LessonEditorProps> = ({ lesson, course, onBa
                 tile={selectedTile}
                 onUpdateTile={updateTile}
                 onSelectTile={handleSelectTile}
-                isTesting={testingTileIds.includes(selectedTile.id)}
-                onToggleTesting={toggleTestingTile}
               />
             </div>
           ) : (
@@ -415,7 +411,6 @@ export const LessonEditor: React.FC<LessonEditorProps> = ({ lesson, course, onBa
                 dispatch={dispatch}
                 showGrid={editorState.showGrid}
                 onEditorReady={setActiveEditor}
-                testingTileIds={testingTileIds}
               />
             </div>
           </div>

--- a/src/components/admin/canvas/LessonCanvas.tsx
+++ b/src/components/admin/canvas/LessonCanvas.tsx
@@ -16,7 +16,6 @@ interface LessonCanvasProps {
   onFinishTextEditing: () => void;
   showGrid?: boolean;
   onEditorReady: (editor: Editor | null) => void;
-  testingTileIds?: string[];
 }
 
 export const LessonCanvas = forwardRef<HTMLDivElement, LessonCanvasProps>(({ 
@@ -30,7 +29,6 @@ export const LessonCanvas = forwardRef<HTMLDivElement, LessonCanvasProps>(({
   onFinishTextEditing,
   showGrid = true,
   onEditorReady,
-  testingTileIds = []
 }, ref) => {
   const {
     dragPreview,
@@ -127,7 +125,6 @@ export const LessonCanvas = forwardRef<HTMLDivElement, LessonCanvasProps>(({
             isEditing={editorState.mode === 'editing' && editorState.selectedTileId === tile.id}
             isEditingText={editorState.mode === 'textEditing' && editorState.selectedTileId === tile.id}
             isImageEditing={editorState.mode === 'imageEditing' && editorState.selectedTileId === tile.id}
-            isTestingMode={testingTileIds.includes(tile.id)}
             onMouseDown={(e) => handleTileMouseDown(e, tile)}
             onImageMouseDown={handleImageMouseDown}
             isDraggingImage={editorState.interaction.type === 'imageDrag'}


### PR DESCRIPTION
## Summary
- remove the unused sequencing tile testing controls from the side editor and lesson editor
- drop testing-mode plumbing from tile renderers and canvas since tiles are no longer testable in-editor

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js' imported from eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68e16245d6cc8321983ec3b4789175ea