### PR TITLE
Enable student solving for task tiles

### DIFF
--- a/packages/tiles-runtime/src/RuntimeTileRenderer.tsx
+++ b/packages/tiles-runtime/src/RuntimeTileRenderer.tsx
@@ -54,19 +54,31 @@ export const RuntimeTileRenderer: React.FC<RuntimeTileRendererProps> = ({ tile, 
     case 'quiz':
       return (
         <TileChrome {...deriveChromeAppearance(tile)}>
-          <QuizInteractive tile={tile as QuizTile} isPreview />
+          <QuizInteractive
+            tile={tile as QuizTile}
+            isPreview={mode !== 'student'}
+            isTestingMode={mode === 'student'}
+          />
         </TileChrome>
       );
     case 'blanks':
       return (
         <TileChrome {...deriveChromeAppearance(tile)}>
-          <BlanksInteractive tile={tile as BlanksTile} isPreview />
+          <BlanksInteractive
+            tile={tile as BlanksTile}
+            isPreview={mode !== 'student'}
+            isTestingMode={mode === 'student'}
+          />
         </TileChrome>
       );
     case 'open':
       return (
         <TileChrome {...deriveChromeAppearance(tile)}>
-          <OpenInteractive tile={tile as OpenTile} isPreview />
+          <OpenInteractive
+            tile={tile as OpenTile}
+            isPreview={mode !== 'student'}
+            isTestingMode={mode === 'student'}
+          />
         </TileChrome>
       );
     case 'sequencing':

--- a/packages/tiles-runtime/src/blanks/Interactive.tsx
+++ b/packages/tiles-runtime/src/blanks/Interactive.tsx
@@ -469,9 +469,10 @@ export const BlanksInteractive: React.FC<BlanksInteractiveProps> = ({
           <ValidateButton
             state={validationState}
             disabled={!isInteractionEnabled}
-            onClick={() => {}}
+            onClick={handleCheck}
+            onRetry={handleRetry}
             colors={validateButtonColors}
-            labels={{ idle: 'Sprawdź odpowiedź', success: 'Dobrze!', error: 'Spróbuj ponownie' }}
+            labels={validateButtonLabels}
           />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- enable student runtime mode for quiz, blanks, and open tiles so that solving controls are active
- integrate ValidateButton-driven evaluation and messaging for quiz tasks
- wire blanks and open tiles to ValidateButton handling, persisting answers and showing feedback during attempts

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68e17f21e5d88321ac569e7425068e4e