### PR TITLE
Fix Safari artifacts on tile resize handles

### DIFF
--- a/packages/tiles-editor/src/components/TileFrame.tsx
+++ b/packages/tiles-editor/src/components/TileFrame.tsx
@@ -154,28 +154,33 @@ export const TileFrame: React.FC<TileFrameProps> = ({
         </div>
       )}
 
-      {showSelectionChrome && (
-        <>
-          {RESIZE_HANDLES.map(({ handle, position, cursor }) => (
-            <div
-              key={handle}
-              className={`absolute w-3 h-3 rounded-full transition-colors ${
-                isFramelessTextTile
-                  ? 'bg-blue-500 border-2 border-white shadow-lg hover:bg-blue-600 opacity-90 hover:opacity-100'
-                  : 'bg-blue-500 border-2 border-white shadow-md hover:bg-blue-600'
-              }`}
-              style={{
-                left: `${position.x * 100}%`,
-                top: `${position.y * 100}%`,
-                transform: 'translate(-50%, -50%)',
-                cursor,
-                zIndex: 10
-              }}
-              onMouseDown={(e) => handleResizeStart(e, handle)}
-            />
-          ))}
-        </>
-      )}
+      <div
+        className={`absolute inset-0 transition-opacity duration-150 ${
+          showSelectionChrome
+            ? 'opacity-100 pointer-events-auto visible'
+            : 'opacity-0 pointer-events-none invisible'
+        }`}
+        aria-hidden={!showSelectionChrome}
+      >
+        {RESIZE_HANDLES.map(({ handle, position, cursor }) => (
+          <div
+            key={handle}
+            className={`absolute w-3 h-3 rounded-full transition-colors ${
+              isFramelessTextTile
+                ? 'bg-blue-500 border-2 border-white shadow-lg hover:bg-blue-600 opacity-90 hover:opacity-100'
+                : 'bg-blue-500 border-2 border-white shadow-md hover:bg-blue-600'
+            }`}
+            style={{
+              left: `${position.x * 100}%`,
+              top: `${position.y * 100}%`,
+              transform: 'translate(-50%, -50%)',
+              cursor,
+              zIndex: 10
+            }}
+            onMouseDown={(e) => handleResizeStart(e, handle)}
+          />
+        ))}
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- keep tile resize handles mounted and fade them with opacity while toggling visibility
- ensure resize handles are fully hidden when a tile is deselected to avoid Safari artifacts in Safari

## Testing
- not run (environment lacks dependencies)


------
https://chatgpt.com/codex/tasks/task_e_68e1bb61bcd883219d7519664b329610