### PR TITLE
Fix Tailwind content paths

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,10 @@
 /** @type {import('tailwindcss').Config} */
 export default {
-  content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
+  content: [
+    './index.html',
+    './src/**/*.{js,ts,jsx,tsx}',
+    './packages/**/*.{js,ts,jsx,tsx}',
+  ],
   theme: {
     extend: {},
   },


### PR DESCRIPTION
## Summary
- include the workspace package directories in the Tailwind content globs so utility classes defined there are generated

## Testing
- npm install *(fails: 403 Forbidden fetching zod from npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68e2e71b67fc8321b598377045d36e8d