### PR TITLE
Add toast notification when removing lesson tiles

### DIFF
--- a/packages/tiles-editor/src/hooks/useLessonContentManager.ts
+++ b/packages/tiles-editor/src/hooks/useLessonContentManager.ts
@@ -360,9 +360,11 @@ export const useLessonContentManager = ({
         dispatch({ type: 'stopEditing' });
       }
 
+      success('Kafelek usunięty', 'Kafelek został pomyślnie usunięty');
+
       return true;
     },
-    [computeMaxCanvasHeight, dispatch, editorState.selectedTileId]
+    [computeMaxCanvasHeight, dispatch, editorState.selectedTileId, success]
   );
 
   const addPage = useCallback(() => {

--- a/src/Pages/LessonEditor.tsx
+++ b/src/Pages/LessonEditor.tsx
@@ -158,8 +158,8 @@ export const LessonEditor: React.FC<LessonEditorProps> = ({ lesson, course, onBa
       message: `Czy na pewno chcesz usunąć ten kafelek? Ta operacja jest nieodwracalna.`,
       onConfirm: () => {
         const wasRemoved = deleteTile(tileId);
-        if (wasRemoved) {
-          success('Kafelek usunięty', 'Kafelek został pomyślnie usunięty');
+        if (!wasRemoved) {
+          warning('Nie udało się usunąć kafelka', 'Wybrany kafelek nie istnieje.');
         }
       }
     });


### PR DESCRIPTION
## Summary
- trigger a success toast within the content manager when a tile is removed
- warn the user if a tile could not be deleted from the lesson editor dialog

## Testing
- npm run lint *(fails: missing @eslint/js dependency in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e25d31c6b48321bdebe380882b9680