### PR TITLE
Ensure consistent tile instruction rendering

### DIFF
--- a/packages/tiles-editor/src/components/RichTextEditor.tsx
+++ b/packages/tiles-editor/src/components/RichTextEditor.tsx
@@ -181,7 +181,7 @@ export const RichTextEditor: React.FC<RichTextEditorProps> = ({
     }
   };
 
-  const combinedClassName = `w-full h-full p-3 overflow-hidden relative tile-text-content tiptap-editor${
+  const combinedClassName = `w-full h-full overflow-hidden relative tile-text-content tiptap-editor${
     className ? ` ${className}` : ''
   }`;
 

--- a/packages/tiles-runtime/src/blanks/Interactive.tsx
+++ b/packages/tiles-runtime/src/blanks/Interactive.tsx
@@ -11,6 +11,7 @@ import {
 import {
   TaskInstructionPanel,
   TaskTileSection,
+  TileInstructionContent,
   ValidateButton,
   createValidateButtonPalette,
   type ValidateButtonColors,
@@ -368,11 +369,12 @@ export const BlanksInteractive: React.FC<BlanksInteractiveProps> = ({
           labelStyle={{ color: mutedLabelColor }}
         >
           {instructionContent ?? (
-            <div
-              className="text-base leading-relaxed"
-              dangerouslySetInnerHTML={{
-                __html: tile.content.richInstruction || `<p>${tile.content.instruction}</p>`
-              }}
+            <TileInstructionContent
+              html={
+                tile.content.richInstruction ||
+                `<p style="margin: 0;">${tile.content.instruction}</p>`
+              }
+              textColor={textColor}
             />
           )}
         </TaskInstructionPanel>

--- a/packages/tiles-runtime/src/open/Interactive.tsx
+++ b/packages/tiles-runtime/src/open/Interactive.tsx
@@ -5,6 +5,7 @@ import { getReadableTextColor, surfaceColor } from 'tiles-core/utils';
 import {
   TaskInstructionPanel,
   TaskTileSection,
+  TileInstructionContent,
   ValidateButton,
   createValidateButtonPalette,
   type ValidateButtonColors,
@@ -146,11 +147,15 @@ export const OpenInteractive: React.FC<OpenInteractiveProps> = ({
           labelStyle={{ color: mutedLabelColor }}
         >
           {instructionContent ?? (
-            <div
-              className="text-base leading-relaxed"
-              dangerouslySetInnerHTML={{
-                __html: tile.content.richInstruction || `<p>${tile.content.instruction}</p>`
-              }}
+            <TileInstructionContent
+              html={
+                tile.content.richInstruction ||
+                `<p style="margin: 0;">${tile.content.instruction}</p>`
+              }
+              textColor={textColor}
+              fontFamily={tile.content.fontFamily}
+              fontSize={tile.content.fontSize}
+              verticalAlign={tile.content.verticalAlign}
             />
           )}
         </TaskInstructionPanel>

--- a/packages/tiles-runtime/src/pairing/Interactive.tsx
+++ b/packages/tiles-runtime/src/pairing/Interactive.tsx
@@ -5,6 +5,7 @@ import { createSurfacePalette, getReadableTextColor } from 'tiles-core/utils';
 import {
   TaskInstructionPanel,
   TaskTileSection,
+  TileInstructionContent,
   ValidateButton,
   createValidateButtonPalette,
   type ValidateButtonColors
@@ -151,11 +152,15 @@ export const PairingInteractive: React.FC<PairingInteractiveProps> = ({
           labelStyle={{ color: mutedLabelColor }}
         >
           {instructionContent ?? (
-            <div
-              className="text-base leading-relaxed"
-              dangerouslySetInnerHTML={{
-                __html: tile.content.richInstruction || `<p>${tile.content.instruction}</p>`
-              }}
+            <TileInstructionContent
+              html={
+                tile.content.richInstruction ||
+                `<p style="margin: 0;">${tile.content.instruction}</p>`
+              }
+              textColor={textColor}
+              fontFamily={tile.content.fontFamily}
+              fontSize={tile.content.fontSize}
+              verticalAlign={tile.content.verticalAlign}
             />
           )}
         </TaskInstructionPanel>

--- a/packages/tiles-runtime/src/quiz/Interactive.tsx
+++ b/packages/tiles-runtime/src/quiz/Interactive.tsx
@@ -5,6 +5,7 @@ import { getReadableTextColor } from 'tiles-core/utils';
 import { createSurfacePalette } from 'tiles-core/utils';
 import {
   TaskInstructionPanel,
+  TileInstructionContent,
   ValidateButton,
   createValidateButtonPalette,
   type ValidateButtonColors,
@@ -134,15 +135,14 @@ export const QuizInteractive: React.FC<QuizInteractiveProps> = ({
     }
 
     return (
-      <div
-        className="text-sm leading-relaxed"
-        style={{
-          fontFamily: tile.content.questionFontFamily || 'Inter',
-          fontSize: `${tile.content.questionFontSize ?? 16}px`
-        }}
-        dangerouslySetInnerHTML={{
-          __html: tile.content.richQuestion || `<p>${tile.content.question}</p>`
-        }}
+      <TileInstructionContent
+        html={
+          tile.content.richQuestion ||
+          `<p style="margin: 0;">${tile.content.question}</p>`
+        }
+        textColor={textColor}
+        fontFamily={tile.content.questionFontFamily}
+        fontSize={tile.content.questionFontSize}
       />
     );
   };

--- a/packages/tiles-runtime/src/sequencing/Interactive.tsx
+++ b/packages/tiles-runtime/src/sequencing/Interactive.tsx
@@ -10,6 +10,7 @@ import {
 import {
   TaskInstructionPanel,
   TaskTileSection,
+  TileInstructionContent,
   ValidateButton,
   createValidateButtonPalette,
   type ValidateButtonColors,
@@ -496,15 +497,15 @@ export const SequencingInteractive: React.FC<SequencingInteractiveProps> = ({
           bodyClassName="px-5 pb-5"
         >
           {instructionContent ?? (
-            <div
-              className="text-base leading-relaxed"
-              style={{
-                fontFamily: tile.content.fontFamily,
-                fontSize: `${tile.content.fontSize}px`
-              }}
-              dangerouslySetInnerHTML={{
-                __html: tile.content.richQuestion || tile.content.question
-              }}
+            <TileInstructionContent
+              html={
+                tile.content.richQuestion ||
+                `<p style="margin: 0;">${tile.content.question}</p>`
+              }
+              textColor={textColor}
+              fontFamily={tile.content.fontFamily}
+              fontSize={tile.content.fontSize}
+              verticalAlign={tile.content.verticalAlign}
             />
           )}
         </TaskInstructionPanel>

--- a/packages/ui-primitives/src/TileInstructionContent.tsx
+++ b/packages/ui-primitives/src/TileInstructionContent.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+
+export type TileInstructionVerticalAlign = 'top' | 'center' | 'bottom';
+
+export interface TileInstructionContentProps {
+  html: string;
+  textColor?: string;
+  fontFamily?: string;
+  fontSize?: number;
+  verticalAlign?: TileInstructionVerticalAlign;
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+const resolveJustifyContent = (verticalAlign?: TileInstructionVerticalAlign) => {
+  switch (verticalAlign) {
+    case 'center':
+      return 'center';
+    case 'bottom':
+      return 'flex-end';
+    case 'top':
+    default:
+      return 'flex-start';
+  }
+};
+
+export const TileInstructionContent: React.FC<TileInstructionContentProps> = ({
+  html,
+  textColor,
+  fontFamily,
+  fontSize,
+  verticalAlign = 'top',
+  className = '',
+  style
+}) => {
+  const sanitizedHtml = html?.trim().length ? html : '<p style="margin: 0;"></p>';
+
+  return (
+    <div
+      className={`w-full h-full tile-text-content ${className}`.trim()}
+      style={{
+        color: textColor,
+        fontFamily,
+        fontSize: fontSize ? `${fontSize}px` : undefined,
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: resolveJustifyContent(verticalAlign),
+        ...style
+      }}
+    >
+      <div
+        className="w-full rich-text-content tile-formatted-text text-base"
+        dangerouslySetInnerHTML={{ __html: sanitizedHtml }}
+      />
+    </div>
+  );
+};
+
+export default TileInstructionContent;

--- a/packages/ui-primitives/src/index.ts
+++ b/packages/ui-primitives/src/index.ts
@@ -3,6 +3,7 @@ export * from './TileChrome';
 export * from './TileContainer';
 export * from './views';
 export * from './TaskInstructionPanel';
+export * from './TileInstructionContent';
 export * from './TaskTileSection';
 export * from './ValidateButton';
 export * from './validateButtonPalette';

--- a/packages/ui-primitives/src/views/ProgrammingTileView.tsx
+++ b/packages/ui-primitives/src/views/ProgrammingTileView.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ProgrammingTile } from 'tiles-core';
-import { TaskInstructionPanel } from '../../../ui-primitives';
+import { TaskInstructionPanel, TileInstructionContent } from '../../../ui-primitives';
 import { darkenColor, getReadableTextColor, surfaceColor } from 'tiles-core/utils';
 import { TileChrome } from '../TileChrome';
 
@@ -65,15 +65,14 @@ export const ProgrammingTileView: React.FC<ProgrammingTileViewProps> = ({
         }}
         labelStyle={{ color: textColor === '#0f172a' ? '#475569' : '#dbeafe' }}
       >
-        <div
-          className="text-sm leading-relaxed"
-          style={{
-            fontFamily: tile.content.fontFamily,
-            fontSize: `${tile.content.fontSize}px`,
-          }}
-          dangerouslySetInnerHTML={{
-            __html: tile.content.richDescription || `<p>${tile.content.description}</p>`
-          }}
+        <TileInstructionContent
+          html={
+            tile.content.richDescription ||
+            `<p style="margin: 0;">${tile.content.description}</p>`
+          }
+          textColor={textColor}
+          fontFamily={tile.content.fontFamily}
+          fontSize={tile.content.fontSize}
         />
       </TaskInstructionPanel>
 


### PR DESCRIPTION
## Summary
- add a shared TileInstructionContent component to render task instructions with consistent formatting
- update interactive tiles to reuse the shared renderer so previewed text matches the editor styling, including code formatting
- remove extra padding from the rich text editor wrapper to eliminate layout shifts when toggling edit mode

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68e248f82ce883219a9c3fadde848ced