### PR TITLE
Fix validate button behavior across blanks and quiz tiles

### DIFF
--- a/packages/tiles-runtime/src/blanks/Interactive.tsx
+++ b/packages/tiles-runtime/src/blanks/Interactive.tsx
@@ -430,7 +430,7 @@ export const BlanksInteractive: React.FC<BlanksInteractiveProps> = ({
         <div className="flex flex-col items-center gap-2 pt-2">
           <ValidateButton
             state={validationState}
-            disabled={!isInteractionEnabled}
+            disabled={!isInteractionEnabled || !isComplete}
             onClick={handleCheck}
             onRetry={handleRetry}
           />

--- a/packages/tiles-runtime/src/quiz/Interactive.tsx
+++ b/packages/tiles-runtime/src/quiz/Interactive.tsx
@@ -218,9 +218,11 @@ export const QuizInteractive: React.FC<QuizInteractiveProps> = ({
 
   const validationState: ValidateButtonState = evaluationState;
 
+  const evaluationMessage = renderEvaluationMessage();
+
   return (
     <div className="relative w-full h-full" onDoubleClick={handleTileDoubleClick}>
-      <div className="w-full h-full flex flex-col gap-5 p-6">
+      <div className="w-full h-full flex flex-col gap-5 p-6 overflow-hidden">
 
         <TaskInstructionPanel
           icon={<HelpCircle className="w-4 h-4" />}
@@ -241,22 +243,26 @@ export const QuizInteractive: React.FC<QuizInteractiveProps> = ({
           {renderInstructionContent()}
         </TaskInstructionPanel>
 
-        <div className="flex flex-col gap-3">
-          {tile.content.answers.map((answer, index) => renderAnswerButton(answer, index))}
+        <div className="flex-1 min-h-0 flex flex-col gap-4 overflow-hidden">
+          <div className="flex-1 min-h-0 flex flex-col gap-3 overflow-auto">
+            {tile.content.answers.map((answer, index) => renderAnswerButton(answer, index))}
+          </div>
+
+          {evaluationMessage && (
+            <div className="flex-shrink-0">
+              {evaluationMessage}
+            </div>
+          )}
         </div>
 
-        {isInteractionEnabled && (
-          <div className="flex flex-col items-center gap-2 pt-2">
-            <ValidateButton
-              state={validationState}
-              disabled={!isInteractionEnabled || selectedAnswers.length === 0}
-              onClick={handleEvaluate}
-              onRetry={handleRetry}
-            />
-          </div>
-        )}
-
-        {renderEvaluationMessage()}
+        <div className="flex flex-col items-center gap-2 pt-2">
+          <ValidateButton
+            state={validationState}
+            disabled={!isInteractionEnabled || selectedAnswers.length === 0}
+            onClick={handleEvaluate}
+            onRetry={handleRetry}
+          />
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- disable the blanks validate button until every blank is filled
- keep the quiz validate button visible in the editor and maintain consistent spacing
- make the quiz answers section scrollable so the validate button retains its padding

## Testing
- npm run lint *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68e260dd3e7c8321b3adb8df44f53ff9