### PR TITLE
feat: add drag pairing layout with validation

### DIFF
--- a/packages/tiles-runtime/src/pairing/PairConnectionLayer.tsx
+++ b/packages/tiles-runtime/src/pairing/PairConnectionLayer.tsx
@@ -1,0 +1,140 @@
+import React from 'react';
+import type { RefObject } from 'react';
+
+export type LineColorResolver = (leftId: string) => string;
+
+export interface Temp {
+  active: boolean;
+  x: number;
+  y: number;
+  leftId: string | null;
+}
+
+interface Props {
+  containerRef: RefObject<HTMLDivElement>;
+  leftRefs: Record<string, HTMLDivElement | null>;
+  rightRefs: Record<string, HTMLDivElement | null>;
+  connections: Map<string, string>;
+  getLineColor: LineColorResolver;
+  temp?: Temp;
+}
+
+interface LineDefinition {
+  leftId: string;
+  path: string;
+  color: string;
+}
+
+const strokeWidth = 3;
+
+const calculateAnchor = (
+  element: HTMLDivElement,
+  containerRect: DOMRect,
+  position: 'left' | 'right'
+) => {
+  const rect = element.getBoundingClientRect();
+  const xOffset = rect.left - containerRect.left;
+  const yOffset = rect.top - containerRect.top;
+
+  if (position === 'left') {
+    return {
+      x: xOffset + rect.width,
+      y: yOffset + rect.height / 2
+    };
+  }
+
+  return {
+    x: xOffset,
+    y: yOffset + rect.height / 2
+  };
+};
+
+/**
+ * Renders SVG lines representing committed and temporary pairing connections.
+ */
+export const PairConnectionLayer: React.FC<Props> = ({
+  containerRef,
+  leftRefs,
+  rightRefs,
+  connections,
+  getLineColor,
+  temp
+}) => {
+  const container = containerRef.current;
+  if (!container) {
+    return null;
+  }
+
+  const containerRect = container.getBoundingClientRect();
+
+  const lines = Array.from(connections.entries()).reduce<LineDefinition[]>((acc, [leftId, rightId]) => {
+    const leftElement = leftRefs[leftId];
+    const rightElement = rightRefs[rightId];
+    if (!leftElement || !rightElement) {
+      return acc;
+    }
+
+    const start = calculateAnchor(leftElement, containerRect, 'left');
+    const end = calculateAnchor(rightElement, containerRect, 'right');
+    const color = getLineColor(leftId);
+
+    acc.push({
+      leftId,
+      path: `M ${start.x} ${start.y} L ${end.x} ${end.y}`,
+      color
+    });
+
+    return acc;
+  }, []);
+
+  let tempLine: LineDefinition | null = null;
+
+  if (temp && temp.active && temp.leftId) {
+    const activeElement = leftRefs[temp.leftId];
+    if (activeElement) {
+      const start = calculateAnchor(activeElement, containerRect, 'left');
+      const end = {
+        x: temp.x - containerRect.left,
+        y: temp.y - containerRect.top
+      };
+
+      tempLine = {
+        leftId: temp.leftId,
+        path: `M ${start.x} ${start.y} L ${end.x} ${end.y}`,
+        color: getLineColor(temp.leftId)
+      };
+    }
+  }
+
+  if (!lines.length && !tempLine) {
+    return null;
+  }
+
+  return (
+    <svg className="absolute inset-0 pointer-events-none" width="100%" height="100%">
+      {lines.map(line => (
+        <path
+          key={line.leftId}
+          d={line.path}
+          stroke={line.color}
+          strokeWidth={strokeWidth}
+          strokeLinecap="round"
+          fill="none"
+          data-testid={`pair-line-${line.leftId}`}
+        />
+      ))}
+      {tempLine && (
+        <path
+          d={tempLine.path}
+          stroke={tempLine.color}
+          strokeWidth={strokeWidth}
+          strokeLinecap="round"
+          fill="none"
+          data-testid="pair-temp-line"
+        />
+      )}
+    </svg>
+  );
+};
+
+export default PairConnectionLayer;

--- a/packages/tiles-runtime/src/pairing/useElementSize.ts
+++ b/packages/tiles-runtime/src/pairing/useElementSize.ts
@@ -1,0 +1,27 @@
+import { useLayoutEffect, useState } from 'react';
+import type { RefObject } from 'react';
+
+/**
+ * Observe the size of an element and return the latest width and height.
+ */
+export function useElementSize<T extends HTMLElement>(ref: RefObject<T>) {
+  const [size, setSize] = useState({ w: 0, h: 0 });
+
+  useLayoutEffect(() => {
+    const element = ref.current;
+    if (!element) return;
+
+    const observer = new ResizeObserver(entries => {
+      const entry = entries[0];
+      if (!entry) return;
+      const { width, height } = entry.contentRect;
+      setSize({ w: width, h: height });
+    });
+
+    observer.observe(element);
+
+    return () => observer.disconnect();
+  }, [ref]);
+
+  return size;
+}


### PR DESCRIPTION
## Summary
- gate the pairing interactive when available height is insufficient and display a localized info message
- add drag-to-connect behaviour with SVG connection lines and validation feedback for student answers
- introduce shared utilities for measuring element size and rendering connection paths

## Testing
- npm run build *(fails: `vite` binary not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e28f790a6c8321bbc9eb25aa78ffa7