### PR TITLE
Fix tile drag offset calculation

### DIFF
--- a/packages/tiles-editor/src/hooks/useTileInteractions.ts
+++ b/packages/tiles-editor/src/hooks/useTileInteractions.ts
@@ -113,7 +113,13 @@ export const useTileInteractions = ({
       };
       document.addEventListener('mouseup', removeOutline);
     }
-    dispatch({ type: 'startDrag', tile, offset: { x: e.nativeEvent.offsetX, y: e.nativeEvent.offsetY } });
+    const tileElement = e.currentTarget as HTMLElement;
+    const rect = tileElement.getBoundingClientRect();
+    dispatch({
+      type: 'startDrag',
+      tile,
+      offset: { x: e.clientX - rect.left, y: e.clientY - rect.top }
+    });
   };
 
   const handleImageMouseDown = (e: React.MouseEvent, tile: LessonTile) => {


### PR DESCRIPTION
## Summary
- compute drag offset using the tile's bounding box to keep cursor relative position stable

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e170180a888321a03b97f89fef94c8