### PR TITLE
Fix confirm dialog closure after confirming actions

### DIFF
--- a/src/Pages/LessonEditor.tsx
+++ b/src/Pages/LessonEditor.tsx
@@ -158,7 +158,6 @@ export const LessonEditor: React.FC<LessonEditorProps> = ({ lesson, course, onBa
       message: `Czy na pewno chcesz usunąć ten kafelek? Ta operacja jest nieodwracalna.`,
       onConfirm: () => {
         deleteTile(tileId);
-        setConfirmDialog(prev => ({ ...prev, isOpen: false }));
       }
     });
   };
@@ -182,7 +181,6 @@ export const LessonEditor: React.FC<LessonEditorProps> = ({ lesson, course, onBa
       onConfirm: () => {
         deletePage(pageToDelete);
         setActiveEditor(null);
-        setConfirmDialog(prev => ({ ...prev, isOpen: false }));
       }
     });
   };
@@ -199,13 +197,12 @@ export const LessonEditor: React.FC<LessonEditorProps> = ({ lesson, course, onBa
       setConfirmDialog({
         isOpen: true,
         title: 'Niezapisane zmiany',
-        message: 'Masz niezapisane zmiany. Czy chcesz je zapisać przed wyjściem?',
-        onConfirm: async () => {
-          await saveLessonContent();
-          setConfirmDialog(prev => ({ ...prev, isOpen: false }));
-          onBack();
-        }
-      });
+      message: 'Masz niezapisane zmiany. Czy chcesz je zapisać przed wyjściem?',
+      onConfirm: async () => {
+        await saveLessonContent();
+        onBack();
+      }
+    });
     } else {
       onBack();
     }
@@ -223,7 +220,6 @@ export const LessonEditor: React.FC<LessonEditorProps> = ({ lesson, course, onBa
         if (cleared) {
           setActiveEditor(null);
         }
-        setConfirmDialog(prev => ({ ...prev, isOpen: false }));
       }
     });
   };

--- a/src/components/common/ConfirmDialog.tsx
+++ b/src/components/common/ConfirmDialog.tsx
@@ -8,7 +8,7 @@ interface ConfirmDialogProps {
   confirmText?: string;
   cancelText?: string;
   type?: 'warning' | 'danger' | 'info';
-  onConfirm: () => void;
+  onConfirm: () => void | Promise<void>;
   onCancel: () => void;
 }
 
@@ -37,6 +37,14 @@ export const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
     }
   };
 
+  const handleConfirm = async () => {
+    try {
+      await Promise.resolve(onConfirm());
+    } finally {
+      onCancel();
+    }
+  };
+
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
       <div className="bg-white rounded-lg shadow-xl max-w-md w-full mx-4">
@@ -58,7 +66,7 @@ export const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
               {cancelText}
             </button>
             <button
-              onClick={onConfirm}
+              onClick={handleConfirm}
               className={`px-4 py-2 rounded-lg transition-colors ${getButtonColors()}`}
             >
               {confirmText}


### PR DESCRIPTION
## Summary
- make the shared ConfirmDialog invoke its cancel handler after running the confirm callback so it always closes
- allow confirm callbacks to be async-capable and simplify the LessonEditor handlers that rely on the dialog

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js' imported from eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68e16f2605b883219b8a96badf0b0f25